### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- N/A
+### Changed
+- [Form] The popover inside a single-value `<SelectRow>` should now close automatically after click on any option. (#125)
+- [Form] Update examples for `<SelectRow>`. (#125)
+
+### Fixed
+- [Core] Fix `<Popover>` should only scroll its container. (#125)
 
 ## [1.5.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- N/A
+
+## [1.5.2]
 ### Changed
 - [Form] The popover inside a single-value `<SelectRow>` should now close automatically after click on any option. (#125)
 - [Form] Update examples for `<SelectRow>`. (#125)

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.5.1",
+  "version": "1.5.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "commands": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-build",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "iCHEF web components library, built with React.",
   "private": true,
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "iCHEF web components library, built with React.",
   "repository": "iCHEF/gypcrete",
   "contributors": [

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -13,7 +13,7 @@ const TOUCH_CLOSE_DELAY = 100;
  * Provide various of ways to determine when to “close” a component by
  * binding event listeners on `document`.
  *
- * Formally `escapable()`.
+ * Formerlly `escapable()`.
  *
  * @param {object} options
  */

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -5,15 +5,11 @@ $component-name: #{$prefix}-popover;
     background-color: $c-popover-background;
     min-width: rem($popover-min-width);
     max-width: rem($popover-max-width);
-    max-height: rem($popover-max-height);
     padding-bottom: rem($popover-bottom-padding);
     border-radius: $popover-border-radius;
     filter: drop-shadow($popover-drop-shadow);
     position: relative;
     z-index: z(popover);
-    overflow-x: 0;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
 
     // Elements
     &__arrow {
@@ -26,6 +22,13 @@ $component-name: #{$prefix}-popover;
         position: absolute;
         left: 50%;
         margin-left: -$popover-arrow-size;
+    }
+
+    &__container {
+        max-height: rem($popover-max-height);
+        overflow-x: hidden;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
     // Position

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-form",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Form components built on Gypcrete",
   "repository": "iCHEF/gypcrete",
   "contributors": [
@@ -39,7 +39,7 @@
     "react-dom": "^15.3.0"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^1.5.1",
+    "@ichef/gypcrete": "^1.5.2",
     "classnames": "^2.2.5",
     "immutable": "^3.8.2",
     "keycode": "^2.1.9"

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -125,10 +125,13 @@ class SelectRow extends PureComponent {
     }
 
     renderPopover(selectListProps) {
+        const closableOptions = this.props.multiple ? undefined : { onClickInside: true };
+
         return (
             <Popover
                 anchor={this.anchorNode}
                 className={BEM.popover.toString()}
+                closable={closableOptions}
                 onClose={this.handlePopoverClose}>
                 <SelectList
                     values={this.state.cachedValues}

--- a/packages/storybook/examples/Form.SelectRow/Customize.js
+++ b/packages/storybook/examples/Form.SelectRow/Customize.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import List from '@ichef/gypcrete/src/List';
+import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+import Option from '@ichef/gypcrete-form/src/SelectOption';
+
+function MultipleValues() {
+    return (
+        <List title="Switch rows with customized labels">
+            <SelectRow
+                multiple
+                label="Custom 'All' label"
+                asideAll="EVERYHTING SELECTED"
+                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                <Option label="Option A" value="opt-a" />
+                <Option label="Option B" value="opt-b" />
+                <Option label="Option C" value="opt-c" />
+            </SelectRow>
+
+            <SelectRow
+                multiple
+                label="Turn off 'All' label"
+                asideAll={false}
+                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                <Option label="Option A" value="opt-a" />
+                <Option label="Option B" value="opt-b" />
+                <Option label="Option C" value="opt-c" />
+            </SelectRow>
+
+            <SelectRow
+                multiple
+                label="Custom 'None' label"
+                asideNone="Nothing">
+                <Option label="Option A" value="opt-a" />
+                <Option label="Option B" value="opt-b" />
+                <Option label="Option C" value="opt-c" />
+            </SelectRow>
+
+            <SelectRow
+                multiple
+                label="Custom separator label"
+                asideAll={false}
+                asideSeparator=" + "
+                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                <Option label="Option A" value="opt-a" />
+                <Option label="Option B" value="opt-b" />
+                <Option label="Option C" value="opt-c" />
+            </SelectRow>
+        </List>
+    );
+}
+
+export default MultipleValues;

--- a/packages/storybook/examples/Form.SelectRow/MultipleValues.js
+++ b/packages/storybook/examples/Form.SelectRow/MultipleValues.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import List from '@ichef/gypcrete/src/List';
+import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+import Option from '@ichef/gypcrete-form/src/SelectOption';
+
+function MultipleValues() {
+    return (
+        <List title="Switch rows with multiple selection">
+            <SelectRow
+                multiple
+                label="Enabled modules"
+                onChange={action('change')}>
+                <Option label="Module 1" value="mod1" />
+                <Option label="Module 2" value="mod2" />
+                <Option label="Module 3" value="mod3" />
+                <Option label="Module 4" value="mod4" />
+                <Option label="Module 5" value="mod5" />
+            </SelectRow>
+
+            <SelectRow
+                multiple
+                label="Minimal selection: 2"
+                minCheck={2}
+                defaultValues={['opt-c', 'opt-d']}>
+                <Option label="Option A" value="opt-a" />
+                <Option label="Option B" value="opt-b" />
+                <Option label="Option C" value="opt-c" />
+                <Option label="Option D" value="opt-d" />
+                <Option label="Option E" value="opt-e" />
+            </SelectRow>
+
+            <SelectRow
+                multiple
+                label="Multiple selection with no options" />
+        </List>
+    );
+}
+
+export default MultipleValues;

--- a/packages/storybook/examples/Form.SelectRow/index.js
+++ b/packages/storybook/examples/Form.SelectRow/index.js
@@ -6,8 +6,12 @@ import { withInfo } from '@storybook/addon-info';
 import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
 
 import BasicUsage from './BasicUsage';
+import MultipleValues from './MultipleValues';
+import Customize from './Customize';
 
 storiesOf('[Form] SelectRow', module)
     .add('basic usage', withInfo()(BasicUsage))
+    .add('multiple selection', withInfo()(MultipleValues))
+    .add('customize labels', withInfo()(Customize))
     // Props table
     .addPropsTable(() => <SelectRow />);

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-storybook",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "React Storybook for Gypcrete",
   "private": true,
   "repository": "iCHEF/gypcrete",
@@ -20,8 +20,8 @@
     "ghpages": "npm run clean && npm run build:storybook && sh ./scripts/ghpages.sh"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^1.5.1",
-    "@ichef/gypcrete-form": "^1.5.1",
+    "@ichef/gypcrete": "^1.5.2",
+    "@ichef/gypcrete-form": "^1.5.2",
     "@storybook/addon-actions": "^3.2.12",
     "@storybook/addon-info": "^3.2.12",
     "@storybook/addon-options": "^3.2.12",


### PR DESCRIPTION
### Changed
- [Form] The popover inside a single-value `<SelectRow>` should now close automatically after click on any option. (#125)
- [Form] Update examples for `<SelectRow>`. (#125)

### Fixed
- [Core] Fix `<Popover>` should only scroll its container. (#125)