### PR TITLE
Style tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add transition to text in `<TextInputRow>` when being focused.
+- [Core] Add `tinted` prop for `<IconButton>` for a half-transparent icon.
 
 ### Changed
 - `<SelectList>` now passes sorted values via `onChange()`
 - `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
 - Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
 - Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
+- [Core] `<ListRow>` stops forwarding status props to children via context. This is changed against `v1.2.0`.
 
 ### Fixed
 - Fix input inside `<TextInputRow>` should take up whole space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Add transition to text in `<TextInputRow>` when being focused.
+- [Form] Add transition to text in `<TextInputRow>` when being focused.
 - [Core] Add `tinted` prop for `<IconButton>` for a half-transparent icon.
 
 ### Changed
-- `<SelectList>` now passes sorted values via `onChange()`
-- `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
-- Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
-- Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
+- [Form] `<SelectList>` now passes sorted values via `onChange()`
+- [Form] `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
+- [Form] Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
+- [Form] Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
 - [Core] `<ListRow>` stops forwarding status props to children via context. This is changed against `v1.2.0`.
 
 ### Fixed
-- Fix input inside `<TextInputRow>` should take up whole space.
-- Fix input inside `<TextInputRow>` should not have background.
-- Fix click events are ignored if fire from components inside `closable()` HOC mixin configured to close on inside click.
+- [Form] Fix input inside `<TextInputRow>` should take up whole space.
+- [Form] Fix input inside `<TextInputRow>` should not have background.
+- [Core] Fix click events are ignored if fire from components inside `closable()` HOC mixin configured to close on inside click.
 
 ## [1.3.2]
 ### Fixed

--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -6,14 +6,15 @@ import icBEM from './utils/icBEM';
 import Button, { COMPONENT_NAME } from './Button';
 import IconLayout from './IconLayout';
 
-const rootClass = icBEM(COMPONENT_NAME)
-    .modifier('icon-only')
-    .toString({ stripBlock: true });
-
 /**
  * color & solid props are not invalid in <IconButton>
  */
-function IconButton({ icon, color, solid, ...buttonProps }) {
+function IconButton({ icon, tinted, color, solid, ...buttonProps }) {
+    const rootClass = icBEM(COMPONENT_NAME)
+        .modifier('icon-only')
+        .modifier('tinted', tinted)
+        .toString({ stripBlock: true });
+
     return (
         <Button className={rootClass} {...buttonProps}>
             <IconLayout icon={icon} />
@@ -26,13 +27,15 @@ IconButton.propTypes = {
         PropTypes.string,
         PropTypes.element
     ]).isRequired,
+    tinted: PropTypes.bool,
     color: EnhancedPropTypes.isEmpty,
-    solid: EnhancedPropTypes.isEmpty
+    solid: EnhancedPropTypes.isEmpty,
 };
 
 IconButton.defaultProps = {
+    tinted: false,
     color: undefined,
-    solid: undefined
+    solid: undefined,
 };
 
 export default IconButton;

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -57,25 +57,6 @@ class ListRow extends PureComponent<Props, Props, any> {
         desc: undefined,
     };
 
-    static childContextTypes = {
-        status: statusPropTypes.status,
-        statusOptions: statusPropTypes.statusOptions,
-    };
-
-    /**
-     * Take `status` and its options then pass to children components.
-     * Error messages are rendered in this Row so it's filtered out from context.
-     *
-     * In the future v2, status are expected to be set on a row-basis components.
-     * #TODO: Remove status-related behavior from `rowComp()` mixin.
-     */
-    getChildContext() {
-        return {
-            status: this.props.status,
-            statusOptions: this.props.statusOptions,
-        };
-    }
-
     renderFooter() {
         const { desc, errorMsg } = this.props;
         const hasFooter = desc || errorMsg;

--- a/packages/core/src/mixins/__tests__/rowComp.test.js
+++ b/packages/core/src/mixins/__tests__/rowComp.test.js
@@ -105,6 +105,24 @@ it('passes down other props to wrapped component', () => {
     expect(wrapper.find(Foo).prop('bar')).toBeTruthy();
 });
 
+it('holds context for children components', () => {
+    const wrapper = shallow(
+        <RowCompFoo
+            align="right"
+            status="success"
+            statusOptions={{ autoHide: true }}
+            errorMsg="foo-bar" />
+    );
+    const context = wrapper.instance().getChildContext();
+
+    expect(context).toMatchObject({
+        align: 'right',
+        status: 'success',
+        statusOptions: { autoHide: true },
+        errorMsg: 'foo-bar',
+    });
+});
+
 it('takes defaults to its <RowComp> wrapper-component', () => {
     const Comp = rowComp({ defaultAlign: 'center', defaultMinified: true })(Foo);
 

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -148,13 +148,6 @@ const rowComp = ({
             errorMsg: undefined,
         };
 
-        static contextTypes = {
-            ...statusPropTypes,
-            // status,
-            // statusOptions,
-            // errorMsg,
-        };
-
         static childContextTypes = {
             align: PropTypes.oneOf(Object.values(ROW_COMP_ALIGN)),
             ...statusPropTypes,
@@ -167,8 +160,8 @@ const rowComp = ({
             const { align, status, statusOptions, errorMsg } = this.props;
 
             return {
-                status: (status === undefined) ? this.context.status : status,
-                statusOptions: statusOptions || this.context.statusOptions,
+                status,
+                statusOptions,
                 errorMsg,
                 align,
             };

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -163,7 +163,7 @@ const rowComp = ({
                 status,
                 statusOptions,
                 errorMsg,
-                align,
+                align, // for <TextInput>
             };
         }
 

--- a/packages/core/src/styles/Button.scss
+++ b/packages/core/src/styles/Button.scss
@@ -113,10 +113,11 @@
 //  Icon-only <Button>
 // ----------------------
 .#{$prefix}-button--icon-only {
-    color: $c-icon-header;
+    color: inherit;
+}
 
-    // #TODO: Row class to be determined.
-    .#{$prefix}-row {
-        color: $c-icon-row;
+.#{$prefix}-button--tinted {
+    .#{$prefix}-icon {
+        opacity: .5;
     }
 }

--- a/packages/storybook/examples/List/NormalList.js
+++ b/packages/storybook/examples/List/NormalList.js
@@ -4,6 +4,7 @@ import List from '@ichef/gypcrete/src/List';
 import ListRow from '@ichef/gypcrete/src/ListRow';
 
 import Button from '@ichef/gypcrete/src/Button';
+import IconButton from '@ichef/gypcrete/src/IconButton';
 import TextLabel from '@ichef/gypcrete/src/TextLabel';
 
 import DebugBox from 'utils/DebugBox';
@@ -24,7 +25,10 @@ function NormalList() {
                         bold
                         icon="tickets"
                         basic="Hello World"
-                        aside="Component aside" />
+                        aside="Component aside"
+                        status={null} />
+                    <IconButton icon="edit" />
+                    <IconButton tinted icon="drag" />
                 </ListRow>
 
                 <ListRow highlight>
@@ -32,9 +36,13 @@ function NormalList() {
                         icon="tickets"
                         basic="Highlighted row"
                         aside="Component aside" />
+                    <IconButton icon="edit" />
+                    <IconButton tinted icon="drag" />
                 </ListRow>
                 <ListRow>
                     <TextLabel icon="tickets" basic="Row 3" />
+                    <IconButton icon="edit" />
+                    <IconButton tinted icon="drag" />
                 </ListRow>
                 <ListRow>
                     <Button


### PR DESCRIPTION
### Implement
1. [Core] Add `tinted` prop for `<IconButton>` for a half-transparent icon.
2. [Core] `<ListRow>` stops forwarding status props to children via context. This is changed against `v1.2.0`.

### Screenshot
<img width="501" alt="2017-11-09 12 44 39" src="https://user-images.githubusercontent.com/365035/32561707-e2ff8700-c4e7-11e7-84b6-058f7a584a66.png">
