### PR TITLE
Fix <Button> contents not center-aligned in expanded mode in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
-N/A
+### Changed
+- `<Button>` now renders a `<div>` instead of `<button>` to address a Safari bug where applies faulty Flexbox rendering to `<button>` tags.
 
 ## [1.1.0]
 ### Changed

--- a/src/Button.js
+++ b/src/Button.js
@@ -33,6 +33,7 @@ function Button({
 
     const rootClassName = classNames(className, `${bemClass}`);
 
+    // #TODO: Restore wrapper to <button> after Safari 11 goes mainstream
     return (
         <div className={rootClassName} {...otherProps}>
             {children}

--- a/src/Button.js
+++ b/src/Button.js
@@ -34,9 +34,9 @@ function Button({
     const rootClassName = classNames(className, `${bemClass}`);
 
     return (
-        <button type="button" className={rootClassName} {...otherProps}>
+        <div className={rootClassName} {...otherProps}>
             {children}
-        </button>
+        </div>
     );
 }
 

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -20,6 +20,15 @@ describe('rowComp(Button)', () => {
 });
 
 describe('Pure <Button>', () => {
+    // #TODO: Restore this after Safari 11 goes mainstream
+    it.skip('renders a <button type=button>', () => {
+        const wrapper = shallow(<PureButton solid>Label</PureButton>);
+
+        expect(wrapper.children()).toHaveLength(1);
+        expect(wrapper.find('button').exists()).toBeTruthy();
+        expect(wrapper.find('button').prop('type')).toBe('button');
+    });
+
     it('handles primary modifier', () => {
         const wrapper = shallow(<PureButton primary>Label</PureButton>);
 

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -20,14 +20,6 @@ describe('rowComp(Button)', () => {
 });
 
 describe('Pure <Button>', () => {
-    it('renders a <button type=button>', () => {
-        const wrapper = shallow(<PureButton solid>Label</PureButton>);
-
-        expect(wrapper.children()).toHaveLength(1);
-        expect(wrapper.find('button').exists()).toBeTruthy();
-        expect(wrapper.find('button').prop('type')).toBe('button');
-    });
-
     it('handles primary modifier', () => {
         const wrapper = shallow(<PureButton primary>Label</PureButton>);
 

--- a/src/styles/Button.scss
+++ b/src/styles/Button.scss
@@ -18,9 +18,8 @@
 }
 
 .#{$prefix}-button {
-    @include remove-button-appearance;
-
     cursor: pointer;
+    user-select: none;
     -webkit-tap-highlight-color: transparent;
 
     // ----------------------

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,6 +8,7 @@ html {
 
 body {
     font-size: rem($component-base-font-size);
+    font-family: sans-serif;
     font-weight: $font-weight-base;
 
     &.#{$prefix}-has-overlay {


### PR DESCRIPTION
### Summary
The issue comes from a Safari/Webkit bug where `<button>` behaves slightly different as a Flex box. This makes a `<Button align="center" minified={false} />` unable to place its content at the center of whole component.

The bug is addressed in Safari 11. But for backward compatibility, the underlying tag for `<Button>` is changed to `<div>` until Safari 11 gets widely adapted.

Ref: https://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-element-in-safar