### PR TITLE
Update <Text> with new design spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `<EditableBasicRow>` now passes all unknown props to its underlying input.
 - `<EditableTextLabel>` filters out `status` from its inner `<TextLabel>` when it's in edit mode.
+- The *basic* text is now bold in `<Text>`, while the color of *aside* text goes grey.
 
 ## [1.1.1]
 ### Changed

--- a/src/styles/Text.scss
+++ b/src/styles/Text.scss
@@ -31,9 +31,11 @@
     &__basic {
         font-size: inherit;
         line-height: inherit;
+        font-weight: $font-weight-bold;
     }
 
     &__aside {
+        color: $c-text-aside;
         font-size: rem($aside-text-font-size);
         line-height: rem($aside-text-line-height);
     }

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -16,6 +16,7 @@ $c-text-editable: $c-blue;
 $c-text-disabled: hsba(0, 0, 0, 30);
 $c-text-readonly: $c-gray;
 $c-text-placeholder: hsba(0, 0, 0, 30);
+$c-text-aside:    hsba(0, 0, 30, 100);
 
 // Icon-only buttons
 $c-icon-header: $c-black;


### PR DESCRIPTION
### Purpose
Align `<Text>` with new design spec.

### Implement
1. The “basic” text is now in bold font.
2. The “aside” text is now slighter in color.

### Demo
![2017-10-02 2 49 54](https://user-images.githubusercontent.com/365035/31066648-075c0fca-a714-11e7-90b0-9724dcb2c0ac.png)
