### PR TITLE
[form] Add <SelectRow>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Fix aside label for `<Text>` should turn white inside a highlighted `<ListRow>`. (#104)
 - [Core] Adds hover background for `<ListRow>`. (#104)
 - [Core] Fix vertical padding for `<HeaderRow>`. (#104)
+- [Form] Add `<SelectRow>` which lets user to pick options from a `<SelectList>` rendered inside a `<Popover>`. (#107)
 
 ## [1.3.0]
 ### Added

--- a/packages/core/src/mixins/__tests__/anchored.test.js
+++ b/packages/core/src/mixins/__tests__/anchored.test.js
@@ -178,9 +178,7 @@ it('aligns to the right side of anchor if space is not enough on right side', ()
     expect(boxWrapper.prop('style').left)
         // Viewport width - anchor right offset - box width
         .toBe(920);
-    expect(boxWrapper.find(Box).prop('arrowStyle').left)
-        // anchor center x - box left
-        .toBe(90);
+    expect(boxWrapper.find(Box).prop('arrowStyle').left).toBeUndefined();
 });
 
 it('aligns to the left side of anchor if space is not enough on left side', () => {
@@ -193,9 +191,7 @@ it('aligns to the left side of anchor if space is not enough on left side', () =
     expect(boxWrapper.prop('style').left)
         // anchor left
         .toBe(10);
-    expect(boxWrapper.find(Box).prop('arrowStyle').left)
-        // anchor size / 2
-        .toBe(10);
+    expect(boxWrapper.find(Box).prop('arrowStyle').left).toBeUndefined();
 });
 
 it('can take an HTMLElement as anchor', () => {

--- a/packages/core/src/mixins/__tests__/anchored.test.js
+++ b/packages/core/src/mixins/__tests__/anchored.test.js
@@ -178,7 +178,9 @@ it('aligns to the right side of anchor if space is not enough on right side', ()
     expect(boxWrapper.prop('style').left)
         // Viewport width - anchor right offset - box width
         .toBe(920);
-    expect(boxWrapper.find(Box).prop('arrowStyle').left).toBeUndefined();
+    expect(boxWrapper.find(Box).prop('arrowStyle').left)
+        // box width - edge padding
+        .toBe(84);
 });
 
 it('aligns to the left side of anchor if space is not enough on left side', () => {
@@ -191,7 +193,9 @@ it('aligns to the left side of anchor if space is not enough on left side', () =
     expect(boxWrapper.prop('style').left)
         // anchor left
         .toBe(10);
-    expect(boxWrapper.find(Box).prop('arrowStyle').left).toBeUndefined();
+    expect(boxWrapper.find(Box).prop('arrowStyle').left)
+        // edge padding
+        .toBe(16);
 });
 
 it('can take an HTMLElement as anchor', () => {

--- a/packages/core/src/mixins/anchored.js
+++ b/packages/core/src/mixins/anchored.js
@@ -194,7 +194,8 @@ const anchored = ({
             const hasSpaceOnLeft = anchorRect.left >= selfHalfWidth;
             const hasSpaceOnRight = (window.innerWidth - anchorRect.right) >= selfHalfWidth;
 
-            const arrowSafeAreaWidth = selfRect.width - (edgePadding * 2);
+            const arrowSafeAreaLeft = edgePadding;
+            const arrowSafeAreaRight = selfRect.width - edgePadding;
 
             switch (true) {
                 // Center-aligned
@@ -219,9 +220,12 @@ const anchored = ({
             }
 
             // Calibrate arrow position so it stays in safe area
-            if (nextState.arrowPosition.left < edgePadding
-                || nextState.arrowPosition.left > arrowSafeAreaWidth) {
-                delete nextState.arrowPosition;
+            if (nextState.arrowPosition.left < arrowSafeAreaLeft) {
+                nextState.arrowPosition.left = arrowSafeAreaLeft;
+            }
+
+            if (nextState.arrowPosition.left > arrowSafeAreaRight) {
+                nextState.arrowPosition.left = arrowSafeAreaRight;
             }
 
             this.setState(nextState);

--- a/packages/core/src/mixins/anchored.js
+++ b/packages/core/src/mixins/anchored.js
@@ -207,24 +207,21 @@ const anchored = ({
                     nextState.position.left =
                         anchorOffset.left + anchorRect.width - selfRect.width;
 
-                    // Calibrate arrow position to stay in safe area
-                    nextState.arrowPosition.left = Math.max(
-                        // anchorOffset.left - nextState.position.left + anchorHalfWidth
-                        selfRect.width - anchorHalfWidth,
-                        edgePadding
-                    );
+                    // anchorOffset.left - nextState.position.left + anchorHalfWidth
+                    nextState.arrowPosition.left = selfRect.width - anchorHalfWidth;
                     break;
 
                 // Left-align to the anchor
                 default:
                     nextState.position.left = anchorOffset.left;
-
-                    // Calibrate arrow position to stay in safe area
-                    nextState.arrowPosition.left = Math.min(
-                        anchorHalfWidth,
-                        arrowSafeAreaWidth
-                    );
+                    nextState.arrowPosition.left = anchorHalfWidth;
                     break;
+            }
+
+            // Calibrate arrow position so it stays in safe area
+            if (nextState.arrowPosition.left < edgePadding
+                || nextState.arrowPosition.left > arrowSafeAreaWidth) {
+                delete nextState.arrowPosition;
             }
 
             this.setState(nextState);

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -37,6 +37,7 @@ const closable = ({
 
         state = {
             closeDelayTimeout: null,
+            clickedInside: false,
         };
 
         componentDidMount() {
@@ -92,31 +93,41 @@ const closable = ({
         }
 
         handleDocumentClick = () => {
+            if (this.state.clickedInside) {
+                this.setState({ clickedInside: false });
+                return;
+            }
+
             if (onClickOutside) {
                 this.props.onClose();
             }
         }
 
-        // Trigger `onClose()` call on any touch if turned on in options.
         handleDocumentTouch = (event) => {
+            if (this.state.clickedInside) {
+                this.setState({ clickedInside: false });
+                return;
+            }
+
             if (onClickOutside) {
                 this.delayedClose(event);
             }
         }
 
         handleInsideClick = (event) => {
+            this.setState({ clickedInside: true });
+
             if (onClickInside) {
                 this.props.onClose(event);
             }
-            // Stop event from bubbling up so the listeners at document won't hear.
-            event.stopPropagation();
         }
 
         handleInsideTouch = (event) => {
+            this.setState({ clickedInside: true });
+
             if (onClickInside) {
                 this.delayedClose(event);
             }
-            event.stopPropagation();
         }
 
         render() {

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -85,7 +85,14 @@ const closable = ({
             this.nodeRef = node;
         }
 
-        // Trigger `onClose()` call on Escape keyup if turned on in options.
+        handleDocumentClickOrTouch(callback) {
+            if (this.state.clickedInside) {
+                this.setState({ clickedInside: false });
+                return;
+            }
+            callback();
+        }
+
         handleDocumentKeyup = (event) => {
             if (onEscape && event.keyCode === keycode(ESCAPE)) {
                 this.props.onClose(event);
@@ -93,25 +100,19 @@ const closable = ({
         }
 
         handleDocumentClick = () => {
-            if (this.state.clickedInside) {
-                this.setState({ clickedInside: false });
-                return;
-            }
-
-            if (onClickOutside) {
-                this.props.onClose();
-            }
+            this.handleDocumentClickOrTouch(() => {
+                if (onClickOutside) {
+                    this.props.onClose();
+                }
+            });
         }
 
         handleDocumentTouch = (event) => {
-            if (this.state.clickedInside) {
-                this.setState({ clickedInside: false });
-                return;
-            }
-
-            if (onClickOutside) {
-                this.delayedClose(event);
-            }
+            this.handleDocumentClickOrTouch(() => {
+                if (onClickOutside) {
+                    this.delayedClose(event);
+                }
+            });
         }
 
         handleInsideClick = (event) => {

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -9,6 +9,7 @@ $component-name: #{$prefix}-popover;
     border-radius: $popover-border-radius;
     filter: drop-shadow($popover-drop-shadow);
     position: relative;
+    z-index: z(popover);
 
     // Elements
     &__arrow {

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -20,7 +20,7 @@ import SelectList from './SelectList';
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
 
-const Popover = renderToLayer(
+export const Popover = renderToLayer(
     closable({
         onEscape: true,
         onClickOutside: true,

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -96,10 +96,12 @@ class SelectRow extends PureComponent {
             <ListRow className={wrapperClassName} {...rowProps}>
                 <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
-                        ref={(ref) => { this.anchorNode = ref; }}
                         bold={!ineditable}
                         basic={label} />
-                    <Icon type="unfold" />
+
+                    <span ref={(ref) => { this.anchorNode = ref; }}>
+                        <Icon type="unfold" />
+                    </span>
 
                     {popoverOpen && this.renderPopover(selectListProps)}
                 </Content>

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -1,0 +1,62 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import {
+    ListRow,
+    Button,
+    Icon,
+    Text,
+    TextLabel,
+} from '@ichef/gypcrete';
+
+import formRow, { rowPropTypes } from './mixins/formRow';
+import './styles/SelectRow.scss';
+
+class SelectRow extends PureComponent {
+    static propTypes = {
+        label: PropTypes.node.isRequired,
+        disabled: PropTypes.bool,
+        // from formRow()
+        ineditable: PropTypes.bool,
+        rowProps: rowPropTypes,
+    };
+
+    static defaultProps = {
+        disabled: false,
+        ineditable: false,
+        rowProps: {},
+    };
+
+    render() {
+        const {
+            label,
+            disabled,
+            // from formRow()
+            ineditable,
+            rowProps,
+            // React props
+            className,
+        } = this.props;
+
+        const Content = ineditable ? TextLabel : Button;
+        const wrapperClassName = classNames(
+            'gyp-form-select',
+            className,
+        );
+
+        return (
+            <ListRow className={wrapperClassName} {...rowProps}>
+                <Content minified={false} disabled={disabled}>
+                    <Text
+                        bold={!ineditable}
+                        basic={label} />
+                    <Icon type="unfold" />
+                </Content>
+            </ListRow>
+        );
+    }
+}
+
+export { SelectRow as PureSelectRow };
+export default formRow()(SelectRow);

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
-    Checkbox,
-    List,
     ListRow,
     Button,
     Icon,
@@ -13,17 +11,24 @@ import {
 } from '@ichef/gypcrete';
 
 import { PurePopover } from '@ichef/gypcrete/lib/Popover';
+import anchored from '@ichef/gypcrete/lib/mixins/anchored';
 import closable from '@ichef/gypcrete/lib/mixins/closable';
+import renderToLayer from '@ichef/gypcrete/lib/mixins/renderToLayer';
 
 import SelectList from './SelectList';
 
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
 
-const Popover = closable({
-    onEscape: true,
-    onClickOutside: true,
-})(PurePopover);
+const Popover = renderToLayer(
+    closable({
+        onEscape: true,
+        onClickOutside: true,
+        onClickInside: false,
+    })(
+        anchored()(PurePopover)
+    )
+);
 
 class SelectRow extends PureComponent {
     static propTypes = {
@@ -55,6 +60,7 @@ class SelectRow extends PureComponent {
     renderPopover(selectListProps) {
         return (
             <Popover
+                anchor={this.anchorNode}
                 onClose={this.handlePopoverClose}>
                 <SelectList
                     onChange={this.handleSelectChange}
@@ -90,6 +96,7 @@ class SelectRow extends PureComponent {
             <ListRow className={wrapperClassName} {...rowProps}>
                 <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
+                        ref={(ref) => { this.anchorNode = ref; }}
                         bold={!ineditable}
                         basic={label} />
                     <Icon type="unfold" />

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -14,11 +14,20 @@ import { PurePopover } from '@ichef/gypcrete/lib/Popover';
 import anchored from '@ichef/gypcrete/lib/mixins/anchored';
 import closable from '@ichef/gypcrete/lib/mixins/closable';
 import renderToLayer from '@ichef/gypcrete/lib/mixins/renderToLayer';
+import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
+import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
 
 import SelectList from './SelectList';
 
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
+
+export const COMPONENT_NAME = prefixClass('form-select');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    popover: ROOT_BEM.element('popover'),
+};
 
 export const Popover = renderToLayer(
     closable({
@@ -61,6 +70,7 @@ class SelectRow extends PureComponent {
         return (
             <Popover
                 anchor={this.anchorNode}
+                className={BEM.popover.toString()}
                 onClose={this.handlePopoverClose}>
                 <SelectList
                     onChange={this.handleSelectChange}
@@ -83,7 +93,7 @@ class SelectRow extends PureComponent {
         const { popoverOpen } = this.state;
 
         const wrapperClassName = classNames(
-            'gyp-form-select',
+            COMPONENT_NAME,
             className,
         );
 

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
+    Checkbox,
+    List,
     ListRow,
     Button,
     Icon,
@@ -10,8 +12,16 @@ import {
     TextLabel,
 } from '@ichef/gypcrete';
 
+import { PurePopover } from '@ichef/gypcrete/lib/Popover';
+
+import closable from '@ichef/gypcrete/lib/mixins/closable';
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
+
+const Popover = closable({
+    onEscape: true,
+    onClickOutside: true,
+})(PurePopover);
 
 class SelectRow extends PureComponent {
     static propTypes = {
@@ -28,6 +38,31 @@ class SelectRow extends PureComponent {
         rowProps: {},
     };
 
+    state = {
+        popoverOpen: false,
+    };
+
+    handleButtonClick = () => {
+        this.setState({ popoverOpen: true });
+    }
+
+    handlePopoverClose = () => {
+        this.setState({ popoverOpen: false });
+    }
+
+    renderPopover() {
+        return (
+            <Popover
+                onClose={this.handlePopoverClose}>
+                <List>
+                    <ListRow>
+                        <Checkbox basic="Hello World" />
+                    </ListRow>
+                </List>
+            </Popover>
+        );
+    }
+
     render() {
         const {
             label,
@@ -38,20 +73,26 @@ class SelectRow extends PureComponent {
             // React props
             className,
         } = this.props;
+        const { popoverOpen } = this.state;
 
-        const Content = ineditable ? TextLabel : Button;
         const wrapperClassName = classNames(
             'gyp-form-select',
             className,
         );
 
+        const Content = ineditable ? TextLabel : Button;
+        const contentProps = ineditable ? {} : {
+            onClick: this.handleButtonClick,
+        };
+
         return (
             <ListRow className={wrapperClassName} {...rowProps}>
-                <Content minified={false} disabled={disabled}>
+                <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
                         bold={!ineditable}
                         basic={label} />
                     <Icon type="unfold" />
+                    {popoverOpen && this.renderPopover()}
                 </Content>
             </ListRow>
         );

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -13,8 +13,10 @@ import {
 } from '@ichef/gypcrete';
 
 import { PurePopover } from '@ichef/gypcrete/lib/Popover';
-
 import closable from '@ichef/gypcrete/lib/mixins/closable';
+
+import SelectList from './SelectList';
+
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
 
@@ -50,15 +52,13 @@ class SelectRow extends PureComponent {
         this.setState({ popoverOpen: false });
     }
 
-    renderPopover() {
+    renderPopover(selectListProps) {
         return (
             <Popover
                 onClose={this.handlePopoverClose}>
-                <List>
-                    <ListRow>
-                        <Checkbox basic="Hello World" />
-                    </ListRow>
-                </List>
+                <SelectList
+                    onChange={this.handleSelectChange}
+                    {...selectListProps} />
             </Popover>
         );
     }
@@ -72,6 +72,7 @@ class SelectRow extends PureComponent {
             rowProps,
             // React props
             className,
+            ...selectListProps,
         } = this.props;
         const { popoverOpen } = this.state;
 
@@ -92,7 +93,8 @@ class SelectRow extends PureComponent {
                         bold={!ineditable}
                         basic={label} />
                     <Icon type="unfold" />
-                    {popoverOpen && this.renderPopover()}
+
+                    {popoverOpen && this.renderPopover(selectListProps)}
                 </Content>
             </ListRow>
         );

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import {
+    Button,
+    Text,
+    TextLabel,
+} from '@ichef/gypcrete';
+
+import SelectRow, { PureSelectRow, Popover } from '../SelectRow';
+import SelectList from '../SelectList';
+import Option from '../SelectOption';
+
+describe('formRow(SelectRow)', () => {
+    it('renders without crashing', () => {
+        const div = document.createElement('div');
+        const element = (
+            <SelectRow label="Select">
+                <Option label="Option A" value="a" />
+                <Option label="Option B" value="b" />
+                <Option label="Option C" value="c" />
+            </SelectRow>
+        );
+
+        ReactDOM.render(element, div);
+    });
+});
+
+describe('Pure <SelectRow>', () => {
+    it('renders a <Button> if the row is editable', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" />
+        );
+
+        expect(wrapper.find(Button).exists()).toBeTruthy();
+        expect(wrapper.find(TextLabel).exists()).toBeFalsy();
+    });
+
+    it('renders a <TextLabel> if the row is not editable', () => {
+        const wrapper = shallow(
+            <PureSelectRow ineditable label="Select" />
+        );
+
+        expect(wrapper.find(Button).exists()).toBeFalsy();
+        expect(wrapper.find(TextLabel).exists()).toBeTruthy();
+    });
+
+    it('renders an anchored <Popover> with a <SelectList> when click on <Button>', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" />
+        );
+        expect(wrapper.find(Popover).exists()).toBeFalsy();
+        expect(wrapper.state('popoverOpen')).toBeFalsy();
+
+        expect(wrapper.find(Button).simulate('click'));
+        expect(wrapper.find(Popover).exists()).toBeTruthy();
+        expect(wrapper.state('popoverOpen')).toBeTruthy();
+
+        expect(wrapper.find(Popover).find(SelectList).exists()).toBeTruthy();
+    });
+
+    it('removed <Popover> when it requests close', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" />
+        );
+        wrapper.setState({ popoverOpen: true });
+        expect(wrapper.find(Popover).exists()).toBeTruthy();
+
+        wrapper.find(Popover).simulate('close');
+        wrapper.setState({ popoverOpen: false });
+        expect(wrapper.find(Popover).exists()).toBeFalsy();
+    });
+
+    it('passes children to <SelectList> inside <Popover>', () => {
+        const element = (
+            <PureSelectRow label="Select">
+                <Option label="foo" />
+            </PureSelectRow>
+        );
+        const wrapper = shallow(element);
+        wrapper.setState({ popoverOpen: true });
+
+        expect(element.props.children)
+            .toEqual(wrapper.find(SelectList).prop('children'));
+    });
+});

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme';
 
 import {
     Button,
-    Text,
     TextLabel,
 } from '@ichef/gypcrete';
 

--- a/packages/form/src/styles/SelectRow.scss
+++ b/packages/form/src/styles/SelectRow.scss
@@ -8,10 +8,4 @@ $componenet-name: gyp-form-select;
     .gyp-button {
         color: inherit;
     }
-
-    .gyp-popover {
-        left: 0;
-        top: 100%;
-        position: absolute;
-    }
 }

--- a/packages/form/src/styles/SelectRow.scss
+++ b/packages/form/src/styles/SelectRow.scss
@@ -1,7 +1,17 @@
 $componenet-name: gyp-form-select;
 
 .#{$componenet-name} {
+    .gyp-list-row__body {
+        position: relative;
+    }
+
     .gyp-button {
         color: inherit;
+    }
+
+    .gyp-popover {
+        left: 0;
+        top: 100%;
+        position: absolute;
     }
 }

--- a/packages/form/src/styles/SelectRow.scss
+++ b/packages/form/src/styles/SelectRow.scss
@@ -1,0 +1,7 @@
+$componenet-name: gyp-form-select;
+
+.#{$componenet-name} {
+    .gyp-button {
+        color: inherit;
+    }
+}

--- a/packages/form/src/styles/SelectRow.scss
+++ b/packages/form/src/styles/SelectRow.scss
@@ -1,6 +1,12 @@
 $componenet-name: gyp-form-select;
 
 .#{$componenet-name} {
+    &__popover {
+        .gyp-popover__arrow {
+            left: 50% !important;
+        }
+    }
+
     .gyp-list-row__body {
         position: relative;
     }

--- a/packages/storybook/examples/Form.SelectRow/BasicUsage.js
+++ b/packages/storybook/examples/Form.SelectRow/BasicUsage.js
@@ -1,35 +1,38 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 import List from '@ichef/gypcrete/src/List';
 import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
 import Option from '@ichef/gypcrete-form/src/SelectOption';
-
-const DESC = `
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    Nunc risus risus, gravida in nisl ac, iaculis aliquam dui.
-    Nunc dictum ipsum eu sapien lacinia, eu finibus nibh vestibulum.
-`;
 
 function BasicUsage() {
     return (
         <List title="Switch rows">
             <SelectRow
                 label="Module default state on iPad"
-                desc={DESC}
-                defaultValues={['0']}>
-                <Option label="Yes" value="1" />
-                <Option label="No" value="0" />
+                desc="Default is off"
+                defaultValues={['no']}
+                onChange={action('change')}>
+                <Option label="Yes" value="yes" />
+                <Option label="No" value="no" />
             </SelectRow>
 
             <SelectRow
                 disabled
-                label="Disabled row" />
+                label="Disabled row">
+                <Option label="Yes" value="yes" />
+                <Option label="No" value="no" />
+            </SelectRow>
 
             <SelectRow
                 checked
                 label="World peace"
                 status="error"
-                errorMsg="Cannot declare a war." />
+                errorMsg="Cannot declare a war."
+                values={['peace']}>
+                <Option label="Peace" value="peace" />
+                <Option label="War" value="war" />
+            </SelectRow>
         </List>
     );
 }

--- a/packages/storybook/examples/Form.SelectRow/BasicUsage.js
+++ b/packages/storybook/examples/Form.SelectRow/BasicUsage.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import List from '@ichef/gypcrete/src/List';
 import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+import Option from '@ichef/gypcrete-form/src/SelectOption';
 
 const DESC = `
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -14,7 +15,11 @@ function BasicUsage() {
         <List title="Switch rows">
             <SelectRow
                 label="Module default state on iPad"
-                desc={DESC} />
+                desc={DESC}
+                defaultValues={['0']}>
+                <Option label="Yes" value="1" />
+                <Option label="No" value="0" />
+            </SelectRow>
 
             <SelectRow
                 disabled

--- a/packages/storybook/examples/Form.SelectRow/BasicUsage.js
+++ b/packages/storybook/examples/Form.SelectRow/BasicUsage.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import List from '@ichef/gypcrete/src/List';
+import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+
+const DESC = `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nunc risus risus, gravida in nisl ac, iaculis aliquam dui.
+    Nunc dictum ipsum eu sapien lacinia, eu finibus nibh vestibulum.
+`;
+
+function BasicUsage() {
+    return (
+        <List title="Switch rows">
+            <SelectRow
+                label="Module default state on iPad"
+                desc={DESC} />
+
+            <SelectRow
+                disabled
+                label="Disabled row" />
+
+            <SelectRow
+                checked
+                label="World peace"
+                status="error"
+                errorMsg="Cannot declare a war." />
+        </List>
+    );
+}
+
+export default BasicUsage;

--- a/packages/storybook/examples/Form.SelectRow/index.js
+++ b/packages/storybook/examples/Form.SelectRow/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+// For props table
+import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+
+import BasicUsage from './BasicUsage';
+
+storiesOf('[Form] SelectRow', module)
+    .add('basic usage', withInfo()(BasicUsage))
+    // Props table
+    .addPropsTable(() => <SelectRow />);


### PR DESCRIPTION
### Purpose
Add a row-based component which lets you to pick options from a `<SelectList>` rendered inside a `<Popover>`

### Implement
- Add new `<SelectRow>`, which takes `<SelectOption>` as children and renders `<SelectList>` inside a popover when user clicks on the row.

### Screenshot
![2017-10-26 2 16 06](https://user-images.githubusercontent.com/365035/32038686-aeafbe18-b9f0-11e7-960b-048a6ba43f3f.png)
