### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+N/A
+
+## [1.1.1]
 ### Changed
 - `<Button>` now renders a `<div>` instead of `<button>` to address a Safari bug where applies faulty Flexbox rendering to `<button>` tags.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "iCHEF web components library, built with React.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This release contains bug fixes:

### Changed
- `<Button>` now renders a `<div>` instead of `<button>` to address a Safari bug where applies faulty Flexbox rendering to `<button>` tags.