### PR TITLE
Containers: Header and List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- N/A
+- Add `<HeaderRow>` which is split into `left`, `center` and `right` tiers.
+- Add `<List>` section that supports a title and a description block.
+- Add simple `<ListRow>` with a Flexbox body for row components.
+
+### Changed
+- Improved tests coverage
 
 
 ## [0.13.1]

--- a/examples/DebugBox.js
+++ b/examples/DebugBox.js
@@ -7,15 +7,16 @@ const defaultBoxStyle = {
     position: 'relative',
 };
 
-function DebugBox({ width, height, children }) {
-    const style = {
+function DebugBox({ width, height, style, children }) {
+    const boxStyle = {
         ...defaultBoxStyle,
         width,
         height,
+        ...style,
     };
 
     return (
-        <div style={style}>
+        <div style={boxStyle}>
             {children}
         </div>
     );
@@ -30,11 +31,13 @@ DebugBox.propTypes = {
         PropTypes.number,
         PropTypes.string
     ]),
+    style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 DebugBox.defaultProps = {
     width: '20rem',
     height: 'auto',
+    style: {},
 };
 
 export default DebugBox;

--- a/examples/HeaderRow/BasicUsage.js
+++ b/examples/HeaderRow/BasicUsage.js
@@ -3,16 +3,23 @@ import React from 'react';
 import HeaderRow from 'src/HeaderRow';
 import Button from 'src/Button';
 import TextLabel from 'src/TextLabel';
+import TextEllipsis from 'src/TextEllipsis';
 
 import DebugBox from '../DebugBox';
 
 function BasicUsage() {
     const leftBtn = <Button icon="prev" basic="Back" />;
     const rightBtn = <Button basic="Save" />;
-    const centerLabel = <TextLabel basic="A slightly longer title" />;
+    const centerLabel = (
+        <TextLabel
+            align="center"
+            basic={
+                <TextEllipsis>Lorem ipsum a slightly longer title</TextEllipsis>
+            } />
+    );
 
     return (
-        <DebugBox width="30rem">
+        <DebugBox>
             <HeaderRow
                 left={leftBtn}
                 center={centerLabel}

--- a/examples/HeaderRow/BasicUsage.js
+++ b/examples/HeaderRow/BasicUsage.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import HeaderRow from 'src/HeaderRow';
+import Button from 'src/Button';
+import TextLabel from 'src/TextLabel';
+
+import DebugBox from '../DebugBox';
+
+function BasicUsage() {
+    const leftBtn = <Button icon="prev" basic="Back" />;
+    const rightBtn = <Button basic="Save" />;
+    const centerLabel = <TextLabel basic="A slightly longer title" />;
+
+    return (
+        <DebugBox width="30rem">
+            <HeaderRow
+                left={leftBtn}
+                center={centerLabel}
+                right={rightBtn} />
+        </DebugBox>
+    );
+}
+
+export default BasicUsage;

--- a/examples/HeaderRow/index.js
+++ b/examples/HeaderRow/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+// For props table
+import HeaderRow from 'src/HeaderRow';
+
+import BasicUsage from './BasicUsage';
+
+storiesOf('HeaderRow', module)
+    .addWithInfo('Basic usage', BasicUsage)
+    // Props table
+    .addPropsTable(() => <HeaderRow />);

--- a/examples/List/NormalList.js
+++ b/examples/List/NormalList.js
@@ -11,12 +11,12 @@ import DebugBox from '../DebugBox';
 function NormalList() {
     return (
         <DebugBox width="30rem">
-            <List variant="normal">
+            <List variant="normal" title="List title" desc="Help text here">
                 <ListRow>
-                    <TextLabel basic="Hello World" />
+                    <TextLabel icon="tickets" basic="Hello World" />
                 </ListRow>
                 <ListRow>
-                    <TextLabel basic="Row 2" />
+                    <TextLabel icon="tickets" basic="Row 2" />
                 </ListRow>
                 <ListRow>
                     <Button

--- a/examples/List/NormalList.js
+++ b/examples/List/NormalList.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import List from 'src/List';
+import ListRow from 'src/ListRow';
+
+import Button from 'src/Button';
+import TextLabel from 'src/TextLabel';
+
+import DebugBox from '../DebugBox';
+
+function NormalList() {
+    return (
+        <DebugBox width="30rem">
+            <List variant="normal">
+                <ListRow>
+                    <TextLabel basic="Hello World" />
+                </ListRow>
+                <ListRow>
+                    <TextLabel basic="Row 2" />
+                </ListRow>
+                <ListRow>
+                    <Button
+                        icon="add"
+                        basic="Add row" />
+                </ListRow>
+            </List>
+        </DebugBox>
+    );
+}
+
+export default NormalList;

--- a/examples/List/SettingList.js
+++ b/examples/List/SettingList.js
@@ -12,8 +12,8 @@ import DebugBox from '../DebugBox';
 
 function SettingList() {
     return (
-        <DebugBox width="30rem" style={{ padding: '1rem' }}>
-            <List variant="setting">
+        <DebugBox width="30rem" style={{ padding: '0 1rem' }}>
+            <List variant="setting" title="List title" desc="Help text here">
                 <ListRow>
                     <TextLabel basic="Hello World" />
                 </ListRow>

--- a/examples/List/SettingList.js
+++ b/examples/List/SettingList.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import List from 'src/List';
+import ListRow from 'src/ListRow';
+
+import Button from 'src/Button';
+import Icon from 'src/Icon';
+import TextLabel from 'src/TextLabel';
+import TextInput from 'src/TextInput';
+
+import DebugBox from '../DebugBox';
+
+function SettingList() {
+    return (
+        <DebugBox width="30rem" style={{ padding: '1rem' }}>
+            <List variant="setting">
+                <ListRow>
+                    <TextLabel basic="Hello World" />
+                </ListRow>
+                <ListRow>
+                    <TextLabel basic="Row 2" />
+                    <TextInput value="Value" />
+                    <Icon type="row-padding" />
+                </ListRow>
+                <ListRow>
+                    <Button
+                        icon="add"
+                        basic="Add row" />
+                </ListRow>
+            </List>
+        </DebugBox>
+    );
+}
+
+export default SettingList;

--- a/examples/List/index.js
+++ b/examples/List/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+// For props table
+import List from 'src/List';
+import ListRow from 'src/ListRow';
+
+import NormalList from './NormalList';
+import SettingList from './SettingList';
+
+storiesOf('List', module)
+    .addWithInfo('Normal list', NormalList)
+    .addWithInfo('Setting list', SettingList)
+    // Props table
+    .addPropsTable(() => <List />, [ListRow]);

--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -1,0 +1,53 @@
+// @flow
+import React from 'react';
+import classNames from 'classnames';
+import type { ReactChildren } from 'react-flow-types';
+
+import prefixClass from './utils/prefixClass';
+import icBEM from './utils/icBEM';
+
+export const COMPONENT_NAME = prefixClass('header');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    left: ROOT_BEM.element('left'),
+    center: ROOT_BEM.element('center'),
+    right: ROOT_BEM.element('right'),
+};
+
+export type Props = {
+    left?: ReactChildren,
+    center?: ReactChildren,
+    right?: ReactChildren,
+    className?: string, // eslint-disable-line react/require-default-props
+};
+
+function HeaderRow({
+    left,
+    center,
+    right,
+    // React props
+    className,
+    ...otherProps,
+}: Props) {
+    const rootClassName = classNames(
+        BEM.root.toString(),
+        className,
+    );
+
+    return (
+        <div className={rootClassName} {...otherProps}>
+            <div className={BEM.left}>{left}</div>
+            <div className={BEM.center}>{center}</div>
+            <div className={BEM.right}>{right}</div>
+        </div>
+    );
+}
+
+HeaderRow.defaultProps = {
+    left: undefined,
+    center: undefined,
+    right: undefined,
+};
+
+export default HeaderRow;

--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -2,11 +2,12 @@
 import React from 'react';
 import classNames from 'classnames';
 import type { ReactChildren } from 'react-flow-types';
+import './styles/BasicRow.scss';
 
 import prefixClass from './utils/prefixClass';
 import icBEM from './utils/icBEM';
 
-export const COMPONENT_NAME = prefixClass('header');
+export const COMPONENT_NAME = prefixClass('header-row');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 export const BEM = {
     root: ROOT_BEM,

--- a/src/List.js
+++ b/src/List.js
@@ -10,6 +10,12 @@ import icBEM from './utils/icBEM';
 
 export const COMPONENT_NAME = prefixClass('list');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    title: ROOT_BEM.element('title'),
+    body: ROOT_BEM.element('body'),
+    desc: ROOT_BEM.element('desc'),
+};
 
 const NORMAL = 'normal';
 const SETTING = 'setting';
@@ -18,6 +24,8 @@ const LIST_VARIANTS = [NORMAL, SETTING, BUTTON];
 
 export type Props = {
     variant: typeof NORMAL | typeof SETTING | typeof BUTTON,
+    title?: string,
+    desc?: ReactChildren,
 
     /* eslint-disable react/require-default-props */
     className?: string,
@@ -27,27 +35,40 @@ export type Props = {
 
 function List({
     variant,
+    title,
+    desc,
     // React props
     className,
     children,
     ...otherProps,
 }: Props) {
-    const bemClass = ROOT_BEM.modifier(variant);
+    const bemClass = BEM.root.modifier(variant);
     const rootClassName = classNames(bemClass.toString(), className);
 
+    const titleNode = <div className={BEM.title.toString()}>{title}</div>;
+    const descNode = <div className={BEM.desc.toString()}>{desc}</div>;
+
     return (
-        <ul className={rootClassName} {...otherProps}>
-            {children}
-        </ul>
+        <div className={rootClassName} {...otherProps}>
+            {title && titleNode}
+            <ul className={BEM.body.toString()}>
+                {children}
+            </ul>
+            {desc && descNode}
+        </div>
     );
 }
 
 List.propTypes = {
     variant: PropTypes.oneOf(Object.values(LIST_VARIANTS)),
+    title: PropTypes.string,
+    desc: PropTypes.node,
 };
 
 List.defaultProps = {
     variant: NORMAL,
+    title: undefined,
+    desc: undefined,
 };
 
 export default List;

--- a/src/List.js
+++ b/src/List.js
@@ -1,0 +1,53 @@
+// @flow
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import type { ReactChildren } from 'react-flow-types';
+import './styles/List.scss';
+
+import prefixClass from './utils/prefixClass';
+import icBEM from './utils/icBEM';
+
+export const COMPONENT_NAME = prefixClass('list');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+
+const NORMAL = 'normal';
+const SETTING = 'setting';
+const BUTTON = 'button';
+const LIST_VARIANTS = [NORMAL, SETTING, BUTTON];
+
+export type Props = {
+    variant: typeof NORMAL | typeof SETTING | typeof BUTTON,
+
+    /* eslint-disable react/require-default-props */
+    className?: string,
+    children?: ReactChildren,
+    /* eslint-enable react/require-default-props */
+};
+
+function List({
+    variant,
+    // React props
+    className,
+    children,
+    ...otherProps,
+}: Props) {
+    const bemClass = ROOT_BEM.modifier(variant);
+    const rootClassName = classNames(bemClass.toString(), className);
+
+    return (
+        <ul className={rootClassName} {...otherProps}>
+            {children}
+        </ul>
+    );
+}
+
+List.propTypes = {
+    variant: PropTypes.oneOf(Object.values(LIST_VARIANTS)),
+};
+
+List.defaultProps = {
+    variant: NORMAL,
+};
+
+export default List;

--- a/src/ListRow.js
+++ b/src/ListRow.js
@@ -1,0 +1,58 @@
+// @flow
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import type { ReactChildren } from 'react-flow-types';
+import './styles/ListRow.scss';
+
+import prefixClass from './utils/prefixClass';
+import icBEM from './utils/icBEM';
+
+export const COMPONENT_NAME = prefixClass('list-row');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    body: ROOT_BEM.element('body'),
+};
+
+export type Props = {
+    nestedList?: ReactChildren,
+    /* eslint-disable react/require-default-props */
+    className?: string,
+    children?: ReactChildren,
+    /* eslint-enable react/require-default-props */
+};
+
+class ListRow extends PureComponent<Props, Props, any> {
+    static propTypes = {
+        nestedList: PropTypes.node,
+    };
+
+    static defaultProps = {
+        nestedList: undefined,
+    };
+
+    render() {
+        const {
+            nestedList,
+            // React props
+            className,
+            children,
+            ...wrapperProps,
+        } = this.props;
+
+        const bemClass = BEM.root;
+        const rootClassName = classNames(bemClass.toString(), className);
+
+        return (
+            <li className={rootClassName} {...wrapperProps}>
+                <div className={BEM.body.toString()}>
+                    {children}
+                </div>
+                {nestedList}
+            </li>
+        );
+    }
+}
+
+export default ListRow;

--- a/src/TextEllipsis.js
+++ b/src/TextEllipsis.js
@@ -8,7 +8,7 @@ const ROOT_BEM = icBEM(COMPONENT_NAME);
 
 function TextEllipsis({ children }) {
     return (
-        <div className={ROOT_BEM}>
+        <div className={ROOT_BEM} title={children}>
             {children}
         </div>
     );

--- a/src/__tests__/HeaderRow.test.js
+++ b/src/__tests__/HeaderRow.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import HeaderRow from '../HeaderRow';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <HeaderRow left="Left" center="Title" right="Right" />;
+
+    ReactDOM.render(element, div);
+});

--- a/src/__tests__/List.test.js
+++ b/src/__tests__/List.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import List, { BEM as LIST_BEM } from '../List';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <List title="Title">Hello world</List>;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders in variants with "normal" as default', () => {
+    const wrapper = shallow(<List>Foo Bar</List>);
+    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('normal')}`)).toBeTruthy();
+
+    wrapper.setProps({ variant: 'setting' });
+    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('setting')}`)).toBeTruthy();
+
+    wrapper.setProps({ variant: 'button' });
+    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('button')}`)).toBeTruthy();
+});
+
+it('renders children inside a <ul>', () => {
+    const wrapper = shallow(<List>Foo Bar</List>);
+
+    expect(wrapper.find('ul')).toHaveLength(1);
+    expect(wrapper.find('ul').text()).toBe('Foo Bar');
+});
+
+it('renders title in <div> when specified', () => {
+    const wrapper = shallow(<List>Foo</List>);
+    expect(wrapper.find(`.${LIST_BEM.title}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ title: 'Bar' });
+    expect(wrapper.find(`.${LIST_BEM.title}`)).toHaveLength(1);
+    expect(wrapper.find(`.${LIST_BEM.title}`).text()).toBe('Bar');
+});
+
+it('renders desc in <div> when specified', () => {
+    const wrapper = shallow(<List>Foo</List>);
+    expect(wrapper.find(`.${LIST_BEM.desc}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ desc: <span data-test="foo" /> });
+    expect(wrapper.find(`.${LIST_BEM.desc}`)).toHaveLength(1);
+    expect(wrapper.find(`.${LIST_BEM.desc}`).find('[data-test="foo"]')).toHaveLength(1);
+});

--- a/src/__tests__/ListRow.test.js
+++ b/src/__tests__/ListRow.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import ListRow, { BEM as ROW_BEM } from '../ListRow';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <ListRow>Hello world</ListRow>;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders as a <li> element', () => {
+    const wrapper = shallow(<ListRow>Foo</ListRow>);
+
+    expect(wrapper.type()).toBe('li');
+    expect(wrapper.hasClass(`${ROW_BEM.root}`));
+});
+
+it('renders children inside a body wrapper', () => {
+    const wrapper = shallow(<ListRow>Foo</ListRow>);
+
+    expect(wrapper.find(`.${ROW_BEM.body}`)).toHaveLength(1);
+    expect(wrapper.find(`.${ROW_BEM.body}`).text()).toBe('Foo');
+});
+
+it('renders nested item inside <li> but outside of body wrapper', () => {
+    const wrapper = shallow(
+        <ListRow nestedList={<span data-test="bar" />}>
+            Foo
+        </ListRow>
+    );
+
+    expect(wrapper.find('span[data-test]')).toHaveLength(1);
+    expect(wrapper.find(`.${ROW_BEM.body}`).find('span[data-test]').exists()).toBeFalsy();
+});

--- a/src/__tests__/SearchInput.test.js
+++ b/src/__tests__/SearchInput.test.js
@@ -52,7 +52,7 @@ describe('Pure <SearchInput>', () => {
     });
 
     it('clears input value and calls onSearch() on reset button click', () => {
-        const handleSearch = jest.fn();
+        const handleSearch = jest.fn(() => PureSearchInput.defaultProps.onSearch());
         const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
         const inputWrapper = wrapper.find('input');
 
@@ -70,6 +70,12 @@ describe('Pure <SearchInput>', () => {
         const inputWrapper = wrapper.find('input');
 
         inputWrapper.simulate('change', { target: { value: 'foo' } });
+
+        // Other keys should not trigger onSearch()
+        inputWrapper.simulate('keyup', { key: 'Escape' });
+        expect(handleSearch).not.toHaveBeenCalled();
+
+        // Only Enter key should trigger
         inputWrapper.simulate('keyup', { key: 'Enter' });
         expect(handleSearch).toHaveBeenLastCalledWith('foo');
 

--- a/src/__tests__/Text.test.js
+++ b/src/__tests__/Text.test.js
@@ -77,6 +77,12 @@ describe('Pure <Text>', () => {
         expect(rowWrapper.prop('statusIcon')).toEqual(icon);
     });
 
+    it('does not render <BasicRow> if basicRow is overriden with null', () => {
+        const wrapper = shallow(<PureText basicRow={null} />);
+
+        expect(wrapper.find(BasicRow).exists()).toBeFalsy();
+    });
+
     it('renders aside text', () => {
         const wrapper = shallow(<PureText basic="Basic" aside="Aside" />);
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,8 @@ import SearchInput from './SearchInput';
 // Containers
 import InfiniteScroll from './InfiniteScroll';
 import HeaderRow from './HeaderRow';
+import List from './List';
+import ListRow from './ListRow';
 
 export {
     BasicRow,
@@ -60,4 +62,6 @@ export {
 
     InfiniteScroll,
     HeaderRow,
+    List,
+    ListRow,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import SearchInput from './SearchInput';
 
 // Containers
 import InfiniteScroll from './InfiniteScroll';
+import HeaderRow from './HeaderRow';
 
 export {
     BasicRow,
@@ -58,4 +59,5 @@ export {
     SearchInput,
 
     InfiniteScroll,
+    HeaderRow,
 };

--- a/src/mixins/__tests__/anchored.test.js
+++ b/src/mixins/__tests__/anchored.test.js
@@ -206,12 +206,13 @@ it('can take an HTMLElement as anchor', () => {
     mount(<Anchor top={10} left={10} />, { attachTo: anchorRoot });
     const anchorNode = document.getElementById('anchor');
 
-    const boxWrapper = mount(
+    const wrapper = mount(
         <AnchoredBoxTop anchor={anchorNode} />,
         { attachTo: boxRoot }
-    ).find(Box);
+    );
 
-    expect(boxWrapper.exists()).toBeTruthy();
+    expect(wrapper.find(Box).exists()).toBeTruthy();
+    expect(wrapper.instance().getAnchorDOMNode()).toBe(anchorNode);
 });
 
 it('re-adjusts position when assigned with another anchor', () => {
@@ -223,6 +224,11 @@ it('re-adjusts position when assigned with another anchor', () => {
 
     expect(wrapper.find(Box).prop('placement')).toBe(ANCHORED_PLACEMENT.BOTTOM);
 
+    // Should not re-adjust if anchor isn't changed
+    wrapper.setProps({ foo: true });
+    expect(wrapper.find(Box).prop('placement')).toBe(ANCHORED_PLACEMENT.BOTTOM);
+
+    // Should re-adjust since anchor changes
     anchorWrapper = mount(<Anchor top={200} left={10} />, { attachTo: anchorRoot });
     wrapper.setProps({ anchor: anchorWrapper.instance() });
 

--- a/src/mixins/__tests__/rowComp.test.js
+++ b/src/mixins/__tests__/rowComp.test.js
@@ -48,6 +48,15 @@ it('renders <Icon> and <Text> into wrapped component', () => {
     expect(fooWrapper.find(Text).prop('basic')).toBe('Basic');
 });
 
+it('takes a React Element as icon', () => {
+    const icon = <span data-foo="bar" />;
+    const wrapper = shallow(<RowCompFoo icon={icon} basic="Basic" />);
+    const fooWrapper = wrapper.find(Foo).shallow();
+
+    expect(fooWrapper.find(Icon).exists()).toBeFalsy();
+    expect(fooWrapper.find('[data-foo]')).toHaveLength(1);
+});
+
 it('renders <Text> with adjusted alignment', () => {
     const leftWrapper = shallow(<RowCompFoo align="left" basic="Basic" />);
     const centerWrapper = shallow(<RowCompFoo align="center" basic="Basic" />);

--- a/src/mixins/__tests__/withStatus.test.js
+++ b/src/mixins/__tests__/withStatus.test.js
@@ -27,6 +27,7 @@ class Bar extends PureComponent {
 
 const FooWithStatus = withStatus()(Foo);
 const FooWithStatusOptions = withStatus({ autohide: false })(Foo);
+const FooWithRawStatus = withStatus({ withRawStatus: true })(Foo);
 const BarWithRef = withStatus({ withRef: true })(Bar);
 
 it('renders without crashing', () => {
@@ -87,4 +88,13 @@ it('can hold ref to the rendered component, and can be retrieved', () => {
 
     expect(ref).not.toBeNull();
     expect(ref).toBeInstanceOf(Bar);
+});
+
+it('can optionally pass down raw status string from context to component', () => {
+    const wrapper = shallow(
+        <FooWithRawStatus />,
+        { context: { status: 'loading' } },
+    );
+
+    expect(wrapper.find(Foo).prop('status')).toBe('loading');
 });

--- a/src/styles/BasicRow.scss
+++ b/src/styles/BasicRow.scss
@@ -1,0 +1,26 @@
+@import "./mixins";
+$component: #{$prefix}-header-row;
+
+.#{$component} {
+    min-height: rem($row-base-height);
+    display: flex;
+
+    &__left,
+    &__right {
+        // Yield the most space for center block with a small flex-basis.
+        // But it grows at the same rate as the center block, as soon as the space is plenty.
+        flex: 1 3 2rem;
+        display: flex;
+    }
+
+    &__right {
+        justify-content: flex-end;
+    }
+
+    &__center {
+        flex: 1 1 auto;
+        display: flex;
+        overflow: hidden;
+    }
+}
+

--- a/src/styles/Icon.scss
+++ b/src/styles/Icon.scss
@@ -87,6 +87,10 @@
 // Name icon mapping
 // -------------------------------------
 
+.#{$prefix}-icon-row-padding {
+    width: rem($list-row-right-padding-small);
+}
+
 /* Direct copy from fontello */
 /* stylelint-disable rule-empty-line-before */
 

--- a/src/styles/List.scss
+++ b/src/styles/List.scss
@@ -2,14 +2,56 @@
 $component: #{$prefix}-list;
 
 .#{$component} {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    padding: rem($list-vertical-margin) 0;
 
-    // Variants
+    // --------------------
+    //  Elements
+    // --------------------
+    &__body {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    &__title,
+    &__desc {
+        font-size: rem($aside-text-font-size);
+        line-height: rem($aside-text-line-height);
+    }
+
+    &__title {
+        padding: rem(12px) 0 rem(4px);
+    }
+
+    &__desc {
+        padding-top: rem(8px);
+        margin-right: rem($list-row-left-padding);
+    }
+
+    // --------------------
+    //  Variants
+    // --------------------
+    &--normal {
+        .#{$component}__title {
+            border-bottom: 1px solid $c-divider-header;
+        }
+
+        .#{$component}__title,
+        .#{$component}__desc {
+            margin-left: rem($list-row-left-padding);
+        }
+    }
+
     &--setting {
-        background-color: white;
-        border: 1px solid $c-divider-row;
-        border-radius: rem($list-border-radius);
+        .#{$component}__body {
+            background-color: white;
+            border: 1px solid $c-divider-row;
+            border-radius: rem($list-border-radius);
+        }
+
+        .#{$component}__title,
+        .#{$component}__desc {
+            margin-left: rem($list-border-radius);
+        }
     }
 }

--- a/src/styles/List.scss
+++ b/src/styles/List.scss
@@ -1,0 +1,15 @@
+@import "./mixins";
+$component: #{$prefix}-list;
+
+.#{$component} {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    // Variants
+    &--setting {
+        background-color: white;
+        border: 1px solid $c-divider-row;
+        border-radius: rem($list-border-radius);
+    }
+}

--- a/src/styles/ListRow.scss
+++ b/src/styles/ListRow.scss
@@ -1,0 +1,18 @@
+@import "./mixins";
+$component: #{$prefix}-list-row;
+
+.#{$component} {
+    padding-left: $list-row-left-padding;
+
+    // Elements
+    &__body {
+        min-height: $row-base-height;
+        display: flex;
+        align-items: flex-start;
+        border-bottom: 1px solid $c-divider-row;
+
+        li:last-of-type > & {
+            border-bottom: none;
+        }
+    }
+}

--- a/src/styles/ListRow.scss
+++ b/src/styles/ListRow.scss
@@ -11,7 +11,8 @@ $component: #{$prefix}-list-row;
         align-items: flex-start;
         border-bottom: 1px solid $c-divider-row;
 
-        li:last-of-type > & {
+        // Styles inside List
+        .#{$prefix}-list--setting li:last-of-type > & {
             border-bottom: none;
         }
     }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -48,6 +48,8 @@ $search-input-border-radius: 6px;
 $search-input-padding: 8px;
 
 $list-border-radius: 8px;
+$list-vertical-margin: 8px;
+
 $list-row-left-padding: 16px;
 $list-row-right-padding-small: 8px;
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -47,6 +47,10 @@ $search-input-border-color: $c-gray;
 $search-input-border-radius: 6px;
 $search-input-padding: 8px;
 
+$list-border-radius: 8px;
+$list-row-left-padding: 16px;
+$list-row-right-padding-small: 8px;
+
 // -------------------------------------
 // Timing Functions
 //

--- a/src/utils/__tests__/getComponentName.test.js
+++ b/src/utils/__tests__/getComponentName.test.js
@@ -31,6 +31,10 @@ it('reads name from components with custom name', () => {
     expect(getComponentName(FooRev)).toBe('Rev(Foo)');
 });
 
+it('uses fallback name for anonymous components', () => {
+    expect(getComponentName(() => <div />)).toBe('Component');
+});
+
 it('throws if no Component passed in', () => {
     expect(() => getComponentName()).toThrow();
 });

--- a/src/utils/__tests__/icBEM.test.js
+++ b/src/utils/__tests__/icBEM.test.js
@@ -86,6 +86,12 @@ describe('icBEM() helper', () => {
         expect(bem.toString()).toBe('ic-comp');
     });
 
+    it('reports the value of a BEM object as toString() result', () => {
+        const bem = icBEM('ic-comp');
+
+        expect(bem.valueOf()).toBe(bem.toString());
+    });
+
     it('throws when init without a non-empty String', () => {
         expect(() => icBEM()).toThrow();
         expect(() => icBEM('')).toThrow();

--- a/src/utils/icBEM.js
+++ b/src/utils/icBEM.js
@@ -33,7 +33,7 @@ export class BEMFactory {
     _modifiers: string[];
     _nonBemClasses: string[];
 
-    constructor({ block, element, modifiers = [], nonBemClasses = [] }: FactoryParams = {}) {
+    constructor({ block, element, modifiers = [], nonBemClasses = [] }: FactoryParams) {
         if (!block) {
             throw new Error('block is required.');
         }
@@ -142,7 +142,7 @@ function icBEM(blockName: string): BEMFactory {
     if (typeof blockName === 'string') {
         return new BEMFactory({ block: blockName });
     }
-    throw new Error('blockName should be a non-valid String.');
+    throw new Error('blockName should be a non-empty String.');
 }
 
 export default icBEM;


### PR DESCRIPTION
Add basic containers of `<HeaderRow>`, `<List>` (as a section) and `<ListRow>`

### Implement
1. Add `<HeaderRow>` which is split into 3 areas: `left`, `center`, and `right`.
2. Add `<List>` as the list section, which contains `<ListRow>` as well as a title and a description block.
3. Add simple `<ListRow>` containing a Flexbox body for row components.

### Demo
![2017-07-07 10 54 34](https://user-images.githubusercontent.com/365035/27941409-0afbaeec-6303-11e7-8fa9-82f4a6f402e1.png)
![2017-07-07 10 54 24](https://user-images.githubusercontent.com/365035/27941412-0d448d7c-6303-11e7-9810-a0f76bbee945.png)
![2017-07-07 10 57 25](https://user-images.githubusercontent.com/365035/27941415-14417df6-6303-11e7-972f-7985a76bc6ed.png)
