### PR TITLE
Add new <TextInput> for form package

### DIFF
--- a/configs/jest.config.json
+++ b/configs/jest.config.json
@@ -3,5 +3,8 @@
     "moduleNameMapper": {
          "\\.(css|scss|sass|md|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|)$": "<rootDir>/__mocks__/fileMock.js"
     },
-    "testRegex": "(/__tests__/.*.(test|spec))\\.jsx?$"
+    "testRegex": "(/__tests__/.*.(test|spec))\\.jsx?$",
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/(?!@ichef/)"
+    ]
 }

--- a/packages/form/configs/webpack.dist.js
+++ b/packages/form/configs/webpack.dist.js
@@ -9,9 +9,9 @@ module.exports = {
     context: path.resolve(__dirname, '..'),
 
     output: {
-        filename: 'gypcrete.js',
+        filename: 'gypcrete-form.js',
         path: path.resolve(__dirname, '../dist'),
-        library: 'gypcrete'
+        library: 'gypcrete-form'
     },
 
     module: {
@@ -72,7 +72,7 @@ module.exports = {
     },
 
     plugins: [
-        new ExtractTextPlugin('gypcrete.css')
+        new ExtractTextPlugin('gypcrete-form.css')
     ],
 
     externals: {

--- a/packages/form/configs/webpack.dist.js
+++ b/packages/form/configs/webpack.dist.js
@@ -1,0 +1,81 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+const autoprefixer = require('autoprefixer');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+    entry: './src/index.js',
+
+    context: path.resolve(__dirname, '..'),
+
+    output: {
+        filename: 'gypcrete.js',
+        path: path.resolve(__dirname, '../dist'),
+        library: 'gypcrete'
+    },
+
+    module: {
+        rules: [
+            {
+                test: /\.jsx?$/,
+                include: [
+                    path.resolve(__dirname, '../src')
+                ],
+                use: ['babel-loader']
+            },
+            {
+                test: /\.scss$/,
+                include: [
+                    path.resolve(__dirname, '../src')
+                ],
+                use: ExtractTextPlugin.extract({
+                    fallback: 'style-loader',
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                importLoaders: 1
+                            }
+                        },
+                        {
+                            loader: 'postcss-loader',
+                            options: {
+                                plugins: () => [autoprefixer]
+                            }
+                        },
+                        {
+                            loader: 'sass-loader',
+                            options: {
+                                outputStyle: 'expanded'
+                            }
+                        }
+                    ]
+                })
+            },
+            {
+                test: /\.(woff|woff2|otf|ttf|eot|svg)$/,
+                include: [
+                    path.resolve(__dirname, '../src/fonts')
+                ],
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: '[name]-[hash:6].[ext]',
+                            outputPath: 'fonts/',
+                            publicPath: 'fonts/'
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+
+    plugins: [
+        new ExtractTextPlugin('gypcrete.css')
+    ],
+
+    externals: {
+        react: 'React'
+    }
+};

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@ichef/gypcrete",
+  "name": "@ichef/gypcrete-form",
   "version": "1.2.0",
-  "description": "iCHEF web components library, built with React.",
+  "description": "Form components built on Gypcrete",
   "repository": "iCHEF/gypcrete",
   "contributors": [
     "CJies Tan (https://github.com/cjies)",
@@ -25,7 +25,6 @@
       "package.json"
   ],
   "scripts": {
-    "prepublish": "npm run clean && npm run build",
     "build": "npm run build:dist && npm run build:lib && npm run build:es5",
     "build:dist": "webpack --config ./configs/webpack.dist.js --color",
     "build:lib": "BABEL_ENV=lib babel src --out-dir lib",
@@ -39,15 +38,13 @@
     "prop-types": "^15.5.8"
   },
   "dependencies": {
+    "@ichef/gypcrete": "^1.2.0",
     "classnames": "^2.2.5",
-    "document-offset": "^1.0.4",
-    "keycode": "^2.1.9",
-    "react-flow-types": "^0.1.1"
+    "keycode": "^2.1.9"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "enzyme": "^2.8.2",
-    "sinon": "^2.2.0",
     "webpack": "^2.2.1"
   }
 }

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -9,6 +9,7 @@ import {
 
 import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
 import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
+import { statusPropTypes } from '@ichef/gypcrete/lib/mixins/withStatus';
 
 import './styles/TextInput.scss';
 
@@ -26,12 +27,19 @@ class TextInput extends React.PureComponent {
         placeholder: PropTypes.string,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
+        // row props
+        rowDesc: PropTypes.node,
+        ...statusPropTypes,
+        // status
+        // statusOptions
+        // errorMsg
     };
 
     static defaultProps = {
         placeholder: 'Unset',
         onFocus: () => {},
         onBlur: () => {},
+        rowDesc: undefined,
     };
 
     state = {
@@ -64,6 +72,11 @@ class TextInput extends React.PureComponent {
             label,
             onFocus,
             onBlur,
+            // row props
+            rowDesc,
+            status,
+            statusOptions,
+            errorMsg,
             // React props
             className,
             ...inputProps,
@@ -79,8 +92,15 @@ class TextInput extends React.PureComponent {
             </span>
         );
 
+        const rowProps = {
+            desc: rowDesc,
+            status,
+            statusOptions,
+            errorMsg,
+        };
+
         return (
-            <ListRow className={rootClassName}>
+            <ListRow className={rootClassName} {...rowProps}>
                 <TextLabel
                     basic={keyLabel}
                     aside={this.renderInput(inputProps)} />

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -9,10 +9,13 @@ import {
 import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
 import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
 
+import './styles/TextInput.scss';
+
 export const COMPONENT_NAME = prefixClass('form-text-input');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 export const BEM = {
     root: ROOT_BEM,
+    label: ROOT_BEM.element('label'),
     input: ROOT_BEM.element('input'),
 };
 
@@ -33,7 +36,8 @@ class TextInput extends React.PureComponent {
         return (
             <input
                 type="text"
-                value="foo"
+                defaultValue="foo"
+                placeholder="Unset"
                 className={BEM.input.toString()}
                 onFocus={this.handleInputFocus}
                 onBlur={this.handleInputBlur} />
@@ -49,11 +53,16 @@ class TextInput extends React.PureComponent {
             .modifier('focused', this.state.focused);
         const rootClassName = classNames(bemClass.toString(), className);
 
+        const keyLabel = (
+            <span className={BEM.label.toString()}>
+                Key label
+            </span>
+        );
+
         return (
             <ListRow className={rootClassName}>
                 <TextLabel
-                    bold
-                    basic={`${this.state.focused}`}
+                    basic={keyLabel}
                     aside={this.renderInput()} />
             </ListRow>
         );

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
@@ -20,33 +21,52 @@ export const BEM = {
 };
 
 class TextInput extends React.PureComponent {
+    static propTypes = {
+        label: PropTypes.node.isRequired,
+        placeholder: PropTypes.string,
+        onFocus: PropTypes.func,
+        onBlur: PropTypes.func,
+    };
+
+    static defaultProps = {
+        placeholder: 'Unset',
+        onFocus: () => {},
+        onBlur: () => {},
+    };
+
     state = {
         focused: false,
     };
 
-    handleInputFocus = () => {
+    handleInputFocus = (event) => {
         this.setState({ focused: true });
+        this.props.onFocus(event);
     }
 
-    handleInputBlur = () => {
+    handleInputBlur = (event) => {
         this.setState({ focused: false });
+        this.props.onBlur(event);
     }
 
-    renderInput() {
+    renderInput(inputProps = {}) {
         return (
             <input
                 type="text"
-                defaultValue="foo"
-                placeholder="Unset"
                 className={BEM.input.toString()}
                 onFocus={this.handleInputFocus}
-                onBlur={this.handleInputBlur} />
+                onBlur={this.handleInputBlur}
+                {...inputProps} />
         );
     }
 
     render() {
         const {
+            label,
+            onFocus,
+            onBlur,
+            // React props
             className,
+            ...inputProps,
         } = this.props;
 
         const bemClass = BEM.root
@@ -55,7 +75,7 @@ class TextInput extends React.PureComponent {
 
         const keyLabel = (
             <span className={BEM.label.toString()}>
-                Key label
+                {label}
             </span>
         );
 
@@ -63,7 +83,7 @@ class TextInput extends React.PureComponent {
             <ListRow className={rootClassName}>
                 <TextLabel
                     basic={keyLabel}
-                    aside={this.renderInput()} />
+                    aside={this.renderInput(inputProps)} />
             </ListRow>
         );
     }

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -24,7 +24,10 @@ export const BEM = {
 class TextInput extends React.PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
+        // input props
         placeholder: PropTypes.string,
+        disabled: PropTypes.bool,
+        readOnly: PropTypes.bool,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
         // row props
@@ -37,6 +40,8 @@ class TextInput extends React.PureComponent {
 
     static defaultProps = {
         placeholder: 'Unset',
+        disabled: false,
+        readOnly: false,
         onFocus: () => {},
         onBlur: () => {},
         rowDesc: undefined,
@@ -70,6 +75,10 @@ class TextInput extends React.PureComponent {
     render() {
         const {
             label,
+            // input props
+            // placeholder,
+            disabled,
+            readOnly,
             onFocus,
             onBlur,
             // row props
@@ -79,11 +88,12 @@ class TextInput extends React.PureComponent {
             errorMsg,
             // React props
             className,
-            ...inputProps,
+            ...otherInputProps,
         } = this.props;
 
         const bemClass = BEM.root
-            .modifier('focused', this.state.focused);
+            .modifier('focused', this.state.focused)
+            .modifier('ineditable', disabled || readOnly);
         const rootClassName = classNames(bemClass.toString(), className);
 
         const keyLabel = (
@@ -91,6 +101,12 @@ class TextInput extends React.PureComponent {
                 {label}
             </span>
         );
+
+        const inputProps = {
+            disabled,
+            readOnly,
+            ...otherInputProps,
+        };
 
         const rowProps = {
             desc: rowDesc,

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -9,8 +9,8 @@ import {
 
 import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
 import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
-import { statusPropTypes } from '@ichef/gypcrete/lib/mixins/withStatus';
 
+import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/TextInput.scss';
 
 export const COMPONENT_NAME = prefixClass('form-text-input');
@@ -26,25 +26,17 @@ class TextInput extends React.PureComponent {
         label: PropTypes.node.isRequired,
         // input props
         placeholder: PropTypes.string,
-        disabled: PropTypes.bool,
-        readOnly: PropTypes.bool,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
-        // row props
-        rowDesc: PropTypes.node,
-        ...statusPropTypes,
-        // status
-        // statusOptions
-        // errorMsg
+        // from formRow()
+        ineditable: PropTypes.bool.isRequired,
+        rowProps: rowPropTypes.isRequired,
     };
 
     static defaultProps = {
         placeholder: 'Unset',
-        disabled: false,
-        readOnly: false,
         onFocus: () => {},
         onBlur: () => {},
-        rowDesc: undefined,
     };
 
     state = {
@@ -77,23 +69,19 @@ class TextInput extends React.PureComponent {
             label,
             // input props
             // placeholder,
-            disabled,
-            readOnly,
             onFocus,
             onBlur,
             // row props
-            rowDesc,
-            status,
-            statusOptions,
-            errorMsg,
+            ineditable,
+            rowProps,
             // React props
             className,
-            ...otherInputProps,
+            ...inputProps,
         } = this.props;
 
         const bemClass = BEM.root
             .modifier('focused', this.state.focused)
-            .modifier('ineditable', disabled || readOnly);
+            .modifier('ineditable', ineditable);
         const rootClassName = classNames(bemClass.toString(), className);
 
         const keyLabel = (
@@ -101,19 +89,6 @@ class TextInput extends React.PureComponent {
                 {label}
             </span>
         );
-
-        const inputProps = {
-            disabled,
-            readOnly,
-            ...otherInputProps,
-        };
-
-        const rowProps = {
-            desc: rowDesc,
-            status,
-            statusOptions,
-            errorMsg,
-        };
 
         return (
             <ListRow className={rootClassName} {...rowProps}>
@@ -125,4 +100,5 @@ class TextInput extends React.PureComponent {
     }
 }
 
-export default TextInput;
+export { TextInput as PureTextInput };
+export default formRow()(TextInput);

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -29,14 +29,16 @@ class TextInput extends React.PureComponent {
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
         // from formRow()
-        ineditable: PropTypes.bool.isRequired,
-        rowProps: rowPropTypes.isRequired,
+        ineditable: PropTypes.bool,
+        rowProps: rowPropTypes,
     };
 
     static defaultProps = {
         placeholder: 'Unset',
         onFocus: () => {},
         onBlur: () => {},
+        ineditable: false,
+        rowProps: {},
     };
 
     state = {

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -61,7 +61,7 @@ class TextInput extends React.PureComponent {
         this.props.onBlur(event);
     }
 
-    renderInput(inputProps = {}) {
+    renderInput(inputProps) {
         return (
             <input
                 type="text"

--- a/packages/form/src/TextInput.js
+++ b/packages/form/src/TextInput.js
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+import {
+    ListRow,
+    TextLabel,
+} from '@ichef/gypcrete';
+
+import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
+import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
+
+export const COMPONENT_NAME = prefixClass('form-text-input');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    input: ROOT_BEM.element('input'),
+};
+
+class TextInput extends React.PureComponent {
+    state = {
+        focused: false,
+    };
+
+    handleInputFocus = () => {
+        this.setState({ focused: true });
+    }
+
+    handleInputBlur = () => {
+        this.setState({ focused: false });
+    }
+
+    renderInput() {
+        return (
+            <input
+                type="text"
+                value="foo"
+                className={BEM.input.toString()}
+                onFocus={this.handleInputFocus}
+                onBlur={this.handleInputBlur} />
+        );
+    }
+
+    render() {
+        const {
+            className,
+        } = this.props;
+
+        const bemClass = BEM.root
+            .modifier('focused', this.state.focused);
+        const rootClassName = classNames(bemClass.toString(), className);
+
+        return (
+            <ListRow className={rootClassName}>
+                <TextLabel
+                    bold
+                    basic={`${this.state.focused}`}
+                    aside={this.renderInput()} />
+            </ListRow>
+        );
+    }
+}
+
+export default TextInput;

--- a/packages/form/src/__tests__/TextInput.test.js
+++ b/packages/form/src/__tests__/TextInput.test.js
@@ -2,50 +2,50 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 
-import TextInput, { BEM } from '../TextInput';
+import TextInput, { PureTextInput, BEM } from '../TextInput';
 
-it('renders without crashing', () => {
-    const div = document.createElement('div');
-    const element = (
-        <TextInput
-            label="foo"
-            defaultValue="bar" />
-    );
+describe('formRow(TextInput)', () => {
+    it('renders without crashing', () => {
+        const div = document.createElement('div');
+        const element = (
+            <TextInput
+                label="foo"
+                defaultValue="bar" />
+        );
 
-    ReactDOM.render(element, div);
+        ReactDOM.render(element, div);
+    });
 });
 
-it('renders an <input> inside', () => {
-    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
+describe('Pure <TextInput>', () => {
+    it('renders an <input> inside', () => {
+        const wrapper = mount(
+            <PureTextInput
+                label="foo"
+                defaultValue="bar" />
+        );
 
-    expect(wrapper.find('input').exists()).toBeTruthy();
-});
+        expect(wrapper.find('input').exists()).toBeTruthy();
+    });
 
-it('enters and leaves focused state on input events', () => {
-    const focusedModifier = BEM.root
-        .modifier('focused')
-        .toString({ stripBlock: true });
+    it('enters and leaves focused state on input events', () => {
+        const focusedModifier = BEM.root
+            .modifier('focused')
+            .toString({ stripBlock: true });
 
-    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
-    expect(wrapper.state('focused')).toBeFalsy();
+        const wrapper = mount(
+            <PureTextInput
+                label="foo"
+                defaultValue="bar" />
+        );
+        expect(wrapper.state('focused')).toBeFalsy();
 
-    wrapper.find('input').simulate('focus');
-    expect(wrapper.state('focused')).toBeTruthy();
-    expect(wrapper.hasClass(focusedModifier)).toBeTruthy();
+        wrapper.find('input').simulate('focus');
+        expect(wrapper.state('focused')).toBeTruthy();
+        expect(wrapper.hasClass(focusedModifier)).toBeTruthy();
 
-    wrapper.find('input').simulate('blur');
-    expect(wrapper.state('focused')).toBeFalsy();
-    expect(wrapper.hasClass(focusedModifier)).toBeFalsy();
-});
-
-it('has ineditable modifier if input disabled or readOnly', () => {
-    const ineditableModifier = BEM.root
-        .modifier('ineditable')
-        .toString({ stripBlock: true });
-
-    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
-    expect(wrapper.hasClass(ineditableModifier)).toBeFalsy();
-
-    wrapper.setProps({ disabled: true, readOnly: false });
-    expect(wrapper.hasClass(ineditableModifier)).toBeTruthy();
+        wrapper.find('input').simulate('blur');
+        expect(wrapper.state('focused')).toBeFalsy();
+        expect(wrapper.hasClass(focusedModifier)).toBeFalsy();
+    });
 });

--- a/packages/form/src/__tests__/TextInput.test.js
+++ b/packages/form/src/__tests__/TextInput.test.js
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
+
+import TextInput, { BEM } from '../TextInput';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = (
+        <TextInput
+            label="foo"
+            defaultValue="bar" />
+    );
+
+    ReactDOM.render(element, div);
+});
+
+it('renders an <input> inside', () => {
+    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
+
+    expect(wrapper.find('input').exists()).toBeTruthy();
+});
+
+it('enters and leaves focused state on input events', () => {
+    const focusedModifier = BEM.root
+        .modifier('focused')
+        .toString({ stripBlock: true });
+
+    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
+    expect(wrapper.state('focused')).toBeFalsy();
+
+    wrapper.find('input').simulate('focus');
+    expect(wrapper.state('focused')).toBeTruthy();
+    expect(wrapper.hasClass(focusedModifier)).toBeTruthy();
+
+    wrapper.find('input').simulate('blur');
+    expect(wrapper.state('focused')).toBeFalsy();
+    expect(wrapper.hasClass(focusedModifier)).toBeFalsy();
+});
+
+it('has ineditable modifier if input disabled or readOnly', () => {
+    const ineditableModifier = BEM.root
+        .modifier('ineditable')
+        .toString({ stripBlock: true });
+
+    const wrapper = mount(<TextInput label="foo" defaultValue="bar" />);
+    expect(wrapper.hasClass(ineditableModifier)).toBeFalsy();
+
+    wrapper.setProps({ disabled: true, readOnly: false });
+    expect(wrapper.hasClass(ineditableModifier)).toBeTruthy();
+});

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -1,0 +1,5 @@
+import TextInput from './TextInput';
+
+export {
+    TextInput,
+};

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 import TextInput from './TextInput';
 
 export {

--- a/packages/form/src/mixins/__tests__/formRow.test.js
+++ b/packages/form/src/mixins/__tests__/formRow.test.js
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import formRow from '../formRow';
+
+function Foo({ children }) {
+    return <div>{children}</div>;
+}
+
+const FormRowFoo = formRow()(Foo);
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <FormRowFoo />;
+
+    ReactDOM.render(element, div);
+});
+
+it('passes ineditable prop to wrapped component', () => {
+    const wrapper = shallow(<FormRowFoo />);
+
+    expect(wrapper.find(Foo).props()).toMatchObject({
+        ineditable: false,
+        disabled: false,
+        readOnly: false,
+    });
+
+    wrapper.setProps({ disabled: true, readOnly: false });
+    expect(wrapper.find(Foo).props()).toMatchObject({
+        ineditable: true,
+        disabled: true,
+        readOnly: false,
+    });
+
+    wrapper.setProps({ disabled: false, readOnly: true });
+    expect(wrapper.find(Foo).props()).toMatchObject({
+        ineditable: true,
+        disabled: false,
+        readOnly: true,
+    });
+});
+
+it('passes a collected rowProps prop to wrapped component', () => {
+    const wrapper = shallow(
+        <FormRowFoo
+            desc="foo"
+            status="error"
+            statusOptions={{ autoHide: false }}
+            errorMsg="bar" />
+    );
+    const fooProps = wrapper.find(Foo).props();
+
+    expect(fooProps).not.toHaveProperty('desc');
+    expect(fooProps).not.toHaveProperty('status');
+    expect(fooProps).not.toHaveProperty('statusOptions');
+    expect(fooProps).not.toHaveProperty('errorMsg');
+
+    expect(fooProps.rowProps).toMatchObject({
+        desc: 'foo',
+        status: 'error',
+        statusOptions: { autoHide: false },
+        errorMsg: 'bar',
+    });
+});

--- a/packages/form/src/mixins/formRow.js
+++ b/packages/form/src/mixins/formRow.js
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+import getComponentName from '@ichef/gypcrete/lib/utils/getComponentName';
+import { statusPropTypes } from '@ichef/gypcrete/lib/mixins/withStatus';
+
+const propTypes = {
+    disabled: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    desc: PropTypes.node,
+    ...statusPropTypes,
+    // status
+    // statusOptions
+    // errorMsg
+};
+
+const defaultProps = {
+    disabled: false,
+    readOnly: false,
+    desc: undefined,
+};
+
+export const rowPropTypes = PropTypes.shape({
+    desc: PropTypes.node,
+    ...statusPropTypes,
+});
+
+const formRow = (/* mixin options */) => (WrappedComponent) => {
+    function FormRow({
+        disabled,
+        readOnly,
+        desc,
+        status,
+        statusOptions,
+        errorMsg,
+        ...otherProps,
+    }) {
+        const ineditable = disabled || readOnly;
+        const rowProps = {
+            desc,
+            status,
+            statusOptions,
+            errorMsg,
+        };
+
+        return (
+            <WrappedComponent
+                ineditable={ineditable}
+                disabled={disabled}
+                readOnly={readOnly}
+                rowProps={rowProps}
+                {...otherProps} />
+        );
+    }
+
+    FormRow.displayName = getComponentName(WrappedComponent);
+    FormRow.propTypes = propTypes;
+    FormRow.defaultProps = defaultProps;
+
+    return FormRow;
+};
+
+export default formRow;

--- a/packages/form/src/styles/TextInput.scss
+++ b/packages/form/src/styles/TextInput.scss
@@ -1,0 +1,48 @@
+$component-name: 'gyp-form-text-input';
+
+%main-text {
+    color: #000;
+    font-size: 16px;
+    line-height: 18px;
+    font-weight: 700;
+}
+
+%aside-text {
+    color: #4d4d4d;
+    font-size: 14px;
+    line-height: 16px;
+    font-weight: 400;
+}
+
+.#{$component-name} {
+    ::placeholder {
+        color: rgba(0, 0, 0, .3);
+    }
+
+    // Elements
+    &__label {
+        @extend %main-text;
+    }
+
+    &__input {
+        @extend %aside-text;
+
+        color: inherit;
+        font-size: inherit;
+        line-height: inherit;
+        border: none;
+        padding: 0;
+        outline: none;
+    }
+
+    // Modifiers
+    &--focused {
+        .#{$component-name}__label {
+            @extend %aside-text;
+        }
+
+        .#{$component-name}__input {
+            @extend %main-text;
+        }
+    }
+}

--- a/packages/form/src/styles/TextInput.scss
+++ b/packages/form/src/styles/TextInput.scss
@@ -45,4 +45,12 @@ $component-name: 'gyp-form-text-input';
             @extend %main-text;
         }
     }
+
+    // States
+    &.gyp-state-error {
+        .#{$component-name}__label,
+        .#{$component-name}__input {
+            color: inherit;
+        }
+    }
 }

--- a/packages/form/src/styles/TextInput.scss
+++ b/packages/form/src/styles/TextInput.scss
@@ -1,17 +1,19 @@
 $component-name: 'gyp-form-text-input';
+$font-weight-base: 400;
+$font-weight-bold: 700;
 
 %main-text {
     color: #000;
     font-size: 16px;
     line-height: 18px;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
 }
 
 %aside-text {
     color: #4d4d4d;
     font-size: 14px;
     line-height: 16px;
-    font-weight: 400;
+    font-weight: $font-weight-base;
 }
 
 .#{$component-name} {
@@ -43,6 +45,13 @@ $component-name: 'gyp-form-text-input';
 
         .#{$component-name}__input {
             @extend %main-text;
+        }
+    }
+
+    &--ineditable {
+        .#{$component-name}__label,
+        .#{$component-name}__input {
+            font-weight: $font-weight-base;
         }
     }
 

--- a/packages/storybook/examples/Form.TextInput/BasicUsage.js
+++ b/packages/storybook/examples/Form.TextInput/BasicUsage.js
@@ -1,12 +1,32 @@
 import React from 'react';
 
+import List from '@ichef/gypcrete/src/List';
 import TextInput from '@ichef/gypcrete-form/src/TextInput';
 
 function BasicUsage() {
     return (
-        <TextInput
-            label="Module name"
-            defaultValue="Points module" />
+        <List title="Configs">
+            <TextInput
+                label="Module name"
+                defaultValue="Points module" />
+
+            <TextInput
+                disabled
+                label="Disabled row"
+                value="Points module" />
+
+            <TextInput
+                readOnly
+                label="Read-only row"
+                value="Points module" />
+
+
+            <TextInput
+                label="Secret code"
+                value="Foo bar"
+                status="error"
+                errorMsg="Cannot authenticate with this code." />
+        </List>
     );
 }
 

--- a/packages/storybook/examples/Form.TextInput/BasicUsage.js
+++ b/packages/storybook/examples/Form.TextInput/BasicUsage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import TextInput from '@ichef/gypcrete-form/src/TextInput';
+
+function BasicUsage() {
+    return (
+        <TextInput
+            label="Module name"
+            defaultValue="Points module" />
+    );
+}
+
+export default BasicUsage;

--- a/packages/storybook/examples/Form.TextInput/index.js
+++ b/packages/storybook/examples/Form.TextInput/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+// For props table
+import TextInput from '@ichef/gypcrete-form/src/TextInput';
+
+import BasicUsage from './BasicUsage';
+
+storiesOf('[Form] TextInput', module)
+    .addWithInfo('basic usage', BasicUsage)
+    // Props table
+    .addPropsTable(() => <TextInput />);

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,8 @@
     "ghpages": "npm run clean && npm run build:storybook && sh ./scripts/ghpages.sh"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^1.2.0"
+    "@ichef/gypcrete": "^1.2.0",
+    "@ichef/gypcrete-form": "^1.2.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.0.0",


### PR DESCRIPTION
### Purpose
Add an row-based input with alternative behaviors form new design spec.

### Implement
1. Create new package `@ichef/gypcrete-form` for new row-based form components
2. Create new `<TextInput>` and its styles
3. Fix Jest should not ignore `node_modules/@ichef/*` when transforming files.

### Demo
![2017-10-12 2 43 49](https://user-images.githubusercontent.com/365035/31482845-82aa6130-aeef-11e7-8f1c-848d477b18d3.png)

### Design spec
![2017-10-12 2 45 36](https://user-images.githubusercontent.com/365035/31482851-895c746e-aeef-11e7-8bda-2cf3cba54053.png)
