### PR TITLE
Fix <IconButton> injected class overridden by custom class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`.
+
 ## [1.4.0]
 ### Added
 - [Form] Add transition to text in `<TextInputRow>` when being focused.

--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
 import EnhancedPropTypes from './utils/enhancedPropTypes';
 import icBEM from './utils/icBEM';
 
@@ -9,11 +11,21 @@ import IconLayout from './IconLayout';
 /**
  * color & solid props are not invalid in <IconButton>
  */
-function IconButton({ icon, tinted, color, solid, ...buttonProps }) {
-    const rootClass = icBEM(COMPONENT_NAME)
+function IconButton({
+    icon,
+    tinted,
+    color,
+    solid,
+    // React props
+    className,
+    ...buttonProps,
+}) {
+    const bemClass = icBEM(COMPONENT_NAME)
         .modifier('icon-only')
         .modifier('tinted', tinted)
         .toString({ stripBlock: true });
+
+    const rootClass = classNames(bemClass, className);
 
     return (
         <Button className={rootClass} {...buttonProps}>

--- a/packages/core/src/__tests__/IconButton.test.js
+++ b/packages/core/src/__tests__/IconButton.test.js
@@ -31,6 +31,18 @@ describe('<IconButton>', () => {
         expect(buttonChidlren.equals(<IconLayout icon="printer" />)).toBeTruthy();
     });
 
+    it('injects additional BEM class to <Button>', () => {
+        const wrapper = shallow(
+            <IconButton
+                tinted
+                icon="printer"
+                className="other-custom-class" />);
+
+        expect(wrapper.hasClass('gyp-button--icon-only')).toBeTruthy();
+        expect(wrapper.hasClass('gyp-button--tinted')).toBeTruthy();
+        expect(wrapper.hasClass('other-custom-class')).toBeTruthy();
+    });
+
     describe('invalid propTypes', () => {
         let consoleStub;
         beforeEach(() => {


### PR DESCRIPTION
### Summary
`<IconButton>` injects up to 2 BEM class names to `<Button>`:
- `gyp-button--icon-only`
- `gyp-button--tinted`

However they can be overridden if you set a custom `className` prop on it.

### Solution
Use `classnames` helper to combine all class names.