### PR TITLE
Fix deloy issues

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,10 @@
   ],
   "version": "1.2.0",
   "npmClient": "yarn",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "commands": {
+    "publish": {
+      "registry": "https://registry.npmjs.org"
+    }
+  }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.3.1",
+  "lerna": "2.4.0",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "flow-bin": "^0.47.0",
     "file-loader": "^0.10.1",
     "jest": "^19.0.2",
-    "lerna": "^2.3.1",
+    "lerna": "^2.4.0",
     "node-sass": "^4.5.3",
     "postcss-loader": "^1.3.3",
     "react": "^15.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,7 +4926,7 @@ ldjson-stream@^1.2.1:
     split2 "^0.2.1"
     through2 "^0.6.1"
 
-lerna@^2.3.1:
+lerna@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.4.0.tgz#7b76446b154bafb9cba8996f3dc233f1cb6ca7c3"
   dependencies:


### PR DESCRIPTION
It turned out that the default NPM registry config on Travis CI is somehow broken, which finally led to the failure of publish.

This should closes #85.

### Implements
1. Fix `npm publish` failure by manually specify registry URL.
2. Upgrade to [Lerna 2.4.0](https://github.com/lerna/lerna/releases/tag/v2.4.0) for improved exit code