### PR TITLE
Enhance extendibility for a few components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - [Core] `closable()` HOC mixin now takes runtime options via props. (#118)
+- [Form] `formRow()` HOC mixin now takes `withRef` option to maintain a ref to its wrapped component. (#118)
 - [Form] `<TextInputRow>` and `<SwitchRow>` now accepts `children` prop, will render inside `<ListRow>`. (#118)
 - [Form] `<TextInputRow>` now exposes ref to inner `<input>` via `getInputNode()` method. (#118)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Core] `closable()` HOC mixin now takes runtime options via props. (#118)
+- [Form] `<TextInputRow>` and `<SwitchRow>` now accepts `children` prop, will render inside `<ListRow>`. (#118)
+- [Form] `<TextInputRow>` now exposes ref to inner `<input>` via `getInputNode()` method. (#118)
+
 ### Fixed
-- [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`.
+- [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`. (#117)
 
 ## [1.4.0]
 ### Added

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -31,6 +31,23 @@ it('has default configs', () => {
     });
 });
 
+it('takes runtime options', () => {
+    const ClosableFoo = closable()(Foo);
+    const wrapper = mount(
+        <ClosableFoo
+            closable={{
+                onEscape: false,
+                onClickOutside: true,
+            }} />
+    );
+
+    expect(wrapper.instance().getOptions()).toMatchObject({
+        onEscape: false,
+        onClickOutside: true,
+        onClickInside: false,
+    });
+});
+
 it('triggers onClose() call on Escape key up if turned on', () => {
     const ClosableFoo = closable({ onEscape: true })(Foo);
     const handleClose = jest.fn();

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -29,10 +29,20 @@ const closable = ({
 
         static propTypes = {
             onClose: PropTypes.func,
+            closable: PropTypes.shape({
+                onEscape: PropTypes.bool,
+                onClickOutside: PropTypes.bool,
+                onClickInside: PropTypes.bool,
+            }),
         };
 
         static defaultProps = {
             onClose: () => {},
+            closable: {
+                onEscape,
+                onClickInside,
+                onClickOutside,
+            },
         };
 
         state = {
@@ -53,12 +63,17 @@ const closable = ({
             clearTimeout(this.state.closeDelayTimeout);
         }
 
-        // eslint-disable-next-line class-methods-use-this
         getOptions() {
-            return {
+            const configuredOptions = {
                 onEscape,
-                onClickOutside,
                 onClickInside,
+                onClickOutside,
+            };
+            const runtimeOptions = this.props.closable;
+
+            return {
+                ...configuredOptions,
+                ...runtimeOptions,
             };
         }
 
@@ -83,32 +98,41 @@ const closable = ({
         }
 
         handleDocumentKeyup = (event) => {
-            if (onEscape && event.keyCode === keycode(ESCAPE)) {
+            const options = this.getOptions();
+
+            if (options.onEscape && event.keyCode === keycode(ESCAPE)) {
                 this.props.onClose(event);
             }
         }
 
         handleDocumentClickOrTouch = (event) => {
+            const options = this.getOptions();
+
             if (this.state.clickedInside) {
                 this.setState({ clickedInside: false });
                 return;
             }
 
-            if (onClickOutside) {
+            if (options.onClickOutside) {
                 this.delayedClose(event);
             }
         }
 
         handleInsideClickOrTouch = (event) => {
+            const options = this.getOptions();
             this.setState({ clickedInside: true });
 
-            if (onClickInside) {
+            if (options.onClickInside) {
                 this.delayedClose(event);
             }
         }
 
         render() {
-            const { onClose, ...otherProps } = this.props;
+            const {
+                onClose,
+                closable: runtimeOptions,
+                ...otherProps,
+            } = this.props;
 
             return (
                 <div ref={this.captureInsideEvents} role="presentation">

--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -83,6 +83,7 @@ class SwitchRow extends PureComponent {
             rowProps,
             // React props
             className,
+            children,
             ...switchProps,
         } = this.props;
 
@@ -97,6 +98,8 @@ class SwitchRow extends PureComponent {
                     status={null}
                     onChange={this.handleSwitchButtonChange}
                     {...switchProps} />
+
+                {children}
             </ListRow>
         );
     }

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -45,6 +45,10 @@ class TextInputRow extends PureComponent {
         focused: false,
     };
 
+    getInputNode() {
+        return this.inputRef;
+    }
+
     handleInputFocus = (event) => {
         this.setState({ focused: true });
         this.props.onFocus(event);
@@ -58,6 +62,7 @@ class TextInputRow extends PureComponent {
     renderInput(inputProps) {
         return (
             <input
+                ref={(ref) => { this.inputRef = ref; }}
                 type="text"
                 className={BEM.input.toString()}
                 onFocus={this.handleInputFocus}

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -111,4 +111,4 @@ class TextInputRow extends PureComponent {
 }
 
 export { TextInputRow as PureTextInputRow };
-export default formRow()(TextInputRow);
+export default formRow({ withRef: true })(TextInputRow);

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -78,6 +78,7 @@ class TextInputRow extends PureComponent {
             rowProps,
             // React props
             className,
+            children,
             ...inputProps,
         } = this.props;
 
@@ -97,6 +98,8 @@ class TextInputRow extends PureComponent {
                 <TextLabel
                     basic={keyLabel}
                     aside={this.renderInput(inputProps)} />
+
+                {children}
             </ListRow>
         );
     }

--- a/packages/form/src/__tests__/SwitchRow.test.js
+++ b/packages/form/src/__tests__/SwitchRow.test.js
@@ -72,4 +72,14 @@ describe('Pure <SwitchRow>', () => {
         wrapper.setProps({ checked: false });
         expect(wrapper.text()).toBe('fooTEST_OFF');
     });
+
+    it('accepts additional children', () => {
+        const wrapper = mount(
+            <PureSwitchRow label="foo">
+                <span data-foo />
+            </PureSwitchRow>
+        );
+
+        expect(wrapper.containsMatchingElement(<span data-foo />)).toBeTruthy();
+    });
 });

--- a/packages/form/src/__tests__/TextInputRow.test.js
+++ b/packages/form/src/__tests__/TextInputRow.test.js
@@ -51,4 +51,14 @@ describe('Pure <TextInputRow>', () => {
         expect(wrapper.state('focused')).toBeFalsy();
         expect(wrapper.hasClass(focusedModifier)).toBeFalsy();
     });
+
+    it('accepts additional children', () => {
+        const wrapper = mount(
+            <PureTextInputRow label="foo">
+                <span data-foo />
+            </PureTextInputRow>
+        );
+
+        expect(wrapper.containsMatchingElement(<span data-foo />)).toBeTruthy();
+    });
 });

--- a/packages/form/src/__tests__/TextInputRow.test.js
+++ b/packages/form/src/__tests__/TextInputRow.test.js
@@ -61,4 +61,13 @@ describe('Pure <TextInputRow>', () => {
 
         expect(wrapper.containsMatchingElement(<span data-foo />)).toBeTruthy();
     });
+
+    it('keeps a ref to the <input> inside', () => {
+        const wrapper = mount(
+            <PureTextInputRow label="foo" />
+        );
+
+        const inputRef = wrapper.instance().getInputNode();
+        expect(inputRef).toBeInstanceOf(HTMLInputElement);
+    });
 });

--- a/packages/form/src/mixins/__tests__/formRow.test.js
+++ b/packages/form/src/mixins/__tests__/formRow.test.js
@@ -1,14 +1,21 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import formRow from '../formRow';
 
 function Foo({ children }) {
     return <div>{children}</div>;
 }
-
 const FormRowFoo = formRow()(Foo);
+
+// eslint-disable-next-line react/prefer-stateless-function
+class Bar extends PureComponent {
+    render() {
+        return <div>bar</div>;
+    }
+}
+const FormRowBarWithRef = formRow({ withRef: true })(Bar);
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
@@ -62,4 +69,10 @@ it('passes a collected rowProps prop to wrapped component', () => {
         statusOptions: { autoHide: false },
         errorMsg: 'bar',
     });
+});
+
+it('can optionally keep a ref to wrapped component', () => {
+    const wrapper = mount(<FormRowBarWithRef />);
+
+    expect(wrapper.instance().getWrappedComponent()).toBeInstanceOf(Bar);
 });

--- a/packages/form/src/mixins/formRow.js
+++ b/packages/form/src/mixins/formRow.js
@@ -1,61 +1,76 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import getComponentName from '@ichef/gypcrete/lib/utils/getComponentName';
 import { statusPropTypes } from '@ichef/gypcrete/lib/mixins/withStatus';
-
-const propTypes = {
-    disabled: PropTypes.bool,
-    readOnly: PropTypes.bool,
-    desc: PropTypes.node,
-    ...statusPropTypes,
-    // status
-    // statusOptions
-    // errorMsg
-};
-
-const defaultProps = {
-    disabled: false,
-    readOnly: false,
-    desc: undefined,
-};
 
 export const rowPropTypes = PropTypes.shape({
     desc: PropTypes.node,
     ...statusPropTypes,
 });
 
-const formRow = (/* mixin options */) => (WrappedComponent) => {
-    function FormRow({
-        disabled,
-        readOnly,
-        desc,
-        status,
-        statusOptions,
-        errorMsg,
-        ...otherProps,
-    }) {
-        const ineditable = disabled || readOnly;
-        const rowProps = {
-            desc,
-            status,
-            statusOptions,
-            errorMsg,
+const formRow = ({
+    withRef = false,
+} = {}) => (WrappedComponent) => {
+    class FormRow extends PureComponent {
+        static displayName = `formRow(${getComponentName(WrappedComponent)})`;
+
+        static propTypes = {
+            disabled: PropTypes.bool,
+            readOnly: PropTypes.bool,
+            desc: PropTypes.node,
+            ...statusPropTypes,
+            // status
+            // statusOptions
+            // errorMsg
         };
 
-        return (
-            <WrappedComponent
-                ineditable={ineditable}
-                disabled={disabled}
-                readOnly={readOnly}
-                rowProps={rowProps}
-                {...otherProps} />
-        );
-    }
+        static defaultProps = {
+            disabled: false,
+            readOnly: false,
+            desc: undefined,
+        };
 
-    FormRow.displayName = `formRow(${getComponentName(WrappedComponent)})`;
-    FormRow.propTypes = propTypes;
-    FormRow.defaultProps = defaultProps;
+        getWrappedComponent() {
+            return this.componentRef;
+        }
+
+        handleRef = (ref) => {
+            if (withRef) {
+                this.componentRef = ref;
+            }
+        }
+
+        render() {
+            const {
+                disabled,
+                readOnly,
+                desc,
+                status,
+                statusOptions,
+                errorMsg,
+                ...otherProps,
+            } = this.props;
+
+            const ineditable = disabled || readOnly;
+            const rowProps = {
+                desc,
+                status,
+                statusOptions,
+                errorMsg,
+            };
+
+            return (
+                <WrappedComponent
+                    ref={this.handleRef}
+                    ineditable={ineditable}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    rowProps={rowProps}
+                    {...otherProps} />
+            );
+        }
+    }
 
     return FormRow;
 };


### PR DESCRIPTION
### Purpose
Enhance `<TextInputRow>` and other components so it's easier to create variation of input rows.

### Implement
- [Core] `closable()` HOC mixin now takes runtime options via props.
- [Form] `<TextInputRow>` and `<SwitchRow>` now accepts `children` prop, will render inside `<ListRow>`.
- [Form] `<TextInputRow>` now exposes ref to inner `<input>` via `getInputNode()` method. 

### Discussion
I was considering to bundle [`react-dates`](https://github.com/airbnb/react-dates) into `gypcrete-form` as a date row with built-in date picker. But later I think it's better to keep the package simple and focused for now.
