### PR TITLE
Fix closable() blocking children events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix input inside `<TextInputRow>` should take up whole space.
 - Fix input inside `<TextInputRow>` should not have background.
+- Fix click events are ignored if fire from components inside `closable()` HOC mixin configured to close on inside click.
 
 ## [1.3.2]
 ### Fixed

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -65,7 +65,7 @@ it('does not trigger onClose() call on Escape key up if turned off', () => {
     expect(handleClose).toHaveBeenCalledTimes(0);
 });
 
-it('triggers onClose() call on click/touch outside if turned on', () => {
+it('triggers onClose() call on click/touch outside after a delay if turned on', () => {
     const ClosableFoo = closable({ onClickOutside: true })(Foo);
     const handleClose = jest.fn();
 
@@ -74,6 +74,8 @@ it('triggers onClose() call on click/touch outside if turned on', () => {
 
     let event = new MouseEvent('click');
     document.dispatchEvent(event);
+
+    jest.runOnlyPendingTimers();
     expect(handleClose).toHaveBeenCalledTimes(1);
 
     // jsdom doesn't support constructing TouchEvent yet.
@@ -84,7 +86,7 @@ it('triggers onClose() call on click/touch outside if turned on', () => {
     expect(handleClose).toHaveBeenCalledTimes(2);
 });
 
-it('does not trigger onClose() call on any click/touch outside if turned off', () => {
+it('does not trigger onClose() call on any click/touch outside after a delay if turned off', () => {
     const ClosableFoo = closable({ onClickOutside: false })(Foo);
     const handleClose = jest.fn();
 
@@ -93,6 +95,8 @@ it('does not trigger onClose() call on any click/touch outside if turned off', (
 
     let event = new MouseEvent('click');
     document.dispatchEvent(event);
+
+    jest.runOnlyPendingTimers();
     expect(handleClose).toHaveBeenCalledTimes(0);
 
     event = new CustomEvent('touchstart');
@@ -102,7 +106,7 @@ it('does not trigger onClose() call on any click/touch outside if turned off', (
     expect(handleClose).toHaveBeenCalledTimes(0);
 });
 
-it('triggers onClose() call on click/touch inside if turned on', () => {
+it('triggers onClose() call on click/touch inside a delay if turned on', () => {
     const ClosableFoo = closable({ onClickInside: true })(Foo);
     const handleClose = jest.fn();
 
@@ -111,6 +115,8 @@ it('triggers onClose() call on click/touch inside if turned on', () => {
 
     let event = new MouseEvent('click');
     wrapper.instance().nodeRef.dispatchEvent(event);
+
+    jest.runOnlyPendingTimers();
     expect(handleClose).toHaveBeenCalledTimes(1);
 
     // jsdom doesn't support constructing TouchEvent yet.
@@ -121,7 +127,7 @@ it('triggers onClose() call on click/touch inside if turned on', () => {
     expect(handleClose).toHaveBeenCalledTimes(2);
 });
 
-it('triggers onClose() call on click/touch inside if turned off', () => {
+it('triggers onClose() call on click/touch inside a delay if turned off', () => {
     const ClosableFoo = closable({ onClickInside: false })(Foo);
     const handleClose = jest.fn();
 
@@ -130,6 +136,8 @@ it('triggers onClose() call on click/touch inside if turned off', () => {
 
     let event = new MouseEvent('click');
     wrapper.instance().nodeRef.dispatchEvent(event);
+
+    jest.runOnlyPendingTimers();
     expect(handleClose).toHaveBeenCalledTimes(0);
 
     // jsdom doesn't support constructing TouchEvent yet.

--- a/packages/storybook/examples/Popover/DemoList.js
+++ b/packages/storybook/examples/Popover/DemoList.js
@@ -1,20 +1,31 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
+import Button from '@ichef/gypcrete/src/Button';
 import List from '@ichef/gypcrete/src/List';
 import ListRow from '@ichef/gypcrete/src/ListRow';
-import TextLabel from '@ichef/gypcrete/src/TextLabel';
+
+function DemoButton(props) {
+    return (
+        <Button
+            bold
+            minified={false}
+            color="black"
+            {...props} />
+    );
+}
 
 function DemoList() {
     return (
         <List>
             <ListRow>
-                <TextLabel basic="Row 1" />
+                <DemoButton basic="Row 1" onClick={action('click.1')} />
             </ListRow>
             <ListRow>
-                <TextLabel basic="Row 2" />
+                <DemoButton basic="Row 2" onClick={action('click.2')} />
             </ListRow>
             <ListRow>
-                <TextLabel basic="Row 3" />
+                <DemoButton basic="Row 3" onClick={action('click.3')} />
             </ListRow>
         </List>
     );


### PR DESCRIPTION
### Summary
Some `click` events are blocked if they are fired from components inside a `closable()` HOC, if the later is configured to close on inside clicks. The main reason if because the component is removed from React virtual DOM tree by the `onClose` callback triggered on `closable()`.

### Solution
Always delay `onClose()` callback for `closable()` HOC for both clicks and touches.