### PR TITLE
<Popup> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `<List>` section that supports a title and a description block.
 - Add simple `<ListRow>` with a Flexbox body for row components.
 - Add `<ColumnView>` which holds a `header` above and a `footer` below its main body area.
+- Add z-index `z()` sass helper. (Migrate from iC-framework)
+- Add `escapable()` mixin, listening `Esc` key to trigger `onEscape` prop.
+- Add page overlay component, `<Overlay>`.
+- Add `<Popup>` component.
 
 ### Changed
-- Improved tests coverage
+- Improved tests coverage. (especially mixins & utils)
 - `<Button>` active/hover colors are slightly darken.
-
 
 ## [0.13.1]
 ### Added

--- a/examples/Popup/BasicPopup.js
+++ b/examples/Popup/BasicPopup.js
@@ -1,0 +1,87 @@
+import React, { PureComponent } from 'react';
+
+import Popup from 'src/Popup';
+import Button from 'src/Button';
+import Icon from 'src/Icon';
+
+class BasicPopupExample extends PureComponent {
+    state ={
+        errorPopup: false,
+        successPopup: false,
+    };
+
+    /**
+     * Handle popup open or close
+     *
+     * @param {String}  popup
+     * @param {Boolean} isOpen
+     */
+    handleTogglePopup = (popup, isOpen) => () => {
+        this.setState({
+            [popup]: isOpen
+        });
+    }
+
+    renderErrorPopup() {
+        const { errorPopup } = this.state;
+
+        if (!errorPopup) {
+            return null;
+        }
+
+        return (
+            <Popup
+                message="ERROR"
+                icon={<Icon large type="error" color="red" />}
+                buttons={[
+                    <Button
+                        key="dismiss-btn"
+                        color="red"
+                        basic="Dismiss"
+                        onClick={this.handleTogglePopup('errorPopup', false)} />
+                ]} />
+        );
+    }
+
+    renderSuccessPopup() {
+        const { successPopup } = this.state;
+
+        if (!successPopup) {
+            return null;
+        }
+
+        return (
+            <Popup
+                message="Success"
+                icon={<Icon large type="success" color="blue" />}
+                buttons={[
+                    <Button
+                        key="dismiss-btn"
+                        color="blue"
+                        basic="Dismiss"
+                        onClick={this.handleTogglePopup('successPopup', false)} />
+                ]} />
+        );
+    }
+
+    render() {
+        return (
+            <div>
+                <Button
+                    color="red"
+                    basic="Open error popup"
+                    onClick={this.handleTogglePopup('errorPopup', true)} />
+
+                <Button
+                    color="blue"
+                    basic="Open success popup"
+                    onClick={this.handleTogglePopup('successPopup', true)} />
+
+                {this.renderErrorPopup()}
+                {this.renderSuccessPopup()}
+            </div>
+        );
+    }
+}
+
+export default BasicPopupExample;

--- a/examples/Popup/EscapablePopup.js
+++ b/examples/Popup/EscapablePopup.js
@@ -1,0 +1,53 @@
+import React, { PureComponent } from 'react';
+
+import Popup from 'src/Popup';
+import Button from 'src/Button';
+
+class EscapablePopupExample extends PureComponent {
+    state ={
+        isPopupOpen: false
+    };
+
+    handlePopupOpen = () => {
+        this.setState({ isPopupOpen: true });
+    }
+
+    handlePopupClose = () => {
+        this.setState({ isPopupOpen: false });
+    }
+
+    renderPopup() {
+        const { isPopupOpen } = this.state;
+
+        if (!isPopupOpen) {
+            return null;
+        }
+
+        return (
+            <Popup
+                icon="delete"
+                message="Try 'Esc' key"
+                buttons={[
+                    <Button
+                        key="dismiss-btn"
+                        basic="Dismiss"
+                        onClick={this.handlePopupClose} />
+                ]}
+                onEscape={this.handlePopupClose} />
+        );
+    }
+
+    render() {
+        return (
+            <div>
+                <Button
+                    basic="Open popup"
+                    onClick={this.handlePopupOpen} />
+
+                {this.renderPopup()}
+            </div>
+        );
+    }
+}
+
+export default EscapablePopupExample;

--- a/examples/Popup/index.js
+++ b/examples/Popup/index.js
@@ -5,11 +5,17 @@ import { storiesOf } from '@storybook/react';
 import Popup, { EscapablePopup, PurePopup } from 'src/Popup';
 
 import BasicPopupExample from './BasicPopup';
+import EscapablePopupExample from './EscapablePopup';
 
 storiesOf('Popup', module)
     .addWithInfo(
         'basic usage',
         () => <BasicPopupExample />
+    )
+    .addWithInfo(
+        'escapable popup',
+        'Key `Esc` to close.',
+        () => <EscapablePopupExample />
     )
     // Props table
     .addPropsTable(() => <Popup />, [EscapablePopup, PurePopup]);

--- a/examples/Popup/index.js
+++ b/examples/Popup/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+// For props table
+import Popup, { EscapablePopup, PurePopup } from 'src/Popup';
+
+import BasicPopupExample from './BasicPopup';
+
+storiesOf('Popup', module)
+    .addWithInfo(
+        'basic usage',
+        () => <BasicPopupExample />
+    )
+    // Props table
+    .addPropsTable(() => <Popup />, [EscapablePopup, PurePopup]);

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,0 +1,34 @@
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+import icBEM from './utils/icBEM';
+import prefixClass from './utils/prefixClass';
+
+import './styles/Overlay.scss';
+
+export const COMPONENT_NAME = prefixClass('overlay');
+export const HAS_OVERLAY_CLASS = prefixClass('has-overlay');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+
+class Overlay extends PureComponent {
+    componentDidMount() {
+        document.body.classList.add(HAS_OVERLAY_CLASS);
+    }
+
+    componentWillUnmount() {
+        document.body.classList.remove(HAS_OVERLAY_CLASS);
+    }
+
+    render() {
+        const { className, ...overlayProps } = this.props;
+        const rootClassName = classNames(className, `${ROOT_BEM}`);
+
+        return (
+            <div
+                className={rootClassName}
+                {...overlayProps} />
+        );
+    }
+}
+
+export default Overlay;

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -43,10 +43,6 @@ export type Props = {
  * @return {Element}
  */
 function renderPopupIcon(icon) {
-    if (!icon) {
-        return null;
-    }
-
     if (typeof icon === 'string') {
         return (
             <Icon
@@ -90,7 +86,7 @@ function renderPopupButtons(buttons) {
 
     const popupButtons = buttons.map((button) => {
         // Render as expanded button
-        if (button && isValidElement(button)) {
+        if (isValidElement(button)) {
             const buttonBemClass = BEM.button.toString();
 
             return cloneElement(button, {

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -2,7 +2,7 @@
 import React, { isValidElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import type { AnyReactElement, ReactChildren } from 'react-flow-types';
+import type { ReactChildren } from 'react-flow-types';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
@@ -28,7 +28,7 @@ export const BEM = {
 export type Props = {
     icon?: string | ReactChildren,
     message?: ReactChildren,
-    buttons?: AnyReactElement[],
+    buttons?: React$Element<*>[],
 
     /* eslint-disable react/require-default-props */
     className?: string,

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import icBEM from './utils/icBEM';
+import prefixClass from './utils/prefixClass';
+
+import Icon from './Icon';
+import Overlay from './Overlay';
+import escapable from './mixins/escapable';
+import renderToLayer from './mixins/renderToLayer';
+
+import './styles/Popup.scss';
+
+export const COMPONENT_NAME = prefixClass('popup');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+const BEM = {
+    root: ROOT_BEM,
+    container: ROOT_BEM.element('container'),
+    body: ROOT_BEM.element('body'),
+    message: ROOT_BEM.element('message')
+};
+
+/**
+ * Render popup's icon
+ *
+ * @param  {String|Element} icon
+ * @return {Element}
+ */
+function renderPopupIcon(icon) {
+    if (!icon) {
+        return null;
+    }
+
+    if (typeof icon === 'string') {
+        return <Icon large type={icon} />;
+    }
+
+    return icon;
+}
+
+/**
+ * Render popup's message
+ *
+ * @param  {Element|String} message
+ * @return {Element}
+ */
+function renderPopupMessage(message) {
+    if (!message) {
+        return null;
+    }
+
+    return (
+        <div className={BEM.message}>
+            {message}
+        </div>
+    );
+}
+
+function Popup({
+    icon,
+    message,
+    // React props
+    className,
+    children,
+    ...popupProps
+}) {
+    const rootClassName = classNames(className, `${BEM.root}`);
+
+    return (
+        <div className={rootClassName} {...popupProps}>
+            <Overlay />
+
+            <div className={BEM.container}>
+                <div className={BEM.body}>
+                    {renderPopupIcon(icon)}
+                    {renderPopupMessage(message)}
+                </div>
+
+                {children}
+            </div>
+        </div>
+    );
+}
+
+Popup.propTypes = {
+    icon: PropTypes.node,
+    message: PropTypes.node
+};
+
+Popup.defaultProps = {
+    icon: null,
+    message: null
+};
+
+// export for tests
+export { Popup as PurePopup };
+export const EscapablePopup = escapable(Popup);
+
+export default renderToLayer(EscapablePopup);

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -35,7 +35,12 @@ function renderPopupIcon(icon) {
     }
 
     if (typeof icon === 'string') {
-        return <Icon large type={icon} />;
+        return (
+            <Icon
+                large
+                color="blue"
+                type={icon} />
+        );
     }
 
     return icon;

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -1,6 +1,8 @@
+// @flow
 import React, { isValidElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import type { AnyReactElement, ReactChildren } from 'react-flow-types';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
@@ -14,13 +16,24 @@ import './styles/Popup.scss';
 
 export const COMPONENT_NAME = prefixClass('popup');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
-const BEM = {
+export const BEM = {
     root: ROOT_BEM,
     container: ROOT_BEM.element('container'),
     body: ROOT_BEM.element('body'),
     message: ROOT_BEM.element('message'),
     button: ROOT_BEM.element('button'),
     buttonsGroup: ROOT_BEM.element('buttons-group')
+};
+
+export type Props = {
+    icon?: string | ReactChildren,
+    message?: ReactChildren,
+    buttons?: AnyReactElement[],
+
+    /* eslint-disable react/require-default-props */
+    className?: string,
+    children?: ReactChildren,
+    /* eslint-enable react/require-default-props */
 };
 
 /**
@@ -58,7 +71,7 @@ function renderPopupMessage(message) {
     }
 
     return (
-        <div className={BEM.message}>
+        <div className={BEM.message.toString()}>
             {message}
         </div>
     );
@@ -77,9 +90,11 @@ function renderPopupButtons(buttons) {
 
     const popupButtons = buttons.map((button) => {
         // Render as expanded button
-        if (isValidElement(button)) {
+        if (button && isValidElement(button)) {
+            const buttonBemClass = BEM.button.toString();
+
             return cloneElement(button, {
-                className: `${BEM.button}`,
+                className: buttonBemClass,
                 align: 'center',
                 minified: false
             });
@@ -89,7 +104,7 @@ function renderPopupButtons(buttons) {
     });
 
     return (
-        <div className={BEM.buttonsGroup}>
+        <div className={BEM.buttonsGroup.toString()}>
             {popupButtons}
         </div>
     );
@@ -103,15 +118,15 @@ function Popup({
     className,
     children,
     ...popupProps
-}) {
-    const rootClassName = classNames(className, `${BEM.root}`);
+}: Props) {
+    const rootClassName = classNames(BEM.root.toString(), className);
 
     return (
         <div className={rootClassName} {...popupProps}>
             <Overlay />
 
-            <div className={BEM.container}>
-                <div className={BEM.body}>
+            <div className={BEM.container.toString()}>
+                <div className={BEM.body.toString()}>
                     {renderPopupIcon(icon)}
                     {renderPopupMessage(message)}
                 </div>

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -18,7 +18,9 @@ const BEM = {
     root: ROOT_BEM,
     container: ROOT_BEM.element('container'),
     body: ROOT_BEM.element('body'),
-    message: ROOT_BEM.element('message')
+    message: ROOT_BEM.element('message'),
+    button: ROOT_BEM.element('button'),
+    buttonsGroup: ROOT_BEM.element('buttons-group')
 };
 
 /**
@@ -57,9 +59,41 @@ function renderPopupMessage(message) {
     );
 }
 
+/**
+ * Render popup's buttons
+ *
+ * @param  {Array} buttons
+ * @return {Array}
+ */
+function renderPopupButtons(buttons) {
+    if (!buttons || buttons.length === 0) {
+        return null;
+    }
+
+    const popupButtons = buttons.map((button) => {
+        // Render as expanded button
+        if (isValidElement(button)) {
+            return cloneElement(button, {
+                className: `${BEM.button}`,
+                align: 'center',
+                minified: false
+            });
+        }
+
+        return button;
+    });
+
+    return (
+        <div className={BEM.buttonsGroup}>
+            {popupButtons}
+        </div>
+    );
+}
+
 function Popup({
     icon,
     message,
+    buttons,
     // React props
     className,
     children,
@@ -77,6 +111,7 @@ function Popup({
                     {renderPopupMessage(message)}
                 </div>
 
+                {renderPopupButtons(buttons)}
                 {children}
             </div>
         </div>
@@ -85,12 +120,14 @@ function Popup({
 
 Popup.propTypes = {
     icon: PropTypes.node,
-    message: PropTypes.node
+    message: PropTypes.node,
+    buttons: PropTypes.arrayOf(PropTypes.element)
 };
 
 Popup.defaultProps = {
     icon: null,
-    message: null
+    message: null,
+    buttons: []
 };
 
 // export for tests

--- a/src/__tests__/Overlay.test.js
+++ b/src/__tests__/Overlay.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
+
+import Overlay from '../Overlay';
+
+const bodyClassList = document.body.classList;
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <Overlay />;
+
+    ReactDOM.render(element, div);
+});
+
+it('should add "has-overlay" className on body when mounted', () => {
+    mount(<Overlay />);
+
+    expect(bodyClassList.contains('gyp-has-overlay')).toBeTruthy();
+});
+
+it('should remove "has-overlay" className on body before unmount', () => {
+    const wrapper = mount(<Overlay />);
+
+    wrapper.unmount();
+    expect(bodyClassList.contains('gyp-has-overlay')).toBeFalsy();
+});

--- a/src/__tests__/Popup.test.js
+++ b/src/__tests__/Popup.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, ReactWrapper } from 'enzyme';
+
+import Popup, { BEM as POPUP_BEM } from '../Popup';
+import Overlay from '../Overlay';
+import Icon from '../Icon';
+import Button from '../Button';
+
+it('should render without crashing', () => {
+    const div = document.createElement('div');
+    const element = <Popup />;
+
+    ReactDOM.render(element, div);
+});
+
+it('should contain <Overlay>', () => {
+    const wrapper = mount(<Popup>Bar</Popup>);
+    // <Popup> was wrapped by renderToLayer() and rendered outside React root
+    const popupWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
+
+    expect(popupWrapper.find(Overlay).exists()).toBeTruthy();
+});
+
+it('should render message in <div> when specified', () => {
+    const fooText = 'Foo';
+    const wrapper = mount(<Popup>Bar</Popup>);
+    const popupWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
+
+    expect(popupWrapper.find(`.${POPUP_BEM.message}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ message: fooText });
+    expect(popupWrapper.find(`.${POPUP_BEM.message}`).exists()).toBeTruthy();
+    expect(popupWrapper.find(`.${POPUP_BEM.message}`).text()).toBe(fooText);
+});
+
+it('should render icon with icon\'s type string', () => {
+    const wrapper = mount(<Popup icon="error" />);
+    const popupWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
+
+    expect(popupWrapper.find(Icon).exists()).toBeTruthy();
+    expect(popupWrapper.find(Icon).prop('type')).toBe('error');
+
+    // Blue color & large size as default
+    expect(popupWrapper.find(Icon).prop('large')).toBeTruthy();
+    expect(popupWrapper.find(Icon).prop('color')).toBe('blue');
+});
+
+it('should render icon with custom <Icon>', () => {
+    const successIcon = <Icon type="success" />;
+    const wrapper = mount(<Popup icon={successIcon} />);
+    const popupWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
+
+    expect(popupWrapper.find(Icon).exists()).toBeTruthy();
+    expect(popupWrapper.find(Icon).prop('type')).toBe('success');
+});
+
+it('should render button(s) in buttons-group section when specified', () => {
+    const dismissBtn = <Button key="dismiss-btn" basic="Dismiss" />;
+    const wrapper = mount(<Popup />);
+    const popupWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
+
+    expect(popupWrapper.find(`.${POPUP_BEM.buttonsGroup}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ buttons: [dismissBtn, null] });
+    expect(popupWrapper.find(`.${POPUP_BEM.buttonsGroup}`).exists()).toBeTruthy();
+
+    const popupBtn = popupWrapper.find(`.${POPUP_BEM.buttonsGroup}`).find(Button);
+    expect(popupBtn.prop('basic')).toBe('Dismiss');
+
+    // Center align and non-minified as default
+    expect(popupBtn.prop('align')).toBe('center');
+    expect(popupBtn.prop('minified')).toBeFalsy();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import EditableText from './EditableText';
 import Tooltip from './Tooltip';
 import AnchoredTooltip from './AnchoredTooltip';
 import SwitchIcon from './SwitchIcon';
+import Overlay from './Overlay';
 
 // Layout helpers
 import FlexCell from './FlexCell';
@@ -46,6 +47,7 @@ export {
     Tooltip,
     AnchoredTooltip,
     SwitchIcon,
+    Overlay,
 
     FlexCell,
     IconLayout,

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import Tooltip from './Tooltip';
 import AnchoredTooltip from './AnchoredTooltip';
 import SwitchIcon from './SwitchIcon';
 import Overlay from './Overlay';
+import Popup from './Popup';
 
 // Layout helpers
 import FlexCell from './FlexCell';
@@ -48,6 +49,7 @@ export {
     AnchoredTooltip,
     SwitchIcon,
     Overlay,
+    Popup,
 
     FlexCell,
     IconLayout,

--- a/src/mixins/__tests__/escapable.test.js
+++ b/src/mixins/__tests__/escapable.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount, shallow } from 'enzyme';
+import keycode from 'keycode';
+
+import escapable from '../escapable';
+
+const Foo = () => (
+    <div>Foo</div>
+);
+
+const EscapableFoo = escapable(Foo);
+
+// --------------------
+//  Test cases
+// --------------------
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <EscapableFoo />;
+
+    ReactDOM.render(element, div);
+});
+
+it('should trigger onEscape when clicked Esc key', () => {
+    const onEscape = jest.fn();
+    mount(<EscapableFoo onEscape={onEscape} />);
+
+    // Dispatch Escape keyboard event
+    const escKeyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
+    document.dispatchEvent(escKeyEvent);
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+});

--- a/src/mixins/__tests__/escapable.test.js
+++ b/src/mixins/__tests__/escapable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import keycode from 'keycode';
 
 import escapable from '../escapable';
@@ -26,9 +26,24 @@ it('should trigger onEscape when clicked Esc key', () => {
     const onEscape = jest.fn();
     mount(<EscapableFoo onEscape={onEscape} />);
 
-    // Dispatch Escape keyboard event
+    // Dispatch 'Enter' keyboard event, nothing happened
+    const enterKeyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
+    document.dispatchEvent(enterKeyEvent);
+    expect(onEscape).toHaveBeenCalledTimes(0);
+
+    // Dispatch 'Esc' keyboard event
     const escKeyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
     document.dispatchEvent(escKeyEvent);
-
     expect(onEscape).toHaveBeenCalledTimes(1);
+});
+
+it('should listen keyup event when mounted', () => {
+    document.addEventListener = jest.fn();
+    document.removeEventListener = jest.fn();
+    const wrapper = mount(<EscapableFoo />);
+
+    expect(document.addEventListener).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+    expect(document.removeEventListener).toHaveBeenCalledTimes(1);
 });

--- a/src/mixins/escapable.js
+++ b/src/mixins/escapable.js
@@ -6,7 +6,7 @@ import getComponentName from '../utils/getComponentName';
 
 const createEscapeListener = callback => (event) => {
     if (event.keyCode === keycode('Escape')) {
-        if (typeof callback === 'function') callback(event);
+        callback(event);
     }
 };
 

--- a/src/mixins/escapable.js
+++ b/src/mixins/escapable.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import keycode from 'keycode';
+
+import getComponentName from '../utils/getComponentName';
+
+const createEscapeListener = callback => (event) => {
+    if (event.keyCode === keycode('Escape')) {
+        if (typeof callback === 'function') callback(event);
+    }
+};
+
+function escapable(WrappedComponent) {
+    const componentName = getComponentName(WrappedComponent);
+
+    return class extends Component {
+        static displayName = `escapable(${componentName})`;
+
+        static propTypes = {
+            onEscape: PropTypes.func
+        };
+
+        static defaultProps = {
+            onEscape: () => {}
+        };
+
+
+        componentDidMount() {
+            this.keyUpListener = createEscapeListener(this.props.onEscape);
+            document.addEventListener('keyup', this.keyUpListener);
+        }
+
+        componentWillUnmount() {
+            document.removeEventListener('keyup', this.keyUpListener);
+        }
+
+        render() {
+            // Stripe callback prop from <WrappedComponent>
+            // eslint-disable-next-line no-unused-vars
+            const { onEscape, ...otherProps } = this.props;
+            return <WrappedComponent {...otherProps} />;
+        }
+    };
+}
+
+export default escapable;

--- a/src/styles/Overlay.scss
+++ b/src/styles/Overlay.scss
@@ -1,0 +1,16 @@
+@import "./mixins";
+
+.#{$prefix}-overlay {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $c-overlay;
+    z-index: z("default");
+
+    // Active animation
+    opacity: 0;
+    animation: anim-fade-in .3s forwards;
+}

--- a/src/styles/Popup.scss
+++ b/src/styles/Popup.scss
@@ -50,3 +50,17 @@
         line-height: 1.3em;
     }
 }
+
+// -------------------------------------
+//   Popup Button
+// -------------------------------------
+
+// Buttons group
+.#{$prefix}-popup__buttons-group {
+    display: flex;
+}
+
+// Button
+.#{$prefix}-popup__button {
+    border-top: 1px solid $c-popup-button-border;
+}

--- a/src/styles/Popup.scss
+++ b/src/styles/Popup.scss
@@ -15,7 +15,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-
     text-align: center;
     z-index: z("popup");
 }

--- a/src/styles/Popup.scss
+++ b/src/styles/Popup.scss
@@ -5,15 +5,17 @@
 // -------------------------------------
 
 .#{$prefix}-popup {
-    @include remove-spacing(".#{$prefix}-popup__container");
-    @include inline-vertical(".#{$prefix}-popup__container");
-
-    display: block;
     position: fixed;
     top: 0;
-    bottom: 0;
     left: 0;
-    right: 0;
+    width: 100%;
+    height: 100%;
+
+    // Align center with flexbox
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     text-align: center;
     z-index: z("popup");
 }

--- a/src/styles/Popup.scss
+++ b/src/styles/Popup.scss
@@ -1,0 +1,52 @@
+@import "./mixins";
+
+// -------------------------------------
+//   Popup
+// -------------------------------------
+
+.#{$prefix}-popup {
+    @include remove-spacing(".#{$prefix}-popup__container");
+    @include inline-vertical(".#{$prefix}-popup__container");
+
+    display: block;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    z-index: z("popup");
+}
+
+// -------------------------------------
+//   Popup Elements
+// -------------------------------------
+
+.#{$prefix}-popup {
+    // Container
+    &__container {
+        width: 95%;
+        max-width: $popup-container-width;
+        background-color: $c-white;
+        border-radius: $popup-border-radius;
+        box-shadow: $poup-box-shadow;
+        position: relative;
+        overflow: hidden;
+        z-index: z("front");
+        transition: width .15s;
+
+        // Active animation
+        opacity: 0;
+        animation: anim-bounce-in .6s forwards;
+    }
+
+    // Body
+    &__body {
+        padding: 8px 16px 32px;
+    }
+
+    // Message
+    &__message {
+        line-height: 1.3em;
+    }
+}

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -67,3 +67,6 @@ $c-input-placeholder: $c-text-placeholder;
 
 // Overlay colors
 $c-overlay: hsba(0, 0, 0, 60);
+
+// Popup colors
+$c-popup-button-border: rgba(235, 230, 230, 1);

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -60,6 +60,10 @@ $c-switch-knob:   $c-white;
 $c-slider-track: hsba(0, 0, 0, 30);
 $c-slider-thumb-border: hsba(0, 0, 0, 20);
 
+// Input colors
 $c-input-text: $c-text-editable;
 $c-input-border: $c-text-editable;
 $c-input-placeholder: $c-text-placeholder;
+
+// Overlay colors
+$c-overlay: hsba(0, 0, 0, 60);

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -27,6 +27,41 @@
 }
 
 // -------------------------------------
+//   Remove inline spacing
+// -------------------------------------
+
+@mixin remove-spacing($_children, $_font-size: $basic-text-font-size) {
+    font-size: 0;
+
+    #{$_children} {
+        font-size: $_font-size;
+    }
+}
+
+// -------------------------------------
+//   inline Vertical
+// -------------------------------------
+
+@mixin inline-vertical($_children: "> *") {
+    user-select: none;
+
+    &:before {
+        content: "";
+        display: inline-block;
+        width: 0;
+        height: 100%;
+        vertical-align: middle;
+        pointer-events: none;
+    }
+
+    #{$_children} {
+        display: inline-block;
+        vertical-align: middle;
+        user-select: auto;
+    }
+}
+
+// -------------------------------------
 //   Remove button default appearance
 // -------------------------------------
 

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -27,41 +27,6 @@
 }
 
 // -------------------------------------
-//   Remove inline spacing
-// -------------------------------------
-
-@mixin remove-spacing($_children, $_font-size: $basic-text-font-size) {
-    font-size: 0;
-
-    #{$_children} {
-        font-size: $_font-size;
-    }
-}
-
-// -------------------------------------
-//   inline Vertical
-// -------------------------------------
-
-@mixin inline-vertical($_children: "> *") {
-    user-select: none;
-
-    &:before {
-        content: "";
-        display: inline-block;
-        width: 0;
-        height: 100%;
-        vertical-align: middle;
-        pointer-events: none;
-    }
-
-    #{$_children} {
-        display: inline-block;
-        vertical-align: middle;
-        user-select: auto;
-    }
-}
-
-// -------------------------------------
 //   Remove button default appearance
 // -------------------------------------
 

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,5 +1,9 @@
 @import "./variables";
 
+// -------------------------------------
+//   Relative size calculator
+// -------------------------------------
+
 @function relative($target-size, $base-size: $component-base-font-size, $unit: 1em) {
     @return ($target-size / $base-size * $unit);
 }
@@ -7,6 +11,10 @@
 @function rem($target-size) {
     @return relative($target-size, $root-font-size, 1rem);
 }
+
+// -------------------------------------
+//   Text overflow Ellipsis
+// -------------------------------------
 
 @mixin overflow-ellipsis($_width: null) {
     overflow: hidden;
@@ -18,6 +26,10 @@
     }
 }
 
+// -------------------------------------
+//   Remove button default appearance
+// -------------------------------------
+
 @mixin remove-button-appearance {
     color: inherit;
     background: transparent;
@@ -28,4 +40,35 @@
     text-align: inherit;
     appearance: none;
     user-select: none;
+}
+
+// -------------------------------------
+//   z-index helper
+// -------------------------------------
+
+@function map-has-nested-keys($map, $keys...) {
+    @each $key in $keys {
+        @if not map-has-key($map, $key) {
+            @return false;
+        }
+        $map: map-get($map, $key);
+    }
+
+    @return true;
+}
+
+@function map-deep-get($map, $keys...) {
+    @each $key in $keys {
+        $map: map-get($map, $key);
+    }
+
+    @return $map;
+}
+
+@function z($layers...) {
+    @if not map-has-nested-keys($z-layers, $layers...) {
+        @warn "No layer found for `#{inspect($layers...)}` in $z-layers map. Property omitted.";
+    }
+
+    @return map-deep-get($z-layers, $layers...);
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -57,6 +57,10 @@ $list-row-right-padding-small: 8px;
 
 $column-body-padding: 16px;
 
+$popup-container-width: 300px;
+$popup-border-radius: 8px;
+$poup-box-shadow: 0 2px 8px hsba(0, 0, 0, 40);
+
 // -------------------------------------
 // Timing Functions
 //

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -66,3 +66,19 @@ $column-body-padding: 16px;
 
 $ease-out-quad: cubic-bezier(.25, .46, .45, .94);
 $ease-out-cubic: cubic-bezier(.215, .61, .355, 1);
+
+// -------------------------------------
+//   z-index layers
+// -------------------------------------
+
+$z-layers: (
+    "popup":        1000,
+    "modal":        999,
+    "popover":      100,
+    "top":          99,
+    "front":        9,
+    "base":         1,
+    "default":      0,
+    "below":        -1,
+    "hidden":       -9999,
+);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,4 +8,9 @@ html {
 
 body {
     font-size: rem($component-base-font-size);
+
+    &.#{$prefix}-has-overlay {
+        // Prevent body scrolling
+        overflow: hidden !important;
+    }
 }

--- a/src/utils/__tests__/getComponentName.test.js
+++ b/src/utils/__tests__/getComponentName.test.js
@@ -36,5 +36,5 @@ it('uses fallback name for anonymous components', () => {
 });
 
 it('throws if no Component passed in', () => {
-    expect(() => getComponentName()).toThrow();
+    expect(() => getComponentName()).toThrowError(/Cannot read name/);
 });


### PR DESCRIPTION
## Purpose

Add `<Popup>` component.

## Implement
- Add `<Popup>` component and related examples.
- Add z-index sass mixin, which migrate from iC-framework.
- Add `escapable` HOC, which able to listening `Esc` key to trigger `onEscape` callback.
- Add page overlay `<Overlay>` component, formerly known as `<Backdrop>`.

## Screenshot
![popup](https://user-images.githubusercontent.com/5558360/27948179-632f23aa-632b-11e7-925b-7c2816a73bf7.gif)
