### PR TITLE
Enhance <EditableTextLabel>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
+### Changed
+- Fix `<EditableTextLabel>` not supporting custom icon.
+- `<EditableTextLabel>` now does not fire `onEditRequest` callback, leaving users to decide when to control its editing state.
+- `<EditableTextLabel>` now simulates double-touch and then triggers `onDblClick` callback.
+- When the `inEdit` prop isn't set on `<EditableTextLabel>`, it becomes an uncontrolled component and will auto enter edit mode on double clicks.
 
 ## [1.0.0]
 ### Added

--- a/examples/TextLabel/Editable.js
+++ b/examples/TextLabel/Editable.js
@@ -20,16 +20,16 @@ const cleanAction = decorateAction([
     }
 ]);
 
-class EditableExample extends PureComponent {
+class ControlledExample extends PureComponent {
     state = {
         isEditing: false,
         status: null,
         currentBasic: 'Kitchen Printer',
     };
 
-    handleEditRequest = (event) => {
+    handleDblClick = (event) => {
         this.setState({ isEditing: true });
-        action('editRequest')(event);
+        action('dblClick')(event);
     }
 
     handleEditEnd = (payload) => {
@@ -57,7 +57,7 @@ class EditableExample extends PureComponent {
                     basic={this.state.currentBasic}
                     aside="00:11:22:33"
                     tag="Online"
-                    onEditRequest={this.handleEditRequest}
+                    onDblClick={this.handleDblClick}
                     onEditEnd={this.handleEditEnd}
                     status={this.state.status} />
             </DebugBox>
@@ -68,16 +68,17 @@ class EditableExample extends PureComponent {
 function Editable() {
     return (
         <div>
+            <p>Uncontrolled (self-controlled) editable label:</p>
             <EditableTextLabel
                 icon="printer"
                 basic="Kitchen Printer"
                 aside="00:11:22:33"
                 tag="Online"
-                onEditRequest={action('editRequest')}
+                onDblClick={action('dblClick')}
                 onEditEnd={cleanAction('editEnd')} />
 
-            <p>Interactive example:</p>
-            <EditableExample />
+            <p>Controlled editable label:</p>
+            <ControlledExample />
         </div>
     );
 }

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -6,6 +6,7 @@ import keycode from 'keycode';
 import type { ReactChildren } from 'react-flow-types';
 
 import { getTextLayoutProps } from './mixins/rowComp';
+import wrapIfNotElement from './utils/wrapIfNotElement';
 
 import EditableText from './EditableText';
 import Icon from './Icon';
@@ -105,10 +106,12 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
         }
 
         const layoutProps = getTextLayoutProps(align, !!icon);
+        const labelIcon = icon && wrapIfNotElement(icon, { with: Icon, via: 'type' });
 
         return (
             <TextLabel {...labelProps}>
-                {icon && <Icon type={icon} />}
+                {labelIcon}
+
                 <EditableText
                     defaultValue={basic}
                     onBlur={this.handleInputBlur}

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -72,6 +72,12 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
         return fromProps.inEdit !== undefined;
     }
 
+    leaveEditModeIfNotControlled() {
+        if (!this.getEditabilityControlled(this.props)) {
+            this.setState({ inEdit: false });
+        }
+    }
+
     resetDblTouchSimulation = () => {
         this.setState({
             touchCount: 0,
@@ -118,11 +124,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
     }
 
     handleInputBlur = (event: Event & { currentTarget: HTMLInputElement }) => {
-        // Auto leave edit mode if `inEdit` isn't controlled.
-        if (!this.getEditabilityControlled()) {
-            this.setState({ inEdit: false });
-        }
-
+        this.leaveEditModeIfNotControlled();
         this.props.onEditEnd({
             value: event.currentTarget.value,
             event,
@@ -136,6 +138,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
                 event.currentTarget.blur();
                 break;
             case keycode('Escape'):
+                this.leaveEditModeIfNotControlled();
                 this.props.onEditEnd({
                     value: null,
                     event,

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -18,8 +18,8 @@ const TOUCH_TIMEOUT_MS = 250;
 
 export type Props = {
     inEdit?: boolean,
-    onEditRequest: () => void,
     onEditEnd: (payload?: { value: string | null, event: Event }) => void,
+    onDblClick: (event?: Event) => void,
     // #FIXME: use exported Flow types
     icon?: string,
     basic?: ReactChildren,
@@ -30,8 +30,8 @@ export type Props = {
 class EditableTextLabel extends PureComponent<Props, Props, any> {
     static propTypes = {
         inEdit: PropTypes.bool,
-        onEditRequest: PropTypes.func,
         onEditEnd: PropTypes.func,
+        onDblClick: PropTypes.func,
         // <TextLabel> props
         icon: TextLabel.propTypes.icon,
         basic: TextLabel.propTypes.basic,
@@ -41,8 +41,8 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
 
     static defaultProps = {
         inEdit: undefined,
-        onEditRequest: () => {},
         onEditEnd: () => {},
+        onDblClick: () => {},
         // <TextLabel> props
         icon: TextLabel.defaultProps.icon,
         basic: TextLabel.defaultProps.basic,
@@ -79,33 +79,24 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
         });
     }
 
-    handleDoubleClick = () => {
+    handleDoubleClick = (event: Event) => {
         /**
-         * Request edit via double-click is not favored,
-         * because users can hardly find out this interaction.
-         *
-         * This is kept for compatibility reasons.
-         *
-         * Currently I have no plan for supporting the simulated double-click detection
-         * on mobile devices. It's even harder for users to figure out,
-         * and it's not a common UI pattern.
-         *
-         * We should rely on visible buttons or menus to trigger edit.
+         * If `inEdit` isn't controlled, this component by default
+         * goes into edit mode on double click/touch.
          */
-
         if (!this.getEditabilityControlled()) {
             this.setState({ inEdit: true });
         }
 
-        this.props.onEditRequest();
+        this.props.onDblClick(event);
     }
 
-    handleTouchStart = () => {
+    handleTouchStart = (event: Event) => {
         const currentCount = this.state.touchCount + 1;
 
         if (currentCount === 2) {
             // Simulates “double touch”
-            this.handleDoubleClick();
+            this.handleDoubleClick(event);
             this.resetDblTouchSimulation();
             return;
         }
@@ -127,6 +118,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
     }
 
     handleInputBlur = (event: Event & { currentTarget: HTMLInputElement }) => {
+        // Auto leave edit mode if `inEdit` isn't controlled.
         if (!this.getEditabilityControlled()) {
             this.setState({ inEdit: false });
         }
@@ -157,7 +149,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
     render() {
         const {
             inEdit, // not used here
-            onEditRequest,
+            onDblClick, // also not used here
             onEditEnd,
             ...labelProps,
         } = this.props;

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -15,7 +15,7 @@ import TextLabel from './TextLabel';
 import { STATUS_CODE as STATUS } from './StatusIcon';
 
 export type Props = {
-    inEdit: boolean,
+    inEdit?: boolean,
     onEditRequest: () => void,
     onEditEnd: (payload?: { value: string | null, event: Event }) => void,
     // #FIXME: use exported Flow types
@@ -52,7 +52,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
         inEdit: this.props.inEdit || false,
     };
 
-    componentWillReceiveProps(nextProps) {
+    componentWillReceiveProps(nextProps: Props) {
         /**
          * If the edit-state of <EditableTextLabel> is *controlled* by `inEdit` prop.
          * If the prop is `undefined`, this component became *uncontrolled*
@@ -63,7 +63,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
         }
     }
 
-    getEditabilityControlled(fromProps = this.props) {
+    getEditabilityControlled(fromProps: Props = this.props) {
         return fromProps.inEdit !== undefined;
     }
 

--- a/src/__tests__/EditableTextLabel.test.js
+++ b/src/__tests__/EditableTextLabel.test.js
@@ -194,6 +194,8 @@ it('triggers dblClick callback when touch twice with in 250ms', () => {
 
     return new Promise((resolve) => {
         wrapper.simulate('touchstart');
+        expect(wrapper.state('touchCount')).toBe(1);
+
         setTimeout(() => {
             wrapper.simulate('touchstart');
             resolve();

--- a/src/__tests__/EditableTextLabel.test.js
+++ b/src/__tests__/EditableTextLabel.test.js
@@ -65,20 +65,6 @@ it('renders <EditableText> with layout props the same as rowComp() in edit mode'
     });
 });
 
-it('requests to go edit mode when double-clicked in normal mode', () => {
-    const handleEditRequest = jest.fn();
-    const wrapper = shallow(
-        <EditableTextLabel basic="Foo" onEditRequest={handleEditRequest} />
-    );
-
-    wrapper.simulate('dblclick');
-    expect(handleEditRequest).toHaveBeenCalled();
-
-    // Should not break event when callback not set.
-    wrapper.setProps({ onEditRequest: undefined });
-    expect(() => wrapper.simulate('dblclick')).not.toThrowError();
-});
-
 it('fires onEditEnd with input value on input blurs', () => {
     const handleEditEnd = jest.fn(() => EditableTextLabel.defaultProps.onEditEnd());
     const wrapper = mount(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
@@ -154,4 +140,82 @@ it('does not fire onEditEnd on other keys', () => {
 
     wrapper.find('input').simulate('keydown', { keyCode: keycode('Delete') });
     expect(handleEditEnd).not.toHaveBeenCalled();
+});
+
+// Self-controlled edit mode
+it("goes edit mode on double click if 'inEdit' is uncontrolled", () => {
+    const wrapper = shallow(<EditableTextLabel basic="Foo" />);
+    expect(wrapper.state('inEdit')).toBeFalsy();
+
+    wrapper.simulate('dblclick');
+    expect(wrapper.state('inEdit')).toBeTruthy();
+});
+
+it("stays in edit mode as long as 'inEdit' is uncontrolled", () => {
+    const wrapper = shallow(<EditableTextLabel basic="Foo" />);
+    wrapper.setState({ inEdit: true });
+    wrapper.setProps({ icon: 'printer' });
+
+    expect(wrapper.state('inEdit')).toBeTruthy();
+});
+
+it("leaves edit mode on blur if 'inEdit' is uncontrolled", () => {
+    const wrapper = mount(<EditableTextLabel basic="foo" />);
+
+    wrapper.setState({ inEdit: true });
+    wrapper.find('input').simulate('blur');
+
+    expect(wrapper.state('inEdit')).toBeFalsy();
+});
+
+it("leaves edit mode on Esc if 'inEdit' is uncontrolled", () => {
+    const wrapper = mount(<EditableTextLabel basic="foo" />);
+
+    wrapper.setState({ inEdit: true });
+    wrapper.find('input').simulate('keydown', { keyCode: keycode('Escape') });
+
+    expect(wrapper.state('inEdit')).toBeFalsy();
+});
+
+it("does not go edit mode on double click if 'inEdit' is controlled", () => {
+    const wrapper = shallow(<EditableTextLabel basic="Foo" inEdit={false} />);
+    expect(wrapper.state('inEdit')).toBeFalsy();
+
+    wrapper.simulate('dblclick');
+    expect(wrapper.state('inEdit')).toBeFalsy();
+});
+
+// Double-touch simulation
+it('triggers dblClick callback when touch twice with in 250ms', () => {
+    const handleDblClick = jest.fn();
+    const wrapper = shallow(<EditableTextLabel basic="foo" onDblClick={handleDblClick} />);
+
+    expect(handleDblClick).not.toHaveBeenCalled();
+
+    return new Promise((resolve) => {
+        wrapper.simulate('touchstart');
+        setTimeout(() => {
+            wrapper.simulate('touchstart');
+            resolve();
+        }, 200);
+    }).then(() => {
+        expect(handleDblClick).toHaveBeenCalledTimes(1);
+    });
+});
+
+it('does not trigger dblClick callback when touch twice in over 250ms', () => {
+    const handleDblClick = jest.fn();
+    const wrapper = shallow(<EditableTextLabel basic="foo" onDblClick={handleDblClick} />);
+
+    expect(handleDblClick).not.toHaveBeenCalled();
+
+    return new Promise((resolve) => {
+        wrapper.simulate('touchstart');
+        setTimeout(() => {
+            wrapper.simulate('touchstart');
+            resolve();
+        }, 500);
+    }).then(() => {
+        expect(handleDblClick).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
### Implement
1. Fix `<EditableTextLabel>` not supporting custom icon.
2. `<EditableTextLabel>` now does not fire `onEditRequest` callback, leaving users to decide when to control its editing state.
3. `<EditableTextLabel>` now simulates double-touch and then triggers `onDblClick` callback.
4. When the `inEdit` prop isn't set on `<EditableTextLabel>`, it becomes an uncontrolled component and will auto enter edit mode on double clicks.