### PR TITLE
Fix component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- N/A
+### Changed
+- Upgrade webpack to v3 (#101)
+- [Core] Fix aside label for `<Text>` should turn white inside a highlighted `<ListRow>`. (#104)
+- [Core] Adds hover background for `<ListRow>`. (#104)
+- [Core] Fix vertical padding for `<HeaderRow>`. (#104)
 
 ## [1.3.0]
 ### Added

--- a/packages/core/src/styles/HeaderRow.scss
+++ b/packages/core/src/styles/HeaderRow.scss
@@ -5,7 +5,8 @@ $component: #{$prefix}-header-row;
     min-height: rem($row-base-height);
     background-color: $c-header-bg;
     border-bottom: 1px solid $c-divider-header;
-    padding: 0 rem($header-padding);
+    padding: rem($header-row-padding);
+    box-sizing: border-box;
     display: flex;
 
     &__left,

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -2,8 +2,8 @@
 $component: #{$prefix}-list-row;
 
 .#{$component} {
-    min-height: $row-base-height;
-    padding: 0 $list-row-padding-horizontal;
+    min-height: rem($row-base-height);
+    padding: 0 rem($list-row-padding-horizontal);
     box-sizing: border-box;
 
     &:hover {
@@ -16,7 +16,7 @@ $component: #{$prefix}-list-row;
     &__body {
         display: flex;
         align-items: flex-start;
-        padding: $list-row-padding-vertical 0;
+        padding: rem($list-row-padding-vertical) 0;
         box-shadow: inset 0 -1px 0 $c-divider-row;
 
         // Styles inside List
@@ -35,12 +35,12 @@ $component: #{$prefix}-list-row;
 
     &__footer {
         font-size: $list-row-footer-font-size;
-        line-height: $list-row-footer-line-height;
-        padding-top: $list-row-footer-padding-top;
-        padding-bottom: $list-row-footer-padding-bottom;
+        line-height: rem($list-row-footer-line-height);
+        padding-top: rem($list-row-footer-padding-top);
+        padding-bottom: rem($list-row-footer-padding-bottom);
 
         p {
-            margin: 0 0 $list-row-footer-padding-bottom;
+            margin: 0 0 rem($list-row-footer-padding-bottom);
         }
     }
 

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -6,6 +6,10 @@ $component: #{$prefix}-list-row;
     padding: 0 $list-row-padding-horizontal;
     box-sizing: border-box;
 
+    &:hover {
+        background-color: $c-row-bg-hover;
+    }
+
     // --------------------
     //  Elements
     // --------------------
@@ -13,7 +17,6 @@ $component: #{$prefix}-list-row;
         display: flex;
         align-items: flex-start;
         padding: $list-row-padding-vertical 0;
-        // border-bottom: 1px solid $c-divider-row;
         box-shadow: inset 0 -1px 0 $c-divider-row;
 
         // Styles inside List
@@ -45,7 +48,7 @@ $component: #{$prefix}-list-row;
     //  Modifiers
     // --------------------
     &--highlight {
-        background-color: $c-row-bg-highlight;
+        background-color: $c-row-bg-highlight !important;
         color: $c-white;
     }
 }

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -51,4 +51,15 @@ $component: #{$prefix}-list-row;
         background-color: $c-row-bg-highlight !important;
         color: $c-white;
     }
+
+    // --------------------
+    //  In other component
+    // --------------------
+    .#{$prefix}-list--setting & {
+        &:last-of-type {
+            .#{$component}__body {
+                box-shadow: none;
+            }
+        }
+    }
 }

--- a/packages/core/src/styles/Text.scss
+++ b/packages/core/src/styles/Text.scss
@@ -38,7 +38,8 @@
         font-size: rem($aside-text-font-size);
         line-height: rem($aside-text-line-height);
 
-        .#{$prefix}-state-error & {
+        .#{$prefix}-state-error &,
+        .#{$prefix}-list-row--highlight & {
             color: inherit;
         }
     }

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -34,8 +34,6 @@ $component-padding: 4px;
 $element-base-height: 32px;
 $row-base-height: 48px;
 
-$header-padding: 4px;
-
 // ----------------------
 //  <Text>
 // ----------------------
@@ -43,8 +41,6 @@ $basic-text-font-size: $font-size-large;
 $basic-text-line-height: $line-height-large;
 $aside-text-font-size: $font-size-base;
 $aside-text-line-height: $line-height-base;
-
-$header-padding: 4px;
 
 $tag-font-size: $font-size-small;
 $tag-border-radius: 6px;
@@ -82,6 +78,8 @@ $list-row-footer-padding-top: 2px;
 $list-row-footer-padding-bottom: 8px;
 $list-row-footer-font-size: $font-size-small;
 $list-row-footer-line-height: $line-height-small;
+
+$header-row-padding: 4px;
 
 $column-body-padding: 16px;
 

--- a/packages/storybook/examples/List/NormalList.js
+++ b/packages/storybook/examples/List/NormalList.js
@@ -28,7 +28,10 @@ function NormalList() {
                 </ListRow>
 
                 <ListRow highlight>
-                    <TextLabel icon="tickets" basic="Highlighted row" />
+                    <TextLabel
+                        icon="tickets"
+                        basic="Highlighted row"
+                        aside="Component aside" />
                 </ListRow>
                 <ListRow>
                     <TextLabel icon="tickets" basic="Row 3" />


### PR DESCRIPTION
### Purpose
Fix styles that does not match design spec.
Fixes #100.

### Implement
- [Core] Fix aside label for `<Text>` should turn white inside a highlighted `<ListRow>`.
- [Core] Adds hover background for `<ListRow>`.
- [Core] Fix vertical padding for `<HeaderRow>`.

### Screenshot
<img width="504" alt="2017-10-26 9 08 13" src="https://user-images.githubusercontent.com/365035/32030407-4cdaba48-ba2d-11e7-9848-2a9845e13ce6.png">
