### PR TITLE
Layout fixes for <Popover> and appearance tweak for <SelectRow>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`. (#117)
+- [Core] Fix `<Popover>` should have `max-height` while making its content scrollable. (#120)
 
 ## [1.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`. (#117)
 - [Core] Fix `<Popover>` should have `max-height` while making its content scrollable. (#120)
 - [Form] Fix unset `<SelectRow>` showing 'All' when it has no option. (#120)
+- [Form] Fix unset `<SelectRow>` label should be tinted. (#120)
 
 ## [1.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [Core] Fix classNames injected by `<IconButton>` will be overridden with custom `className`. (#117)
 - [Core] Fix `<Popover>` should have `max-height` while making its content scrollable. (#120)
+- [Form] Fix unset `<SelectRow>` showing 'All' when it has no option. (#120)
 
 ## [1.4.0]
 ### Added

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -5,11 +5,15 @@ $component-name: #{$prefix}-popover;
     background-color: $c-popover-background;
     min-width: rem($popover-min-width);
     max-width: rem($popover-max-width);
+    max-height: rem($popover-max-height);
     padding-bottom: rem($popover-bottom-padding);
     border-radius: $popover-border-radius;
     filter: drop-shadow($popover-drop-shadow);
     position: relative;
     z-index: z(popover);
+    overflow-x: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 
     // Elements
     &__arrow {

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -89,6 +89,7 @@ $poup-box-shadow: 0 2px 8px hsba(0, 0, 0, 40);
 
 $popover-min-width: 208px;
 $popover-max-width: 320px;
+$popover-max-height: 320px;
 $popover-arrow-size: 11px;
 $popover-bottom-padding: 8px;
 $popover-border-radius: 8px;

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -28,6 +28,7 @@ const ROOT_BEM = icBEM(COMPONENT_NAME);
 export const BEM = {
     root: ROOT_BEM,
     popover: ROOT_BEM.element('popover'),
+    placeholder: ROOT_BEM.element('placeholder'),
 };
 
 export const Popover = renderToLayer(
@@ -140,7 +141,7 @@ class SelectRow extends PureComponent {
         const { cachedValues, valueLabelMap } = this.state;
 
         if (cachedValues.length === 0) {
-            return asideNone;
+            return <span className={BEM.placeholder.toString()}>{asideNone}</span>;
         }
 
         // Can turn off 'All' display by passing `null`.

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -139,13 +139,13 @@ class SelectRow extends PureComponent {
         const { asideAll, asideNone, asideSeparator } = this.props;
         const { cachedValues, valueLabelMap } = this.state;
 
+        if (cachedValues.length === 0) {
+            return asideNone;
+        }
+
         // Can turn off 'All' display by passing `null`.
         if (asideAll && cachedValues.length === valueLabelMap.size) {
             return asideAll;
-        }
-
-        if (cachedValues.length === 0) {
-            return asideNone;
         }
 
         return cachedValues

--- a/packages/form/src/styles/SelectRow.scss
+++ b/packages/form/src/styles/SelectRow.scss
@@ -1,6 +1,10 @@
 $componenet-name: gyp-form-select;
 
 .#{$componenet-name} {
+    &__placeholder {
+        color: rgba(0, 0, 0, .5);
+    }
+
     &__popover {
         .gyp-popover__arrow {
             left: 50% !important;

--- a/packages/form/src/styles/TextInputRow.scss
+++ b/packages/form/src/styles/TextInputRow.scss
@@ -25,7 +25,7 @@ $font-weight-bold: 700;
 
 .#{$component-name} {
     ::placeholder {
-        color: rgba(0, 0, 0, .3);
+        color: rgba(0, 0, 0, .5);
     }
 
     // Elements


### PR DESCRIPTION
### Purpose
Patches to enhance component behavior

### Changes
- [Core] Fix `<Popover>` should have `max-height` while making its content scrollable. (#120)
- [Form] Fix unset `<SelectRow>` showing 'All' when it has no option. (#120)
- [Form] Fix unset `<SelectRow>` label should be tinted. (#120)