### PR TITLE
Fix bundled CSS reading fonts from 'fonts/fonts/' path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- N/A
+### Fixed
+- Fixed CSS bundle requesting font files from broken path. (#108)
 
 ## [1.3.1]
 ### Changed

--- a/packages/core/configs/webpack.dist.js
+++ b/packages/core/configs/webpack.dist.js
@@ -62,8 +62,7 @@ module.exports = {
                         loader: 'file-loader',
                         options: {
                             name: '[name]-[hash:6].[ext]',
-                            outputPath: 'fonts/',
-                            publicPath: 'fonts/'
+                            outputPath: 'fonts/'
                         }
                     }
                 ]

--- a/packages/form/configs/webpack.dist.js
+++ b/packages/form/configs/webpack.dist.js
@@ -62,8 +62,7 @@ module.exports = {
                         loader: 'file-loader',
                         options: {
                             name: '[name]-[hash:6].[ext]',
-                            outputPath: 'fonts/',
-                            publicPath: 'fonts/'
+                            outputPath: 'fonts/'
                         }
                     }
                 ]


### PR DESCRIPTION
The CSS bundle generated by v1.3.1 has broken path for font files, pointing to non-existing `fonts/fonts/`.

This fixes the double-fonts issue by removing `publicPath` from webpack config.