### PR TITLE
Add values display for <SelectRow>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Changed
+### Added
 - Add transition to text in `<TextInputRow>` when being focused.
+
+### Changed
+- `<SelectList>` now passes sorted values via `onChange()`
+- `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
+- Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
+- Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
 
 ### Fixed
 - Fix input inside `<TextInputRow>` should take up whole space.

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -7,6 +7,7 @@ import {
 } from '@ichef/gypcrete';
 
 import Option, { valueType } from './SelectOption';
+import parseSelectOptions from './utils/parseSelectOptions';
 
 function getInitialCheckedState(fromValues) {
     const checkedState = new ImmutableMap();
@@ -85,15 +86,7 @@ class SelectList extends PureComponent {
     }
 
     getOptions(fromProps = this.props) {
-        const options = [];
-
-        fromProps.children.forEach((child) => {
-            if (child && child.type === Option) {
-                options.push(child.props);
-            }
-        });
-
-        return options;
+        return parseSelectOptions(fromProps.children);
     }
 
     getValues(fromCheckedState = this.state.checkedState) {

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -90,10 +90,11 @@ class SelectList extends PureComponent {
     }
 
     getValues(fromCheckedState = this.state.checkedState) {
-        return fromCheckedState
-            .filter(optionValue => optionValue) // all the checked values
-            .keySeq()
-            .toArray();
+        const allOptions = this.getOptions();
+
+        return allOptions
+            .filter(option => fromCheckedState.get(option.value))
+            .map(option => option.value);
     }
 
     handleChange(nextCheckedState) {

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -19,6 +19,7 @@ import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
 
 import SelectList from './SelectList';
 
+import parseSelectOptions from './utils/parseSelectOptions';
 import formRow, { rowPropTypes } from './mixins/formRow';
 import './styles/SelectRow.scss';
 
@@ -39,6 +40,22 @@ export const Popover = renderToLayer(
     )
 );
 
+/**
+ * Generate a value-label map from all `<SelectOption>`s.
+ *
+ * @param {array} fromOptions
+ * @return {Map}
+ */
+function getValueLabelMap(fromChildren = []) {
+    const resultMap = new Map();
+    const options = parseSelectOptions(fromChildren);
+
+    options.forEach(
+        option => resultMap.set(option.value, option.label)
+    );
+    return resultMap;
+}
+
 class SelectRow extends PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
@@ -56,7 +73,14 @@ class SelectRow extends PureComponent {
 
     state = {
         popoverOpen: false,
+        valueLabelMap: getValueLabelMap(this.props.children),
     };
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({
+            valueLabelMap: getValueLabelMap(nextProps.children),
+        });
+    }
 
     handleButtonClick = () => {
         this.setState({ popoverOpen: true });

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -59,6 +59,9 @@ function getValueLabelMap(fromChildren = []) {
 class SelectRow extends PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
+        asideAll: PropTypes.string,
+        asideNone: PropTypes.string,
+        asideSeparator: PropTypes.string,
         disabled: PropTypes.bool,
         // <SelectList> props
         values: SelectList.propTypes.values,
@@ -70,6 +73,9 @@ class SelectRow extends PureComponent {
     };
 
     static defaultProps = {
+        asideAll: 'All',
+        asideNone: '(Unset)',
+        asideSeparator: ', ',
         disabled: false,
         // <SelectList> props
         values: SelectList.defaultProps.values,
@@ -128,6 +134,24 @@ class SelectRow extends PureComponent {
         );
     }
 
+    renderRowValuesAside() {
+        const { asideAll, asideNone, asideSeparator } = this.props;
+        const { cachedValues, valueLabelMap } = this.state;
+
+        // Can turn off 'All' display by passing `null`.
+        if (asideAll && cachedValues.length === valueLabelMap.size) {
+            return asideAll;
+        }
+
+        if (cachedValues.length === 0) {
+            return asideNone;
+        }
+
+        return cachedValues
+            .map(value => valueLabelMap.get(value))
+            .join(asideSeparator);
+    }
+
     render() {
         const {
             label,
@@ -160,7 +184,8 @@ class SelectRow extends PureComponent {
                 <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
                         bold={!ineditable}
-                        basic={label} />
+                        basic={label}
+                        aside={this.renderRowValuesAside()} />
 
                     <span ref={(ref) => { this.anchorNode = ref; }}>
                         <Icon type="unfold" />

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -81,6 +81,7 @@ class SelectRow extends PureComponent {
         values: SelectList.defaultProps.values,
         defaultValues: SelectList.defaultProps.defaultValues,
         onChange: () => {},
+        // from formRow()
         ineditable: false,
         rowProps: {},
     };

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -60,6 +60,10 @@ class SelectRow extends PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
         disabled: PropTypes.bool,
+        // <SelectList> props
+        values: SelectList.propTypes.values,
+        defaultValues: SelectList.propTypes.defaultValues,
+        onChange: PropTypes.func,
         // from formRow()
         ineditable: PropTypes.bool,
         rowProps: rowPropTypes,
@@ -67,6 +71,10 @@ class SelectRow extends PureComponent {
 
     static defaultProps = {
         disabled: false,
+        // <SelectList> props
+        values: SelectList.defaultProps.values,
+        defaultValues: SelectList.defaultProps.defaultValues,
+        onChange: () => {},
         ineditable: false,
         rowProps: {},
     };
@@ -74,12 +82,21 @@ class SelectRow extends PureComponent {
     state = {
         popoverOpen: false,
         valueLabelMap: getValueLabelMap(this.props.children),
+        cachedValues: this.props.values || this.props.defaultValues,
     };
 
     componentWillReceiveProps(nextProps) {
         this.setState({
             valueLabelMap: getValueLabelMap(nextProps.children),
         });
+
+        if (this.getIsControlled(nextProps)) {
+            this.setState({ cachedValues: nextProps.values });
+        }
+    }
+
+    getIsControlled(fromProps = this.props) {
+        return Array.isArray(fromProps.values);
     }
 
     handleButtonClick = () => {
@@ -90,6 +107,13 @@ class SelectRow extends PureComponent {
         this.setState({ popoverOpen: false });
     }
 
+    handleSelectChange = (newValues) => {
+        if (!this.getIsControlled()) {
+            this.setState({ cachedValues: newValues });
+        }
+        this.props.onChange(newValues);
+    }
+
     renderPopover(selectListProps) {
         return (
             <Popover
@@ -97,6 +121,7 @@ class SelectRow extends PureComponent {
                 className={BEM.popover.toString()}
                 onClose={this.handlePopoverClose}>
                 <SelectList
+                    values={this.state.cachedValues}
                     onChange={this.handleSelectChange}
                     {...selectListProps} />
             </Popover>
@@ -107,6 +132,10 @@ class SelectRow extends PureComponent {
         const {
             label,
             disabled,
+            // <ListRow> props (intercepted from it)
+            values,
+            defaultValues,
+            onChange,
             // from formRow()
             ineditable,
             rowProps,

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -137,24 +137,28 @@ describe('Multiple response mode', () => {
         expect(wrapper.find(Option).at(0).prop('label')).toBe('Check All');
     });
 
-    it('triggers onChange with multiple values', () => {
+    it('triggers onChange with sorted values', () => {
         const handleChange = jest.fn();
         const wrapper = shallow(
             <SelectList multiple onChange={handleChange}>
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
+                <Option label="Meh" value="meh" />
             </SelectList>
         );
         expect(handleChange).not.toHaveBeenCalled();
 
-        wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
-        expect(handleChange).toHaveBeenLastCalledWith(['foo']);
+        wrapper.find('SelectOption[value="meh"]').simulate('change', 'meh', true);
+        expect(handleChange).toHaveBeenLastCalledWith(['meh']);
 
         wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-        expect(handleChange).toHaveBeenLastCalledWith(['foo', 'bar']);
+        expect(handleChange).toHaveBeenLastCalledWith(['bar', 'meh']);
 
-        wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', false);
-        expect(handleChange).toHaveBeenLastCalledWith(['bar']);
+        wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
+        expect(handleChange).toHaveBeenLastCalledWith(['foo', 'bar', 'meh']);
+
+        wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', false);
+        expect(handleChange).toHaveBeenLastCalledWith(['foo', 'meh']);
     });
 
     it('can toggle all options at once', () => {
@@ -223,7 +227,7 @@ describe('Minimum checks limit', () => {
         expect(wrapper.instance().getValues()).toEqual(['foo', 'option3']);
 
         wrapper.find(Option).at(0).simulate('change', null, true);
-        expect(wrapper.instance().getValues()).toEqual(['foo', 'option3', 'bar']);
+        expect(wrapper.instance().getValues()).toEqual(['foo', 'bar', 'option3']);
 
         wrapper.find(Option).at(0).simulate('change', null, false);
         expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 
 import {
     Button,
+    Text,
     TextLabel,
 } from '@ichef/gypcrete';
 
@@ -82,5 +83,114 @@ describe('Pure <SelectRow>', () => {
 
         expect(element.props.children)
             .toEqual(wrapper.find(SelectList).prop('children'));
+    });
+
+    it('caches selected values from <SelectList> when uncontrolled', () => {
+        const wrapper = shallow(
+            <PureSelectRow multiple label="Select" />
+        );
+        wrapper.setState({ popoverOpen: true });
+        expect(wrapper.state('cachedValues')).toEqual([]);
+
+        wrapper.find(SelectList).simulate('change', [1, 2]);
+        expect(wrapper.state('cachedValues')).toEqual([1, 2]);
+    });
+
+    it('does not cache values from <SelectList> when controlled', () => {
+        const wrapper = shallow(
+            <PureSelectRow multiple label="Select" values={[1]} />
+        );
+        wrapper.setState({ popoverOpen: true });
+        expect(wrapper.state('cachedValues')).toEqual([1]);
+
+        wrapper.find(SelectList).simulate('change', [1, 2]);
+        expect(wrapper.state('cachedValues')).toEqual([1]);
+    });
+
+    it('updates cached values from props when controlled', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" values={[1]} />
+        );
+        expect(wrapper.state('cachedValues')).toEqual([1]);
+
+        wrapper.setProps({ values: [1, 2] });
+        expect(wrapper.state('cachedValues')).toEqual([1, 2]);
+    });
+
+    it('does updates cached values from props when uncontrolled', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" defaultValues={[1]} />
+        );
+        expect(wrapper.state('cachedValues')).toEqual([1]);
+
+        wrapper.setProps({ defaultValues: [1, 2] });
+        expect(wrapper.state('cachedValues')).toEqual([1]);
+    });
+
+    it('controls <SelectList> with cached values', () => {
+        const wrapper = shallow(<PureSelectRow label="Select" />);
+        wrapper.setState({
+            cachedValues: [1],
+            popoverOpen: true,
+        });
+        expect(wrapper.find(SelectList).prop('values')).toEqual([1]);
+
+        wrapper.setState({ cachedValues: [1, 2, 3] });
+        expect(wrapper.find(SelectList).prop('values')).toEqual([1, 2, 3]);
+    });
+
+    it('renders current values on aside', () => {
+        const wrapper = shallow(
+            <PureSelectRow multiple label="Select" values={[]}>
+                <Option label="Foo" value="foo" />
+                <Option label="Bar" value="bar" />
+                <Option label="Meh" value="meh" />
+            </PureSelectRow>
+        );
+        expect(wrapper.find(Text).prop('aside')).toBe('(Unset)');
+
+        wrapper.setProps({ values: ['foo', 'bar'] });
+        expect(wrapper.find(Text).prop('aside')).toBe('Foo, Bar');
+
+        wrapper.setProps({ values: ['foo', 'bar', 'meh'] });
+        expect(wrapper.find(Text).prop('aside')).toBe('All');
+    });
+
+    it('can customize aside labels', () => {
+        const wrapper = shallow(
+            <PureSelectRow multiple label="Select" values={[]} asideNone="None">
+                <Option label="Foo" value="foo" />
+                <Option label="Bar" value="bar" />
+                <Option label="Meh" value="meh" />
+            </PureSelectRow>
+        );
+        expect(wrapper.find(Text).prop('aside')).toBe('None');
+
+        wrapper.setProps({
+            values: ['foo', 'bar'],
+            asideSeparator: ' + '
+        });
+        expect(wrapper.find(Text).prop('aside')).toBe('Foo + Bar');
+
+        wrapper.setProps({
+            values: ['foo', 'bar', 'meh'],
+            asideAll: 'Everything'
+        });
+        expect(wrapper.find(Text).prop('aside')).toBe('Everything');
+    });
+
+    it('can disable "All" label by overriding with null', () => {
+        const wrapper = shallow(
+            <PureSelectRow
+                multiple
+                label="Select"
+                asideAll={null}
+                values={['foo', 'bar', 'meh']}>
+                <Option label="Foo" value="foo" />
+                <Option label="Bar" value="bar" />
+                <Option label="Meh" value="meh" />
+            </PureSelectRow>
+        );
+        expect(wrapper.find(Text).prop('aside')).toBe('Foo, Bar, Meh');
     });
 });

--- a/packages/form/src/utils/__tests__/parseSelectOptions.test.js
+++ b/packages/form/src/utils/__tests__/parseSelectOptions.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import SelectOption from 'src/SelectOption';
+import parseSelectOptions from '../parseSelectOptions';
+
+it('reads options from React children of <SelectOption>s', () => {
+    const singleOption = <SelectOption label="Foo" value="foo" />;
+
+    expect(parseSelectOptions(singleOption)).toMatchObject([
+        { label: 'Foo', value: 'foo' },
+    ]);
+
+    const multipleOptions = [
+        <SelectOption label="Foo" value="foo" checked />,
+        <SelectOption label="Bar" value="bar" readOnly />,
+        <SelectOption label="Meh" value="meh" />,
+    ];
+    expect(parseSelectOptions(multipleOptions)).toMatchObject([
+        { label: 'Foo', value: 'foo', checked: true },
+        { label: 'Bar', value: 'bar', readOnly: true },
+        { label: 'Meh', value: 'meh' },
+    ]);
+});
+
+it('ignores children that are not <SelectOption>', () => {
+    const children = [
+        <SelectOption label="Foo" value="foo" />,
+        'Hello World!',
+        <SelectOption label="Bar" value="bar" />
+    ];
+
+    expect(parseSelectOptions(children)).toMatchObject([
+        { label: 'Foo', value: 'foo' },
+        { label: 'Bar', value: 'bar' },
+    ]);
+});

--- a/packages/form/src/utils/__tests__/parseSelectOptions.test.js
+++ b/packages/form/src/utils/__tests__/parseSelectOptions.test.js
@@ -22,6 +22,7 @@ it('reads options from React children of <SelectOption>s', () => {
     ]);
 });
 
+// #TODO: Add warning for children other than <SelectOption>
 it('ignores children that are not <SelectOption>', () => {
     const children = [
         <SelectOption label="Foo" value="foo" />,

--- a/packages/form/src/utils/parseSelectOptions.js
+++ b/packages/form/src/utils/parseSelectOptions.js
@@ -1,15 +1,16 @@
+import { Children } from 'react';
 import SelectOption from '../SelectOption';
 
 /**
  * Convert children of `<SelectOptions>` components to array of options.
  *
- * @param {array} childrenArray - Array of `<SelectOptions>` components
+ * @param {ReactChildren} children - children of `<SelectOptions>`
  * @returns {array}
  */
-function parseSelectOptions(childrenArray = []) {
+function parseSelectOptions(children) {
     const results = [];
 
-    childrenArray.forEach((child) => {
+    Children.forEach(children, (child) => {
         if (child && child.type === SelectOption) {
             results.push(child.props);
         }

--- a/packages/form/src/utils/parseSelectOptions.js
+++ b/packages/form/src/utils/parseSelectOptions.js
@@ -1,0 +1,21 @@
+import SelectOption from '../SelectOption';
+
+/**
+ * Convert children of `<SelectOptions>` components to array of options.
+ *
+ * @param {array} childrenArray - Array of `<SelectOptions>` components
+ * @returns {array}
+ */
+function parseSelectOptions(childrenArray = []) {
+    const results = [];
+
+    childrenArray.forEach((child) => {
+        if (child && child.type === SelectOption) {
+            results.push(child.props);
+        }
+    });
+
+    return results;
+}
+
+export default parseSelectOptions;


### PR DESCRIPTION
### Purpose
A `<SelectRow>` should display its current values at the `aside` area.

### Implement
1. Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
2. `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
3. Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
4. `<SelectList>` now passes sorted values via `onChange()`