### PR TITLE
Use the .npmrc approach to auth 'lerna publish'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_script:
     - yarn test
 
 script:
+    # Auth NPM for publish
+    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > "${TRAVIS_BUILD_DIR}"/.npmrc
     # Publish canary builds when feature merges back to develop
     - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then yarn canary ; fi"
     # Publish release builds when merges to master


### PR DESCRIPTION
This should enable `lerna publish` script with the same approach we once used in `deploy.sh`