### PR TITLE
Fix row components should take equal widths in a flex row

### DIFF
--- a/src/styles/RowComp.scss
+++ b/src/styles/RowComp.scss
@@ -7,7 +7,7 @@
     box-sizing: border-box;
     overflow: hidden;
     display: flex;
-    flex: 1 1 auto;
+    flex: 1 1 $component-flex-basis;
     align-items: flex-start;
     justify-content: flex-start;
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -11,6 +11,7 @@ $basic-text-line-height: 18px;
 $aside-text-font-size: 12px;
 $aside-text-line-height: 14px;
 
+$component-flex-basis: 15rem;
 $component-base-font-size: 16px;
 $component-base-height: 48px;
 $component-padding-vertical: 8px;


### PR DESCRIPTION
### Summary
Row components are supposed to share the available space of a row equally.
A 'flex-basis: auto' will make a short component shorter while a long component longer.
So we need to give them the same static basis to they can be evenly sized.

### Implement
Set `flex-basis: 15rem` on `.gyp-row-comp` components.

### Demo
![2017-05-22 5 05 28](https://cloud.githubusercontent.com/assets/365035/26301044/80e7e45a-3f12-11e7-833f-f7f53a8df501.png)
