### PR TITLE
Refactor editable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Add `Installation` and `Usage` contents in README.
+- A new `<EditableBasicRow>` containing input logics is split from `<EditableText>`. (#63)
 
+### Changed
+- `<EditableText>` is simplified to only hold status-related logic. (#63)
+- `<TextInput>` now passes all unknown props to `<EditableText>` for convenience. (#63)
+- `<EditableTextLabel>` is now the only component which manages the input value change with `onEditEnd` callback, as well as `Enter`/`Esc` key presses and input blurs. (#63)
+- Flow type annotations for `<Editable-*>` components and `<TextInput>`. (#63)
 
 ## [0.12.1]
 ### Changed

--- a/examples/TextInput/BasicUsage.js
+++ b/examples/TextInput/BasicUsage.js
@@ -20,6 +20,18 @@ function BasicUsage() {
             <DebugBox>
                 <TextInput defaultValue="Uncontrolled input" />
             </DebugBox>
+
+            <DebugBox>
+                <TextInput
+                    readOnly
+                    value="Read-only input" />
+            </DebugBox>
+
+            <DebugBox>
+                <TextInput
+                    disabled
+                    value="Disabled input" />
+            </DebugBox>
         </div>
     );
 }

--- a/src/EditableBasicRow.js
+++ b/src/EditableBasicRow.js
@@ -19,6 +19,7 @@ export const BEM = {
 
 class EditableBasicRow extends PureComponent {
     static propTypes = {
+        status: PropTypes.string,
         value: PropTypes.string,
         defaultValue: PropTypes.string,
         readOnly: PropTypes.bool,
@@ -33,6 +34,7 @@ class EditableBasicRow extends PureComponent {
     };
 
     static defaultProps = {
+        status: undefined,
         value: undefined,
         defaultValue: undefined,
         readOnly: false,
@@ -49,6 +51,12 @@ class EditableBasicRow extends PureComponent {
         currentValue: this.props.value || this.props.defaultValue || '',
         focused: false,
     };
+
+    componentWillReceiveProps(nextProps) {
+        if (this.inputNode && nextProps.status !== this.props.status) {
+            this.inputNode.onBlur();
+        }
+    }
 
     handleInputFocus = (event) => {
         this.setState({ focused: true });

--- a/src/EditableBasicRow.js
+++ b/src/EditableBasicRow.js
@@ -1,0 +1,127 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import './styles/EditableBasicRow.scss';
+
+import prefixClass from './utils/prefixClass';
+import icBEM from './utils/icBEM';
+
+import BasicRow from './BasicRow';
+
+export const COMPONENT_NAME = prefixClass('editable-basic-row');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+
+export const BEM = {
+    root: ROOT_BEM,
+    input: ROOT_BEM.element('input'),
+    basicLabel: ROOT_BEM.element('basic-label'),
+};
+
+class EditableBasicRow extends PureComponent {
+    static propTypes = {
+        value: PropTypes.string,
+        defaultValue: PropTypes.string,
+        readOnly: PropTypes.bool,
+        disabled: PropTypes.bool,
+        // <input type="text" /> props
+        placeholder: PropTypes.string,
+        onChange: PropTypes.func,
+        onFocus: PropTypes.func,
+        onBlur: PropTypes.func,
+        // Use `input` to inject props to the underlying <input>
+        input: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    };
+
+    static defaultProps = {
+        value: undefined,
+        defaultValue: undefined,
+        readOnly: false,
+        disabled: false,
+        placeholder: 'Unset',
+        onChange: () => {},
+        onKeyDown: () => {},
+        onFocus: () => {},
+        onBlur: () => {},
+        input: {},
+    };
+
+    state = {
+        currentValue: this.props.value || this.props.defaultValue || '',
+        focused: false,
+    };
+
+    handleInputFocus = (event) => {
+        this.setState({ focused: true });
+        this.props.onFocus(event);
+    }
+
+    handleInputBlur = (event) => {
+        this.setState({ focused: false });
+        this.props.onBlur(event);
+    }
+
+    handleInputChange = (event) => {
+        // Only update if <input> isn't controlled
+        if (!this.props.value) {
+            this.setState({ currentValue: event.target.value });
+        }
+
+        this.props.onChange(event);
+    }
+
+    render() {
+        const {
+            value,
+            defaultValue,
+            readOnly,
+            disabled,
+            // <input type="text" /> props
+            placeholder,
+            onChange,
+            onFocus,
+            onBlur,
+            input: inputProps,
+            // React props
+            className,
+            ...rowProps,
+        } = this.props;
+        const { currentValue, focused } = this.state;
+
+        const bemClass = BEM.root
+            .modifier('empty', !currentValue)
+            .modifier('focused', focused)
+            .modifier('disabled', disabled);
+        const rootClassName = classNames(bemClass.toString(), className);
+
+        const inputTabIndex = (readOnly || disabled) ? -1 : undefined;
+
+        const basicLabel = (
+            <span className={BEM.basicLabel}>
+                {currentValue || placeholder}
+            </span>
+        );
+
+        return (
+            <BasicRow
+                {...rowProps}
+                basic={basicLabel}
+                className={rootClassName}>
+                <input
+                    ref={(ref) => { this.inputNode = ref; }}
+                    type="text"
+                    value={currentValue}
+                    placeholder={placeholder}
+                    className={BEM.input.toString()}
+                    readOnly={readOnly}
+                    disabled={disabled}
+                    tabIndex={inputTabIndex}
+                    onChange={this.handleInputChange}
+                    onFocus={this.handleInputFocus}
+                    onBlur={this.handleInputBlur}
+                    {...inputProps} />
+            </BasicRow>
+        );
+    }
+}
+
+export default EditableBasicRow;

--- a/src/EditableBasicRow.js
+++ b/src/EditableBasicRow.js
@@ -1,3 +1,4 @@
+// @flow
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -17,7 +18,25 @@ export const BEM = {
     basicLabel: ROOT_BEM.element('basic-label'),
 };
 
-class EditableBasicRow extends PureComponent {
+type EventWithInput = Event & { currentTarget: HTMLInputElement };
+
+export type Props = {
+    status?: any,
+    value?: string,
+    defaultValue?: string,
+    readOnly: boolean,
+    disabled: boolean,
+    placeholder: string,
+    onChange: (event?: Event) => void,
+    onFocus: (event?: Event) => void,
+    onBlur: (event?: Event) => void,
+    input: { [string]: any },
+    className?: string, // eslint-disable-line react/require-default-props
+};
+
+class EditableBasicRow extends PureComponent<Props, Props, any> {
+    inputNode: ?HTMLInputElement;
+
     static propTypes = {
         status: PropTypes.string,
         value: PropTypes.string,
@@ -41,7 +60,6 @@ class EditableBasicRow extends PureComponent {
         disabled: false,
         placeholder: 'Unset',
         onChange: () => {},
-        onKeyDown: () => {},
         onFocus: () => {},
         onBlur: () => {},
         input: {},
@@ -52,26 +70,26 @@ class EditableBasicRow extends PureComponent {
         focused: false,
     };
 
-    componentWillReceiveProps(nextProps) {
+    componentWillReceiveProps(nextProps: Props) {
         if (this.inputNode && nextProps.status !== this.props.status) {
-            this.inputNode.onBlur();
+            this.inputNode.blur();
         }
     }
 
-    handleInputFocus = (event) => {
+    handleInputFocus = (event: Event) => {
         this.setState({ focused: true });
         this.props.onFocus(event);
     }
 
-    handleInputBlur = (event) => {
+    handleInputBlur = (event: Event) => {
         this.setState({ focused: false });
         this.props.onBlur(event);
     }
 
-    handleInputChange = (event) => {
+    handleInputChange = (event: EventWithInput) => {
         // Only update if <input> isn't controlled
         if (!this.props.value) {
-            this.setState({ currentValue: event.target.value });
+            this.setState({ currentValue: event.currentTarget.value });
         }
 
         this.props.onChange(event);
@@ -79,6 +97,7 @@ class EditableBasicRow extends PureComponent {
 
     render() {
         const {
+            status,
             value,
             defaultValue,
             readOnly,

--- a/src/EditableBasicRow.js
+++ b/src/EditableBasicRow.js
@@ -71,6 +71,10 @@ class EditableBasicRow extends PureComponent<Props, Props, any> {
     };
 
     componentWillReceiveProps(nextProps: Props) {
+        if (nextProps.value !== this.props.value) {
+            this.setState({ currentValue: nextProps.value });
+        }
+
         if (this.inputNode && nextProps.status !== this.props.status) {
             this.inputNode.blur();
         }

--- a/src/EditableText.js
+++ b/src/EditableText.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import withStatus, { withStatusPropTypes } from './mixins/withStatus';
+import withStatus, { withStatusPropTypes, STATUS_CODE } from './mixins/withStatus';
 
 import EditableBasicRow from './EditableBasicRow';
 import { PureText } from './Text';
@@ -14,6 +14,7 @@ class EditableText extends PureComponent {
         align: PureText.propTypes.align,
         noGrow: PureText.propTypes.noGrow,
         ...withStatusPropTypes,
+        // status,
         // statusIcon,
         // errorMsg,
     };
@@ -25,6 +26,7 @@ class EditableText extends PureComponent {
         align: PureText.defaultProps.align,
         noGrow: PureText.defaultProps.noGrow,
         // Status props
+        status: undefined,
         statusIcon: undefined,
         errorMsg: undefined,
     };
@@ -49,6 +51,7 @@ class EditableText extends PureComponent {
             align,
             noGrow,
             // status props
+            status,
             statusIcon,
             errorMsg,
             // React props,
@@ -62,6 +65,8 @@ class EditableText extends PureComponent {
         const basicRow = (
             <EditableBasicRow
                 {...editableRowProps}
+                status={status}
+                readOnly={status === STATUS_CODE.LOADING}
                 onFocus={this.handleInputFocus}
                 onBlur={this.handleInputBlur} />
         );
@@ -75,5 +80,5 @@ class EditableText extends PureComponent {
     }
 }
 
-export default withStatus({ withRef: true })(EditableText);
+export default withStatus({ withRawStatus: true })(EditableText);
 export { EditableText as PureEditableText };

--- a/src/EditableText.js
+++ b/src/EditableText.js
@@ -1,3 +1,4 @@
+// @flow
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
@@ -5,8 +6,21 @@ import withStatus, { withStatusPropTypes, STATUS_CODE } from './mixins/withStatu
 
 import EditableBasicRow from './EditableBasicRow';
 import { PureText } from './Text';
+import type { Props as TextProps } from './Text';
 
-class EditableText extends PureComponent {
+export type Props = {
+    onFocus: (event?: Event) => void,
+    onBlur: (event?: Event) => void,
+    align: $PropertyType<TextProps, 'align'>,
+    noGrow: $PropertyType<TextProps, 'noGrow'>,
+    // #FIXME: use exported Flow types
+    status?: string | null,
+    statusIcon?: React$Element<*>,
+    errorMsg?: string,
+    className?: string, // eslint-disable-line react/require-default-props
+};
+
+class EditableText extends PureComponent<Props, Props, any> {
     static propTypes = {
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
@@ -25,7 +39,6 @@ class EditableText extends PureComponent {
         // <PureText> props,
         align: PureText.defaultProps.align,
         noGrow: PureText.defaultProps.noGrow,
-        // Status props
         status: undefined,
         statusIcon: undefined,
         errorMsg: undefined,
@@ -35,12 +48,12 @@ class EditableText extends PureComponent {
         focused: false,
     };
 
-    handleInputFocus = (event) => {
+    handleInputFocus = (event: Event) => {
         this.setState({ focused: true });
         this.props.onFocus(event);
     }
 
-    handleInputBlur = (event) => {
+    handleInputBlur = (event: Event) => {
         this.setState({ focused: false });
         this.props.onBlur(event);
     }

--- a/src/EditableText.js
+++ b/src/EditableText.js
@@ -1,99 +1,37 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import keycode from 'keycode';
 
-import prefixClass from './utils/prefixClass';
-import icBEM from './utils/icBEM';
-import withStatus from './mixins/withStatus';
-import './styles/EditableText.scss';
+import withStatus, { withStatusPropTypes } from './mixins/withStatus';
 
-import BasicRow from './BasicRow';
-import { PureText, BEM as TEXT_BEM } from './Text';
-
-export const COMPONENT_NAME = prefixClass('editable-text');
-const ROOT_BEM = icBEM(COMPONENT_NAME);
-export const BEM = {
-    root: ROOT_BEM,
-    input: ROOT_BEM.element('input'),
-    basicRow: ROOT_BEM.element('basic-row'),
-    basicLabel: ROOT_BEM.element('basic-label'),
-};
+import EditableBasicRow from './EditableBasicRow';
+import { PureText } from './Text';
 
 class EditableText extends PureComponent {
     static propTypes = {
-        onEditEnd: PropTypes.func,
-        // <input type="text" /> props
-        value: PropTypes.string,
-        defaultValue: PropTypes.string,
-        placeholder: PropTypes.string,
-        disabled: PropTypes.bool,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
-        onChange: PropTypes.func,
-        onKeyDown: PropTypes.func,
-        // Use `input` to inject props to the underlying <input>
-        input: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-        // withStatus() props,
-        errorMsg: PropTypes.string,
-        statusIcon: PropTypes.node,
+        // <PureText> props,
+        align: PureText.propTypes.align,
+        noGrow: PureText.propTypes.noGrow,
+        ...withStatusPropTypes,
+        // statusIcon,
+        // errorMsg,
     };
 
     static defaultProps = {
-        onEditEnd: () => {}, // ({ value: string|number, reset: boolean}) => {}
-        // <input> props
-        value: undefined,
-        defaultValue: undefined,
-        placeholder: 'Unset',
-        disabled: false,
         onFocus: () => {},
         onBlur: () => {},
-        onChange: () => {},
-        onKeyDown: () => {},
-        input: {},
-        errorMsg: undefined,
+        // <PureText> props,
+        align: PureText.defaultProps.align,
+        noGrow: PureText.defaultProps.noGrow,
+        // Status props
         statusIcon: undefined,
+        errorMsg: undefined,
     };
 
     state = {
-        currentValue: this.props.value || this.props.defaultValue || '',
         focused: false,
-        lastNotified: 0,
     };
-
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.value) {
-            this.setState({ currentValue: nextProps.value });
-        }
-    }
-
-    focusInputNode() {
-        this.inputNode.focus();
-    }
-
-    notifiyEditEnd(event, { reset = false } = {}) {
-        const currentTimestamp = Date.now();
-        const timeDiffMilliseconds = currentTimestamp - this.state.lastNotified;
-
-        /**
-         * Prevent <EditableText> from notifying edit end within a short time interval.
-         *
-         * This way we can blur the <input> after edit end without incorrectly firing an
-         * additional notification.
-         */
-        if (timeDiffMilliseconds < 200) {
-            return;
-        }
-
-        this.props.onEditEnd({
-            reset,
-            value: event.target.value,
-        });
-        this.setState(
-            { lastNotified: currentTimestamp },
-            () => this.inputNode.blur()
-        );
-    }
 
     handleInputFocus = (event) => {
         this.setState({ focused: true });
@@ -102,110 +40,37 @@ class EditableText extends PureComponent {
 
     handleInputBlur = (event) => {
         this.setState({ focused: false });
-        this.notifiyEditEnd(event);
-
         this.props.onBlur(event);
-    }
-
-    handleInputChange = (event) => {
-        // Only update if <input> isn't controlled
-        if (!this.props.value) {
-            this.setState({ currentValue: event.target.value });
-        }
-
-        this.props.onChange(event);
-    }
-
-    handleInputKeyDown = (event) => {
-        switch (event.keyCode) {
-            case keycode('Enter'):
-                this.notifiyEditEnd(event);
-                break;
-            case keycode('Escape'):
-                this.notifiyEditEnd(event, { reset: true });
-                break;
-            default:
-                break;
-        }
-        this.props.onKeyDown(event);
-    }
-
-    renderBasicRow() {
-        const {
-            placeholder,
-            disabled,
-            input: extraInputProps,
-        } = this.props;
-
-        const className = classNames(
-            TEXT_BEM.row.toString(),
-            TEXT_BEM.basic.toString(),
-            BEM.basicRow.toString(),
-        );
-
-        // 'basic' is required for <BasicRow>, but will be set inside <Text>
-        return (
-            <BasicRow basic="" className={className}>
-                <input
-                    ref={(ref) => { this.inputNode = ref; }}
-                    type="text"
-                    className={BEM.input}
-                    value={this.state.currentValue}
-                    placeholder={placeholder}
-                    disabled={disabled}
-                    onFocus={this.handleInputFocus}
-                    onBlur={this.handleInputBlur}
-                    onChange={this.handleInputChange}
-                    onKeyDown={this.handleInputKeyDown}
-                    {...extraInputProps} />
-            </BasicRow>
-        );
     }
 
     render() {
         const {
-            onEditEnd,
-            // <input> props
-            value,
-            defaultValue,
-            placeholder,
-            disabled,
-            onFocus,
-            onBlur,
-            onChange,
-            onKeyDown,
-            input,
+            // <PureText> props
+            align,
+            noGrow,
             // status props
             statusIcon,
             errorMsg,
             // React props,
             className,
-            ...textProps,
+            ...editableRowProps,
         } = this.props;
 
-        const { currentValue, focused } = this.state;
+        const textProps = { align, noGrow };
+        const statusProps = this.state.focused ? {} : { statusIcon, errorMsg };
 
-        const bemClass = BEM.root
-            .modifier('empty', !currentValue)
-            .modifier('focused', focused);
-
-        const rootClassName = classNames(`${bemClass}`, className);
-
-        const basicLabel = (
-            <span className={BEM.basicLabel}>
-                {currentValue || placeholder}
-            </span>
+        const basicRow = (
+            <EditableBasicRow
+                {...editableRowProps}
+                onFocus={this.handleInputFocus}
+                onBlur={this.handleInputBlur} />
         );
-
-        const statusProps = focused ? {} : { statusIcon, errorMsg };
 
         return (
             <PureText
-                className={rootClassName}
-                basic={basicLabel}
-                basicRow={this.renderBasicRow()}
-                {...statusProps}
-                {...textProps} />
+                basicRow={basicRow}
+                {...textProps}
+                {...statusProps} />
         );
     }
 }

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -1,6 +1,9 @@
+// @flow
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import keycode from 'keycode';
+
+import type { ReactChildren } from 'react-flow-types';
 
 import { getTextLayoutProps } from './mixins/rowComp';
 
@@ -10,7 +13,18 @@ import TextLabel from './TextLabel';
 
 import { STATUS_CODE as STATUS } from './StatusIcon';
 
-class EditableTextLabel extends PureComponent {
+export type Props = {
+    inEdit: boolean,
+    onEditRequest: () => void,
+    onEditEnd: (payload?: { value: string | null, event: Event }) => void,
+    // #FIXME: use exported Flow types
+    icon?: string,
+    basic?: ReactChildren,
+    align?: string,
+    status?: string | null,
+};
+
+class EditableTextLabel extends PureComponent<Props, Props, any> {
     static propTypes = {
         inEdit: PropTypes.bool,
         onEditRequest: PropTypes.func,
@@ -49,14 +63,14 @@ class EditableTextLabel extends PureComponent {
         this.props.onEditRequest();
     }
 
-    handleInputBlur = (event) => {
+    handleInputBlur = (event: Event & { currentTarget: HTMLInputElement }) => {
         this.props.onEditEnd({
             value: event.currentTarget.value,
             event,
         });
     }
 
-    handleInputKeyDown = (event) => {
+    handleInputKeyDown = (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => {
         switch (event.keyCode) {
             case keycode('Enter'):
                 // Blur the input, and trigger `onEditEnd` in blur handler

--- a/src/Text.js
+++ b/src/Text.js
@@ -79,13 +79,7 @@ class Text extends PureComponent {
     static defaultProps = {
         align: LEFT,
         aside: undefined,
-        basicRow: (
-            <BasicRow
-                className={classNames(
-                    BEM.row.toString(),
-                    BEM.basic.toString()
-                )} />
-        ),
+        basicRow: <BasicRow />,
         noGrow: false,
         errorMsg: undefined,
         statusIcon: undefined,
@@ -97,7 +91,15 @@ class Text extends PureComponent {
 
     renderBasicRow() {
         const { basicRow, basic, tag, statusIcon } = this.props;
-        const basicRowProps = { basic, tag, statusIcon };
+        const basicRowProps = {
+            basic,
+            tag,
+            statusIcon,
+            className: classNames(
+                BEM.row.toString(),
+                BEM.basic.toString()
+            ),
+        };
 
         if (basicRow && React.isValidElement(basicRow)) {
             // Inject { basic, tag, statusIcon } to default or custom row.

--- a/src/Text.js
+++ b/src/Text.js
@@ -47,14 +47,14 @@ export const TEXT_ALIGN = { LEFT, CENTER, RIGHT };
 
 export type Props = {
     align: typeof LEFT | typeof CENTER | typeof RIGHT,
-    aside: ReactChildren,
+    aside?: ReactChildren,
     basicRow: AnyReactElement,
     noGrow: boolean,
-    errorMsg: string,
-    statusIcon: ReactChildren, // #FIXME: use type from withStatus()
+    errorMsg?: string,
+    statusIcon?: ReactChildren, // #FIXME: use type from withStatus()
     basic: $PropertyType<BasicRowProps, 'basic'>,
     tag: $PropertyType<BasicRowProps, 'tag'>,
-    className: string,
+    className?: string,
 };
 
 class Text extends PureComponent {

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -4,74 +4,42 @@ import classNames from 'classnames';
 
 import prefixClass from './utils/prefixClass';
 import rowComp, { getTextLayoutProps, ROW_COMP_ALIGN } from './mixins/rowComp';
-import './styles/TextLabel.scss';
 
-import EditableText, { PureEditableText } from './EditableText';
+import EditableText from './EditableText';
 
 export const COMPONENT_NAME = prefixClass('text-input');
 
-const filterOutStatusProps = (props) => {
-    const {
-        statusIcon,
-        errorMsg,
-        ...filteredProps
-    } = props;
-
-    return filteredProps;
-};
-
 function TextInput(props, { align }) {
     const {
-        // <EditableText> props
-        onEditEnd,
-        value,
-        defaultValue,
-        placeholder,
-        disabled,
-        onFocus,
-        onBlur,
-        onChange,
-        onKeyDown,
-        input,
+        wrapperProps,
         // React props
         className,
-        ...otherProps
+        ...editableRowProps,
     } = props;
-
-    const editableTextProps = {
-        value,
-        defaultValue,
-        placeholder,
-        disabled,
-        onFocus,
-        onBlur,
-        onChange,
-        input,
-    };
 
     const rootClassName = classNames(className, COMPONENT_NAME);
     const textLayoutProps = getTextLayoutProps(align, false);
 
     return (
-        <div className={rootClassName} {...otherProps}>
+        <div className={rootClassName} {...wrapperProps}>
             <EditableText
-                {...editableTextProps}
-                {...textLayoutProps} />
+                {...textLayoutProps}
+                {...editableRowProps} />
         </div>
     );
 }
 
-TextInput.propTypes =
-    filterOutStatusProps(PureEditableText.propTypes);
+TextInput.propTypes = {
+    wrapperProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
 
-TextInput.defaultProps =
-    filterOutStatusProps(PureEditableText.defaultProps);
+TextInput.defaultProps = {
+    wrapperProps: {},
+};
 
 TextInput.contextTypes = {
     align: PropTypes.oneOf(Object.values(ROW_COMP_ALIGN)),
 };
 
-// export for tests
 export { TextInput as PureTextInput };
-
 export default rowComp({ defaultAlign: ROW_COMP_ALIGN.REVERSE })(TextInput);

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -14,7 +14,8 @@ function TextInput(props, { align }) {
         wrapperProps,
         // React props
         className,
-        ...editableRowProps,
+        children, // strip out from component
+        ...editableTextProps,
     } = props;
 
     const rootClassName = classNames(className, COMPONENT_NAME);
@@ -24,7 +25,7 @@ function TextInput(props, { align }) {
         <div className={rootClassName} {...wrapperProps}>
             <EditableText
                 {...textLayoutProps}
-                {...editableRowProps} />
+                {...editableTextProps} />
         </div>
     );
 }

--- a/src/__tests__/EditableBasicRow.test.js
+++ b/src/__tests__/EditableBasicRow.test.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow, mount } from 'enzyme';
+
+import EditableBasicRow from '../EditableBasicRow';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <EditableBasicRow />;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders an <input> inside a <BasicRow>', () => {
+    const wrapper = shallow(<EditableBasicRow />);
+
+    expect(wrapper.find('BasicRow')).toHaveLength(1);
+    expect(wrapper.find('BasicRow').find('input')).toHaveLength(1);
+});
+
+it('updates state on input focus/blur', () => {
+    const wrapper = shallow(<EditableBasicRow />);
+    const inputWrapper = wrapper.find('input');
+
+    expect(wrapper.state('focused')).toBeFalsy();
+
+    inputWrapper.simulate('focus');
+    expect(wrapper.state('focused')).toBeTruthy();
+
+    inputWrapper.simulate('blur');
+    expect(wrapper.state('focused')).toBeFalsy();
+});
+
+it('forwards onFocus/onBlur events', () => {
+    const handleFocus = jest.fn();
+    const handleBlur = jest.fn();
+
+    const wrapper = shallow(<EditableBasicRow onFocus={handleFocus} onBlur={handleBlur} />);
+    const inputWrapper = wrapper.find('input');
+
+    expect(handleFocus).not.toHaveBeenCalled();
+    expect(handleBlur).not.toHaveBeenCalled();
+
+    inputWrapper.simulate('focus');
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+    expect(handleBlur).not.toHaveBeenCalled();
+
+    inputWrapper.simulate('blur');
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+});
+
+it('forwards onChange event', () => {
+    const handleChange = jest.fn();
+    const wrapper = shallow(<EditableBasicRow onChange={handleChange} />);
+    const inputWrapper = wrapper.find('input');
+
+    expect(handleChange).not.toHaveBeenCalled();
+
+    inputWrapper.simulate('change', { currentTarget: document.createElement('input') });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+});
+
+it('updates user input inside state when not controlled', () => {
+    const wrapper = shallow(<EditableBasicRow defaultValue="Foo" />);
+    const inputWrapper = wrapper.find('input');
+    const mockedInput = document.createElement('input');
+
+    expect(wrapper.state('currentValue')).toBe('Foo');
+
+    mockedInput.value = 'Bar';
+    inputWrapper.simulate('change', { currentTarget: mockedInput });
+    expect(wrapper.state('currentValue')).toBe('Bar');
+});
+
+it('freezes input value when controlled via prop', () => {
+    const wrapper = shallow(<EditableBasicRow value="Foo" />);
+    const inputWrapper = wrapper.find('input');
+    const mockedInput = document.createElement('input');
+
+    expect(wrapper.state('currentValue')).toBe('Foo');
+
+    mockedInput.value = 'Bar';
+    inputWrapper.simulate('change', { currentTarget: mockedInput });
+    expect(wrapper.state('currentValue')).toBe('Foo');
+});
+
+it('renders basic label with the same visual text from input', () => {
+    const wrapper = mount(<EditableBasicRow value="Foo" placeholder="Unset" />);
+    expect(wrapper.text()).toBe('Foo');
+
+    wrapper.setProps({ value: 'Bar' });
+    expect(wrapper.text()).toBe('Bar');
+
+    wrapper.setProps({ value: '' });
+    expect(wrapper.text()).toBe('Unset');
+});
+
+it('blurs input when status changes', () => {
+    const mockedInputBlur = jest.fn();
+    const wrapper = mount(<EditableBasicRow />);
+    wrapper.instance().inputNode.blur = mockedInputBlur;
+
+    expect(mockedInputBlur).not.toHaveBeenCalled();
+
+    wrapper.setProps({ status: 'loading' });
+    expect(mockedInputBlur).toHaveBeenCalledTimes(1);
+});
+
+it('keeps input from keyboard navigation when input looks untouchable', () => {
+    const wrapper = shallow(<EditableBasicRow readOnly={false} disabled={false} />);
+    expect(wrapper.find('input').prop('tabIndex')).toBeUndefined();
+
+    wrapper.setProps({ readOnly: true, disabled: false });
+    expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+
+    wrapper.setProps({ readOnly: false, disabled: true });
+    expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+});
+

--- a/src/__tests__/EditableTextLabel.test.js
+++ b/src/__tests__/EditableTextLabel.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow, mount } from 'enzyme';
+import keycode from 'keycode';
 
 import { getTextLayoutProps, ROW_COMP_ALIGN } from '../mixins/rowComp';
 
@@ -19,24 +20,49 @@ it('renders without crashing', () => {
 it('renders like a typical <TextLabel> when not inEdit or loading', () => {
     const wrapper = shallow(<EditableTextLabel basic="Foo" />);
 
-    expect(wrapper.type()).toEqual(TextLabel);
+    expect(wrapper.is(TextLabel)).toBeTruthy();
     expect(wrapper.prop('basic')).toBe('Foo');
     expect(wrapper.prop('children')).toBeUndefined();
 });
 
-it('renders an <EditableText> when in edit mode', () => {
+it('renders <EditableText> inside <TextLabel> when in edit mode', () => {
     const wrapper = shallow(<EditableTextLabel basic="Foo" inEdit />);
 
-    expect(wrapper.prop('children')[0]).toBeNull();
-    expect(wrapper.prop('children')[1].type).toEqual(EditableText);
+    expect(wrapper.is(TextLabel)).toBeTruthy();
+    expect(wrapper.find(EditableText).exists()).toBeTruthy();
+    expect(wrapper.find(EditableText).prop('defaultValue')).toBe('Foo');
 
-    wrapper.setProps({ icon: 'printer' });
-    expect(wrapper.prop('children')[0]).toEqual(<Icon type="printer" />);
-    expect(wrapper.prop('children')[1].type).toEqual(EditableText);
+    wrapper.setProps({ inEdit: false });
+    expect(wrapper.find(EditableText).exists()).toBeFalsy();
+});
 
-    wrapper.setProps({ inEdit: false, status: 'loading' });
-    expect(wrapper.prop('children')[0]).toEqual(<Icon type="printer" />);
-    expect(wrapper.prop('children')[1].type).toEqual(EditableText);
+it('renders icon no matter in edit mode or not', () => {
+    const wrapper = shallow(<EditableTextLabel icon="printer" basic="Foo" />);
+
+    // Icon is rendered by <TextLabel> when not inEdit
+    expect(wrapper.dive().contains(<Icon type="printer" />)).toBeTruthy();
+
+    // Icon is passed into <TextLabel> by <EditableTextLabel> when inEdit
+    wrapper.setProps({ inEdit: true });
+    expect(wrapper.contains(<Icon type="printer" />)).toBeTruthy();
+});
+
+it('renders <EditableText> with layout props the same as rowComp() in edit mode', () => {
+    const wrapper = shallow(<EditableTextLabel basic="Foo" align="left" inEdit />);
+
+    Object.values(ROW_COMP_ALIGN).forEach((alignment) => {
+        let layoutProps = getTextLayoutProps(alignment, false);
+        wrapper.setProps({ align: alignment, icon: undefined });
+
+        expect(wrapper.find(EditableText).prop('align')).toBe(layoutProps.align);
+        expect(wrapper.find(EditableText).prop('noGrow')).toBe(layoutProps.noGrow);
+
+        layoutProps = getTextLayoutProps(alignment, true);
+        wrapper.setProps({ align: alignment, icon: 'printer' });
+
+        expect(wrapper.find(EditableText).prop('align')).toBe(layoutProps.align);
+        expect(wrapper.find(EditableText).prop('noGrow')).toBe(layoutProps.noGrow);
+    });
 });
 
 it('requests to go edit mode when double-clicked in normal mode', () => {
@@ -53,57 +79,79 @@ it('requests to go edit mode when double-clicked in normal mode', () => {
     expect(() => wrapper.simulate('dblclick')).not.toThrowError();
 });
 
-it('renders <EditableText> with initial value and onEditEnd in edit mode', () => {
+it('fires onEditEnd with input value on input blurs', () => {
     const handleEditEnd = jest.fn();
-    const wrapper = shallow(<EditableTextLabel basic="Foo" inEdit onEditEnd={handleEditEnd} />);
+    const wrapper = mount(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
+    const input = wrapper.find('input').node;
 
-    expect(wrapper.prop('children')[1].props.defaultValue).toBe('Foo');
-    expect(wrapper.prop('children')[1].props.onEditEnd).toBe(handleEditEnd);
+    expect(handleEditEnd).not.toHaveBeenCalled();
+
+    // Blur without changing input value
+    wrapper.find('input').simulate('blur');
+    expect(handleEditEnd).toHaveBeenCalledTimes(1);
+    expect(handleEditEnd.mock.calls[0][0].value).toBe('foo');
+
+    // Blur with a different value
+    input.value = 'bar';
+    wrapper.find('input').simulate('blur');
+    expect(handleEditEnd).toHaveBeenCalledTimes(2);
+    expect(handleEditEnd.mock.calls[1][0].value).toBe('bar');
 });
 
-it('renders <EditableText> with layout props the same as rowComp() in edit mode', () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" align="left" inEdit />);
+it('fires onEditEnd with input value on Enter key', () => {
+    const handleEditEnd = jest.fn();
+    const wrapper = mount(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
 
-    Object.values(ROW_COMP_ALIGN).forEach((alignment) => {
-        let layoutProps = getTextLayoutProps(alignment, false);
-        wrapper.setProps({ align: alignment, icon: undefined });
+    const input = wrapper.find('input').node;
+    input.blur = jest.fn(() => wrapper.find('input').simulate('blur'));
 
-        expect(wrapper.prop('children')[1].props.align).toBe(layoutProps.align);
-        expect(wrapper.prop('children')[1].props.noGrow).toBe(layoutProps.noGrow);
+    expect(handleEditEnd).not.toHaveBeenCalled();
 
-        layoutProps = getTextLayoutProps(alignment, true);
-        wrapper.setProps({ align: alignment, icon: 'printer' });
+    // Simulate 'Enter' without changing input value
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Enter') });
+    expect(handleEditEnd).toHaveBeenCalledTimes(1);
+    expect(handleEditEnd.mock.calls[0][0].value).toBe('foo');
 
-        expect(wrapper.prop('children')[1].props.align).toBe(layoutProps.align);
-        expect(wrapper.prop('children')[1].props.noGrow).toBe(layoutProps.noGrow);
-    });
+    // Simulate 'Enter' with a different value
+    input.value = 'bar';
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Enter') });
+    expect(handleEditEnd).toHaveBeenCalledTimes(2);
+    expect(handleEditEnd.mock.calls[1][0].value).toBe('bar');
 });
 
-it('calls <EditableText> to focus its <input> when going edit mode', () => {
-    const wrapper = mount(<EditableTextLabel basic="Foo" />);
+it('fires onEditEnd with value as null on Escape key', () => {
+    const handleEditEnd = jest.fn();
+    const wrapper = mount(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
 
-    const instance = wrapper.instance();
-    const originalDidUpdate = instance.componentDidUpdate;
+    const input = wrapper.find('input').node;
+    input.blur = jest.fn(() => wrapper.find('input').simulate('blur'));
 
-    const focusInputNode = jest.fn();
-    const getRenderedComponent = jest.fn(() => ({ focusInputNode }));
+    expect(handleEditEnd).not.toHaveBeenCalled();
 
-    // Mock `componentDidUpdate` so we can apply more mocking on refs.
-    instance.componentDidUpdate = (...args) => {
-        if (instance.props.inEdit) {
-            instance.editableTextRef.getRenderedComponent = getRenderedComponent;
-        }
-        originalDidUpdate.apply(instance, args);
-    };
+    // Simulate 'Enter' without changing input value
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Escape') });
+    expect(handleEditEnd).toHaveBeenCalledTimes(1);
+    expect(handleEditEnd.mock.calls[0][0].value).toBeNull();
 
-    // Component updated without `inEdit`
-    wrapper.setProps({ basic: 'Bar' });
-    expect(getRenderedComponent).not.toHaveBeenCalled();
-    expect(focusInputNode).not.toHaveBeenCalled();
+    // Simulate 'Enter' with a different value
+    input.value = 'bar';
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Escape') });
+    expect(handleEditEnd).toHaveBeenCalledTimes(2);
+    expect(handleEditEnd.mock.calls[1][0].value).toBeNull();
+});
 
+it('does not fire onEditEnd on other keys', () => {
+    const handleEditEnd = jest.fn();
+    const wrapper = mount(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
 
-    // Component updated **with** `inEdit`
-    wrapper.setProps({ inEdit: true });
-    expect(getRenderedComponent).toHaveBeenCalled();
-    expect(focusInputNode).toHaveBeenCalled();
+    expect(handleEditEnd).not.toHaveBeenCalled();
+
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('A') });
+    expect(handleEditEnd).not.toHaveBeenCalled();
+
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Ctrl') });
+    expect(handleEditEnd).not.toHaveBeenCalled();
+
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Delete') });
+    expect(handleEditEnd).not.toHaveBeenCalled();
 });

--- a/src/__tests__/TextInput.test.js
+++ b/src/__tests__/TextInput.test.js
@@ -28,6 +28,17 @@ describe('pure <TextInput>', () => {
         expect(wrapper.hasClass('gyp-text-input')).toBeTruthy();
     });
 
+    it('can set props to div-wrapper via wrapperProps', () => {
+        const wrapper = shallow(
+            <PureTextInput
+                wrapperProps={{ disabled: true, 'data-foo': 'bar' }} />
+        );
+
+        expect(wrapper.is('div')).toBeTruthy();
+        expect(wrapper.prop('disabled')).toBeTruthy();
+        expect(wrapper.prop('data-foo')).toBe('bar');
+    });
+
     it('renders <EditableText> and ignores chidlren from parent mixin', () => {
         const wrapper = shallow(
             <PureTextInput>
@@ -52,34 +63,10 @@ describe('pure <TextInput>', () => {
         });
     });
 
-    it('passes only white-listed props to <EditableText>', () => {
-        const handleFocus = jest.fn();
-        const handleBlur = jest.fn();
-        const handleChange = jest.fn();
+    it('passes unknown props to <EditableText>', () => {
+        const wrapper = shallow(<PureTextInput className="foo" foo="bar" />);
 
-        const whitelistedProps = {
-            value: 'Foo',
-            defaultValue: 'Bar',
-            placeholder: 'john.appleseed@example.com',
-            disabled: false,
-            onFocus: handleFocus,
-            onBlur: handleBlur,
-            onChange: handleChange,
-        };
-
-        const wrapper = shallow(
-            <PureTextInput
-                {...whitelistedProps}
-                input={{ id: 'foo-dom-id' }}
-                data-unsupported-prop />
-        );
-        const textWrapper = wrapper.childAt(0);
-
-        Object.entries(whitelistedProps).forEach(([key, value]) => {
-            expect(textWrapper.prop(key)).toBe(value);
-        });
-
-        expect(textWrapper.prop('input')).toEqual({ id: 'foo-dom-id' });
-        expect(textWrapper.prop('data-unsupported-prop')).toBeUndefined();
+        expect(wrapper.find(EditableText).prop('className')).toBeUndefined();
+        expect(wrapper.find(EditableText).prop('foo')).toBe('bar');
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import './styles/index.scss';
 
 // Visual elements
 import BasicRow from './BasicRow';
+import EditableBasicRow from './EditableBasicRow';
 import Icon from './Icon';
 import StatusIcon from './StatusIcon';
 import Tag from './Tag';
@@ -32,6 +33,7 @@ import InfiniteScroll from './InfiniteScroll';
 
 export {
     BasicRow,
+    EditableBasicRow,
     Icon,
     StatusIcon,
     Tag,

--- a/src/mixins/withStatus.js
+++ b/src/mixins/withStatus.js
@@ -5,6 +5,8 @@ import getComponentName from '../utils/getComponentName';
 
 import StatusIcon, { STATUS_CODE } from '../StatusIcon';
 
+export { STATUS_CODE };
+
 // Status context types
 export const statusPropTypes = {
     status: PropTypes.oneOf(Object.values(STATUS_CODE)),
@@ -14,12 +16,14 @@ export const statusPropTypes = {
 
 // prop types for what's going to set on wrapped component
 export const withStatusPropTypes = {
+    status: statusPropTypes.status,
     statusIcon: PropTypes.node,
-    errorMsg: PropTypes.string,
+    errorMsg: statusPropTypes.errorMsg,
 };
 
 const withStatus = ({
     withRef = false,
+    withRawStatus = false,
     ...defaultStatusOptions,
 } = {}) => (WrappedComponent) => {
     const componentName = getComponentName(WrappedComponent);
@@ -38,6 +42,16 @@ const withStatus = ({
             return this.renderedComponentRef;
         }
 
+        getOptionalProps() {
+            const props = {};
+
+            if (withRawStatus) {
+                props.status = this.context.status;
+            }
+
+            return props;
+        }
+
         render() {
             const { status, statusOptions = {}, errorMsg } = this.context;
 
@@ -51,11 +65,13 @@ const withStatus = ({
             const refProps = !withRef ? {} : {
                 ref: (ref) => { this.renderedComponentRef = ref; },
             };
+            const optionalProps = this.getOptionalProps();
 
             return (
                 <WrappedComponent
                     {...refProps}
                     {...this.props}
+                    {...optionalProps}
                     statusIcon={statusIcon}
                     errorMsg={errorMsg} />
             );

--- a/src/styles/EditableBasicRow.scss
+++ b/src/styles/EditableBasicRow.scss
@@ -1,19 +1,17 @@
 @import "./mixins";
 
-$block-name: #{$prefix}-editable-text;
+$block-name: #{$prefix}-editable-basic-row;
 
 .#{$block-name} {
-    cursor: pointer;
+    position: relative;
 
     // ---------------------
     //  Elements
     // ---------------------
     &__basic-label {
         color: $c-input-text;
-    }
-
-    &__basic-row {
-        position: relative;
+        opacity: 1;
+        will-change: opacity;
     }
 
     &__input {
@@ -32,6 +30,14 @@ $block-name: #{$prefix}-editable-text;
         top: 0;
         left: 0;
         will-change: opacity;
+        outline: none;
+
+        &:focus {
+            opacity: 1;
+            box-shadow:
+                0  1px 0 $c-input-border,
+                0 -1px 0 $c-input-border inset;
+        }
     }
 
     ::placeholder {
@@ -45,32 +51,19 @@ $block-name: #{$prefix}-editable-text;
         color: $c-input-placeholder;
     }
 
-    &--focused {
-        cursor: auto;
-
-        .#{$block-name}__input {
-            opacity: 1;
-            outline: none;
-            cursor: text;
-        }
-
-        .#{$block-name}__basic-row {
-            box-shadow: 0 2px 0 $c-input-border;
-        }
-
-        .#{$block-name}__basic-label {
-            opacity: 0;
-        }
+    &--focused &__basic-label,
+    &--disabled &__basic-label {
+        opacity: 0;
     }
 
     // ---------------------
     //  States/Interactions
     // ---------------------
-    &.#{$prefix}-text--center &__input {
+    .#{$prefix}-text--center &__input {
         text-align: center;
     }
 
-    &.#{$prefix}-text--right &__input {
+    .#{$prefix}-text--right &__input {
         text-align: right;
     }
 

--- a/src/styles/Text.scss
+++ b/src/styles/Text.scss
@@ -26,7 +26,6 @@
     &__row {
         display: flex;
         align-items: flex-start;
-        overflow: hidden;
     }
 
     &__basic {


### PR DESCRIPTION
### Purpose
Split out `<EditableBasicRow>` which handles the input from `<EditableText>` , so each `Editable*` components can be more focused.

### Implement
1. The input parts are moved into a new `<EditableBasicRow>`. It renders an `<input>` inside along with the basic label showing what you read on the input.
2. `<EditableText>` is simplified to only passes to/removes the status-related props from `<EditableBasicRow>`.
3. `<TextInput>` is thus simplified to just pass props to `<EditableText>`.
4. `<EditableTextLabel>` is now the only component that's responsible for managing input value changes. It discards input on `Esc` key, and report the input value on `Enter` key and input blurs.
5. Flow annotations for `Editable*` components.