### PR TITLE
Publish canary builds with exact package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "lerna run storybook --stream",
     "bumpversion": "lerna publish -m \"Bump version to %s\" --skip-npm",
     "release": "lerna publish --yes --repo-version $PACKAGE_VERSION --skip-git",
-    "canary": "lerna publish -c --yes",
+    "canary": "lerna publish -c --yes --exact",
     "ghpages": "lerna run ghpages",
     "lint": "npm run lint:eslint && npm run lint:stylelint",
     "lint:eslint": "eslint ./packages --ignore-path=configs/.eslintignore ./ && echo \"eslint: no lint errors\"",


### PR DESCRIPTION
When publishing canary builds, by default Lerna uses carets on package versions.
This means the dependency version will be something like `^1.4.0-alpha.758a88c0`
However the caret here may have npm/yarn resolve to an older version, because npm cannot compare git hashes.

This PR set package version to exactly the same version on canary builds, so you don't get incompatible versions.