### PR TITLE
Update editable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
-N/A
+### Changed
+- `<EditableBasicRow>` now passes all unknown props to its underlying input.
+- `<EditableTextLabel>` filters out `status` from its inner `<TextLabel>` when it's in edit mode.
 
 ## [1.1.1]
 ### Changed

--- a/src/EditableText.js
+++ b/src/EditableText.js
@@ -9,6 +9,7 @@ import { PureText } from './Text';
 import type { Props as TextProps } from './Text';
 
 export type Props = {
+    basic?: void,
     onFocus: (event?: Event) => void,
     onBlur: (event?: Event) => void,
     align: $PropertyType<TextProps, 'align'>,
@@ -20,6 +21,32 @@ export type Props = {
     className?: string, // eslint-disable-line react/require-default-props
 };
 
+/**
+ * <EditableText>
+ * ==============
+ * The visual element which stands as an input version of `<Text>`.
+ *
+ * It actually renders a `<Text>` inside, but swaps its basic row to an editable version.
+ * Since input is the main task of this element, all unknown props are expected
+ * to be passed to the underlying input. (That is, the `<EditableBasicRow>`.)
+ *
+ * It also hides status icon when the underlying input is being focused, leaving the
+ * whole space for input.
+ *
+ * Another difference between `<EditableText>` and the traditional `<Text>` is that
+ * `<EditableText>` does not take the `basic` prop as the later. Its _basic label_
+ * are supposed to be rendered by the value of input.
+ *
+ * Besides these, it does take layout props (`align` and `noGrow`) and status props.
+ *
+ * @example
+ * ```jsx
+ * <EditableText
+ *     value="Hello world"
+ *     onChange={event => console.log(event.target.value)}
+ *     status="loading" />
+ * ```
+ */
 class EditableText extends PureComponent<Props, Props, any> {
     static propTypes = {
         onFocus: PropTypes.func,
@@ -27,6 +54,7 @@ class EditableText extends PureComponent<Props, Props, any> {
         // <PureText> props,
         align: PureText.propTypes.align,
         noGrow: PureText.propTypes.noGrow,
+
         ...withStatusPropTypes,
         // status,
         // statusIcon,

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -27,6 +27,40 @@ export type Props = {
     status?: string | null,
 };
 
+/**
+ * <EditableTextLabel>
+ * ===================
+ * The row component which can either in **edit mode** or **display mode**.
+ *
+ * While it's in **display mode**, it's simply a `<TextLabel>`.
+ * Once it goes **edit mode**, it renders an `<EditableText>` inside
+ * and behaves like an `<TextInput>`.
+ *
+ * The “editibility” can be either controlled or uncontrolled, depending on
+ * the existance of the `inEdit` prop. An uncontrolled `<EditableTextLabel>` can
+ * go into edit mode automatically when you double-click on it.
+ *
+ * Unlike `<TextInput>`, you should treat `<EditableTextLabel>` like a `<TextLabel>`.
+ * It does not offer direct control to the `<input>` inside.
+ *
+ * @example
+ * (Uncontrolled)
+ * ```jsx
+ * <EditableTextLabel
+ *     basic="Text to be edited"
+ *     onEditEnd={(value, event) => console.log(value, event)} />
+ * ```
+ *
+ * (Controlled)
+ * ```jsx
+ * <EditableTextLabel
+ *     basic="Text to be edited"
+ *     inEdit={this.state.inEdit}
+ *     onDblClick={() => this.setState({ inEdit: true })}
+ *     onEditEnd={(value, event) => console.log(value, event)} />
+ * ```
+ */
+
 class EditableTextLabel extends PureComponent<Props, Props, any> {
     static propTypes = {
         inEdit: PropTypes.bool,

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -201,7 +201,7 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
             );
         }
 
-        const layoutProps = getTextLayoutProps(align, !!icon);
+        const layoutProps = getTextLayoutProps(align, !!icon); // { align, noGrow }
         const labelIcon = icon && wrapIfNotElement(icon, { with: Icon, via: 'type' });
 
         return (
@@ -210,11 +210,9 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
 
                 <EditableText
                     defaultValue={basic}
+                    autoFocus={this.state.inEdit}
                     onBlur={this.handleInputBlur}
-                    input={{
-                        autoFocus: this.state.inEdit,
-                        onKeyDown: this.handleInputKeyDown,
-                    }}
+                    onKeyDown={this.handleInputKeyDown}
                     {...layoutProps} />
             </TextLabel>
         );

--- a/src/EditableTextLabel.js
+++ b/src/EditableTextLabel.js
@@ -34,7 +34,8 @@ export type Props = {
  *
  * While it's in **display mode**, it's simply a `<TextLabel>`.
  * Once it goes **edit mode**, it renders an `<EditableText>` inside
- * and behaves like an `<TextInput>`.
+ * and behaves like an `<TextInput>`. It should also filter out status props when
+ * it's in edit mode.
  *
  * The “editibility” can be either controlled or uncontrolled, depending on
  * the existance of the `inEdit` prop. An uncontrolled `<EditableTextLabel>` can
@@ -188,13 +189,15 @@ class EditableTextLabel extends PureComponent<Props, Props, any> {
             inEdit, // not used here
             onDblClick, // also not used here
             onEditEnd,
+            status,
             ...labelProps,
         } = this.props;
-        const { icon, basic, align, status } = labelProps;
+        const { icon, basic, align } = labelProps;
 
         if (!this.state.inEdit && status !== STATUS.LOADING) {
             return (
                 <TextLabel
+                    status={status}
                     onDoubleClick={this.handleDoubleClick}
                     onTouchStart={this.handleTouchStart}
                     {...labelProps} />

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -9,6 +9,24 @@ import EditableText from './EditableText';
 
 export const COMPONENT_NAME = prefixClass('text-input');
 
+/**
+ * <TextInput>
+ * ===========
+ * The row component holding an editable `<input>` as its main part.
+ * All unknown props are expected to be passed into the underlying `<input>`.
+ *
+ * What's different from other row component is: _basic text_ is not allowed
+ * on a `<TextInput>`, since that place is occupied by an `<input>`.
+ *
+ * @example
+ * ```jsx
+ * <TextInput
+ *     value="Hello world"
+ *     placeholder="(Unset)"
+ *     onChange={event => console.log(event.target.value)} />
+ * ```
+ */
+
 function TextInput(props, { align }) {
     const {
         wrapperProps,

--- a/src/__tests__/EditableBasicRow.test.js
+++ b/src/__tests__/EditableBasicRow.test.js
@@ -135,3 +135,9 @@ it('keeps input from keyboard navigation when input looks untouchable', () => {
     expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
 });
 
+it('passes unknown props to its underlying input', () => {
+    const wrapper = shallow(<EditableBasicRow autoFocus id="foo-input" />);
+
+    expect(wrapper.find('input').prop('autoFocus')).toBeTruthy();
+    expect(wrapper.find('input').prop('id')).toBe('foo-input');
+});

--- a/src/mixins/rowComp.js
+++ b/src/mixins/rowComp.js
@@ -104,7 +104,7 @@ export function getTextLayoutProps(compAlign, hasIcon) {
 
 const rowComp = ({
     defaultMinified = false,
-    defaultAlign = 'left'
+    defaultAlign = LEFT,
 } = {}) => (WrappedComponent) => {
     const componentName = getComponentName(WrappedComponent);
 


### PR DESCRIPTION
### Purpose
Clarify the behaviors of editable components, update them in a shared logic.

### Implement
1. Update comments for editable components to clarify usage and behavior
2. `<EditableBasicRow>` now passes all unknown props to its underlying input.
3. `<EditableTextLabel>` filters out `status` from its inner `<TextLabel>` when it's in edit mode.