### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ N/A
 
 ## [1.1.0]
 ### Changed
-- Fix `<EditableTextLabel>` not supporting custom icon.
-- `<EditableTextLabel>` now does not fire `onEditRequest` callback, leaving users to decide when to control its editing state.
-- `<EditableTextLabel>` now simulates double-touch and then triggers `onDblClick` callback.
-- When the `inEdit` prop isn't set on `<EditableTextLabel>`, it becomes an uncontrolled component and will auto enter edit mode on double clicks.
+- API changes to `<EditableTextLabel>`:
+  * `inEdit` prop now defaults to `undefined`, which means the component is **uncontrolled**.
+  * When `inEdit` is set either `true` or `false`, the component is **controlled**
+  * ~`onEditRequest`~ prop is removed in favor of new `onDblClick` callback. Users can decide when to update the edit state.
+- Behavior changes to `<EditableTextLabel>`:
+  * Custom element passed via `icon` now renders correctly under edit mode
+  * Double touch on mobile devices also triggers `onDblClick` callback.
+  * If component is **uncontrolled**, it auto enters edit mode on double clicks/touches and leaves on edit ends.
 
 ## [1.0.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
+### Changed
+- Fix `<EditableTextLabel>` not supporting custom icon.
+- `<EditableTextLabel>` now does not fire `onEditRequest` callback, leaving users to decide when to control its editing state.
+- `<EditableTextLabel>` now simulates double-touch and then triggers `onDblClick` callback.
+- When the `inEdit` prop isn't set on `<EditableTextLabel>`, it becomes an uncontrolled component and will auto enter edit mode on double clicks.
 
 ## [1.0.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+N/A
+
+## [1.1.0]
 ### Changed
 - Fix `<EditableTextLabel>` not supporting custom icon.
 - `<EditableTextLabel>` now does not fire `onEditRequest` callback, leaving users to decide when to control its editing state.

--- a/examples/TextLabel/Editable.js
+++ b/examples/TextLabel/Editable.js
@@ -20,16 +20,16 @@ const cleanAction = decorateAction([
     }
 ]);
 
-class EditableExample extends PureComponent {
+class ControlledExample extends PureComponent {
     state = {
         isEditing: false,
         status: null,
         currentBasic: 'Kitchen Printer',
     };
 
-    handleEditRequest = (event) => {
+    handleDblClick = (event) => {
         this.setState({ isEditing: true });
-        action('editRequest')(event);
+        action('dblClick')(event);
     }
 
     handleEditEnd = (payload) => {
@@ -57,7 +57,7 @@ class EditableExample extends PureComponent {
                     basic={this.state.currentBasic}
                     aside="00:11:22:33"
                     tag="Online"
-                    onEditRequest={this.handleEditRequest}
+                    onDblClick={this.handleDblClick}
                     onEditEnd={this.handleEditEnd}
                     status={this.state.status} />
             </DebugBox>
@@ -68,16 +68,17 @@ class EditableExample extends PureComponent {
 function Editable() {
     return (
         <div>
+            <p>Uncontrolled (self-controlled) editable label:</p>
             <EditableTextLabel
                 icon="printer"
                 basic="Kitchen Printer"
                 aside="00:11:22:33"
                 tag="Online"
-                onEditRequest={action('editRequest')}
+                onDblClick={action('dblClick')}
                 onEditEnd={cleanAction('editEnd')} />
 
-            <p>Interactive example:</p>
-            <EditableExample />
+            <p>Controlled editable label:</p>
+            <ControlledExample />
         </div>
     );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "iCHEF web components library, built with React.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This release introduces API changes to `<EditableTextLabel>`

### Changes
- API changes to `<EditableTextLabel>`:
  * `inEdit` prop now defaults to `undefined`, which means the component is **uncontrolled**.
  * When `inEdit` is set either `true` or `false`, the component is **controlled**
  * ~`onEditRequest`~ prop is removed in favor of new `onDblClick` callback. Users can decide when to update the edit state.
- Behavior changes to `<EditableTextLabel>`:
  * Custom element passed via `icon` now renders correctly under edit mode
  * Double touch on mobile devices also triggers `onDblClick` callback.
  * If component is **uncontrolled**, it auto enters edit mode on double clicks/touches and leaves on edit ends.