### PR TITLE
[Hotfix] node engines version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - N/A
 
 
+## [0.11.1]
+### Changed
+- Use `>=` for versioning in `engines` fields.
+
+
 ## [0.11.0]
 ### Added
 - Migrate `@kadira/storybook` to `@storybook/react`. (#52)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "iCHEF web components library, built with React.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Purpose

Use `>=` to replace caret versioning in node and npm engines.