### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+
+node_js:
+    - "node"
+
+install:
+    - yarn
+
+script:
+    - yarn lint
+    - yarn test
+    # Deploy package to dist branch or npm
+    - "if [ ${TRAVIS_PULL_REQUEST} = 'false']; then yarn deploy; fi"
+    # Publish storybook to gh-pages branch
+    - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master']; then yarn gppages; fi"
+
+branches:
+    only:
+        - master
+        - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ script:
     # Publish storybook to gh-pages branch
     - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master']; then yarn gppages; fi"
 
+# Send coverage data to Coveralls
+after_script:
+    - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+
 branches:
     only:
         - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,7 @@ branches:
     only:
         - master
         - develop
+
+env:
+  global:
+    - GH_REPO: github.com/iCHEF/gypcrete.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ node_js:
 install:
     - yarn
 
-script:
+before_script:
     - yarn lint
     - yarn test
+
+script:
     # Deploy package to dist branch or npm
     - "if [ ${TRAVIS_PULL_REQUEST} = 'false']; then yarn deploy; fi"
     # Publish storybook to gh-pages branch
-    - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master']; then yarn gppages; fi"
+    - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master']; then yarn ghpages; fi"
 
 # Send coverage data to Coveralls
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Apache License 2.0 for open-source.
 - Add `Installation` and `Usage` contents in README.
 - A new `<EditableBasicRow>` containing input logics is split from `<EditableText>`. (#63) Also supports choosing from `input` or `textarea` for its inner tag. (#64)
+- Add shields on README. (#66)
+
+### Changed
+- Add `Installation` and `Usage` contents in README.
+- Turn CI service to TravisCI. (#66)
+- Update `deloy.sh` and `ghpages.sh` scripts to fit TravisCI.
+- Upgrade `node-sass` to v4.5.3 to fix error on Node 8.
+- Replace `jest-junit` reporter by [Coveralls](https://coveralls.io/github/iCHEF/gypcrete), send coverage data to Coveralls after CI build.
+
 
 ### Changed
 - `<EditableText>` is simplified to only hold status-related logic. (#63)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # gypcrete
 iCHEF web components library, built with React.
 
-[Demo](http://ichef.github.io/gypcrete)
+[![npm package](https://img.shields.io/npm/v/@ichef/gypcrete.svg)](https://www.npmjs.com/package/@ichef/gypcrete)
+[![build status](https://img.shields.io/travis/iCHEF/gypcrete/master.svg)](https://travis-ci.org/iCHEF/gypcrete)
+[![Coverage Status](https://img.shields.io/coveralls/iCHEF/gypcrete/master.svg)](https://coveralls.io/github/iCHEF/gypcrete?branch=master)
+
+[![PeerDependencies](https://img.shields.io/david/peer/iCHEF/gypcrete.svg)](https://david-dm.org/iCHEF/gypcrete?type=peer)
+[![Dependencies](https://img.shields.io/david/iCHEF/gypcrete.svg)](https://david-dm.org/iCHEF/gypcrete)
+[![DevDependencies](https://img.shields.io/david/dev/iCHEF/gypcrete.svg)](https://david-dm.org/iCHEF/gypcrete?type=dev)
+
+## Demo
+[ichef.github.io/gypcrete](https://ichef.github.io/gypcrete)
 
 ## Installation
 ```sh

--- a/configs/jest.config.json
+++ b/configs/jest.config.json
@@ -3,6 +3,5 @@
     "moduleNameMapper": {
          "\\.(css|scss|sass|md|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|)$": "<rootDir>/__mocks__/fileMock.js"
     },
-    "testRegex": "(/__tests__/.*.(test|spec))\\.jsx?$",
-    "testResultsProcessor": "<rootDir>/node_modules/jest-junit"
+    "testRegex": "(/__tests__/.*.(test|spec))\\.jsx?$"
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-preset-env": "^1.2.1",
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-2": "^6.22.0",
+    "coveralls": "^2.13.1",
     "css-loader": "^0.26.2",
     "enzyme": "^2.8.2",
     "eslint": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "flow-bin": "^0.47.0",
     "jest": "^19.0.2",
     "jest-junit": "zhusee2/jest-junit#update_format",
-    "node-sass": "^4.5.0",
+    "node-sass": "^4.5.3",
     "postcss-loader": "^1.3.3",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "file-loader": "^0.10.1",
     "flow-bin": "^0.47.0",
     "jest": "^19.0.2",
-    "jest-junit": "zhusee2/jest-junit#update_format",
     "node-sass": "^4.5.3",
     "postcss-loader": "^1.3.3",
     "react": "^15.5.4",
@@ -101,8 +100,5 @@
   },
   "stylelint": {
     "extends": "./configs/.stylelintrc.yml"
-  },
-  "jest-junit": {
-    "output": "./coverage/junit.xml"
   }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,15 +3,19 @@
 # Clear and re-create the deploy directory
 rm -rf deploy || exit 0
 
+# Setup git
+git config --global user.name "ichefbot"
+git config --global user.email "developer@ichef.com.tw"
+
 # Screenshot master branch with release tag
-if [ "$GIT_BRANCH" = "origin/master" ]; then
+if [ "$TRAVIS_BRANCH" = "master" ]; then
     export PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
     git tag -a "${PACKAGE_VERSION}" -m "Deployed with ${BUILD_TAG}"
     git push --tag --force origin || exit 1
 fi
 
 # Git clone
-git clone -b dist --single-branch git@github.com:iCHEF/gypcrete.git deploy
+git clone -b dist --single-branch "https://${GH_REPO}" deploy
 
 # Clean up files from last build
 rm -rf ./deploy/dist ./deploy/lib ./deploy/es5
@@ -26,13 +30,14 @@ cp ./package.json ./deploy/package.json
 # Commit built files
 cd deploy
 git add .
-git commit -m "Built at ${BUILD_TAG}" --author="ichefbot <developer@ichef.com.tw>"
+git commit -m "Built at Travis-${TRAVIS_BUILD_NUMBER} (${TRAVIS_COMMIT_RANGE})"
 
 # Push to dist branch
-git push origin dist
+git remote add origin-pages "https://${GH_TOKEN}@${GH_REPO}" > /dev/null 2>&1
+git push --set-upstream origin-pages dist
 
 # Publish to npm (only in master)
-if [ "$GIT_BRANCH" = "origin/master" ]; then
-    echo //registry.npmjs.org/:_authToken="${NPM_TOKEN}" > "${WORKSPACE}"/deploy/.npmrc
+if [ "$TRAVIS_BRANCH" = "master" ]; then
+    echo //registry.npmjs.org/:_authToken="${NPM_TOKEN}" > "${TRAVIS_BUILD_DIR}"/deploy/.npmrc
     npm publish || exit 1
 fi

--- a/scripts/ghpages.sh
+++ b/scripts/ghpages.sh
@@ -4,9 +4,13 @@
 rm -rf deploy || exit 0
 
 # Only deploy storybook from master branch
-if [ "$GIT_BRANCH" = "origin/master" ]; then
+if [ "$TRAVIS_BRANCH" = "master" ]; then
+    # Setup git
+    git config --global user.name "ichefbot"
+    git config --global user.email "developer@ichef.com.tw"
+
     # Git clone
-    git clone -b gh-pages --single-branch git@github.com:iCHEF/gypcrete.git deploy
+    git clone -b gh-pages --single-branch "https://${GH_REPO}" deploy
 
     # Clean up files from last build(except .git)
     find ./deploy/* ! -path "./deploy/.git/*" ! -name ".git" | xargs rm -rf
@@ -14,9 +18,12 @@ if [ "$GIT_BRANCH" = "origin/master" ]; then
     # Copy public files
     cp -R ./public/. ./deploy
 
-    # Commit and push
+    # Commit files
     cd deploy
     git add .
-    git commit -m "Built at ${BUILD_TAG}" --author="ichefbot <developer@ichef.com.tw>"
-    git push origin gh-pages
+    git commit -m "Built at Travis-${TRAVIS_BUILD_NUMBER} (${TRAVIS_COMMIT_RANGE})"
+
+    # Push to gh-pages
+    git remote add origin-pages "https://${GH_TOKEN}@${GH_REPO}" > /dev/null 2>&1
+    git push --set-upstream origin-pages gh-pages
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -4222,13 +4222,6 @@ jest-jasmine2@^19.0.2:
     jest-message-util "^19.0.0"
     jest-snapshot "^19.0.2"
 
-jest-junit@zhusee2/jest-junit#update_format:
-  version "1.4.0"
-  resolved "https://codeload.github.com/zhusee2/jest-junit/tar.gz/df09e52562db8664214772231265390ec1046d39"
-  dependencies:
-    mkdirp "^0.5.1"
-    xml "^1.0.1"
-
 jest-matcher-utils@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
@@ -7274,10 +7267,6 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,10 @@ case-sensitive-paths-webpack-plugin@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz#3d29ced8c1f124bf6f53846fb3f5894731fdc909"
 
+caseless@~0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -2284,6 +2288,16 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     os-homedir "^1.0.1"
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
+
+coveralls@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.1.tgz#d70bb9acc1835ec4f063ff9dac5423c17b11f178"
+  dependencies:
+    js-yaml "3.6.1"
+    lcov-parse "0.0.10"
+    log-driver "1.2.5"
+    minimist "1.2.0"
+    request "2.79.0"
 
 create-ecdh@^4.0.0:
   version "4.0.0"
@@ -3579,6 +3593,15 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
+har-validator@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
+  dependencies:
+    chalk "^1.1.1"
+    commander "^2.9.0"
+    is-my-json-valid "^2.12.4"
+    pinkie-promise "^2.0.0"
+
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
@@ -3902,7 +3925,7 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-my-json-valid@^2.10.0:
+is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
@@ -4325,7 +4348,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
+js-yaml@3.6.1, js-yaml@^3.4.3, js-yaml@^3.5.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
+
+js-yaml@^3.7.0:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.2.tgz#02d3e2c0f6beab20248d412c352203827d786721"
   dependencies:
@@ -4465,6 +4495,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+lcov-parse@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 ldjson-stream@^1.2.1:
   version "1.2.1"
@@ -4641,6 +4675,10 @@ lodash@4.x.x, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.15.0, loda
 lodash@~4.16.4:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
+
+log-driver@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -4824,7 +4862,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5777,6 +5815,10 @@ qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+qs@~6.3.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
 query-string@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.2.tgz#ec0fd765f58a50031a3968c2431386f8947a5cdd"
@@ -6150,6 +6192,31 @@ request@2, request@^2.79.0, request@^2.81.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
+request@2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
 require-directory@^2.1.1:
@@ -6836,6 +6903,10 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
+
+tunnel-agent@~0.4.1:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,9 +4972,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.0.tgz#532e37bad0ce587348c831535dbc98ea4289508b"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -4991,7 +4991,7 @@ node-sass@^4.5.0:
     nan "^2.3.2"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "^2.61.0"
+    request "^2.79.0"
     sass-graph "^2.1.1"
     stdout-stream "^1.4.0"
 
@@ -6125,7 +6125,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@^2.61.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -6202,13 +6202,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:


### PR DESCRIPTION
## Purpose

Turn CI service to free and open-source friendly [TravisCI](https://travis-ci.org/iCHEF/gypcrete).

## Implement
- Add travis config.
- Add [shields](http://shields.io/) on README.
- Upgrade `node-sass` to v4.5.3 to fix error on Node 8.
- Replace `jest-junit` reporter by [Coveralls](https://coveralls.io/github/iCHEF/gypcrete), send coverage data to Coveralls after CI build.
- Update `deloy.sh` and `ghpages.sh` scripts to fit TravisCI.
