### PR TITLE
Stack base layers with stacking context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- N/A
+### Changed
+- [Core] Remove `z-index` from components with `renderToLayer()` HOC mixin. They will now be stack based on the stacking context on the base layers. (#128)
 
 ## [1.5.2]
 ### Changed

--- a/packages/core/src/mixins/renderToLayer.js
+++ b/packages/core/src/mixins/renderToLayer.js
@@ -24,9 +24,13 @@ import React, { Component } from 'react';
 // eslint-disable-next-line camelcase
 import ReactDOM, { unstable_renderSubtreeIntoContainer } from 'react-dom';
 
+import prefixClass from '../utils/prefixClass';
 import getComponentName from '../utils/getComponentName';
 import randId from '../utils/randId';
 
+import '../styles/RenderToLayer.scss';
+
+const COMPONENT_NAME = prefixClass('base-layer');
 const LAYER_ID_PREFIX = 'layer';
 
 function renderToLayer(WrappedComponent) {
@@ -67,6 +71,7 @@ function renderToLayer(WrappedComponent) {
          */
         createBaseLayer() {
             const baseLayer = document.createElement('div');
+            baseLayer.className = COMPONENT_NAME;
             baseLayer.id = randId({ prefix: LAYER_ID_PREFIX });
 
             this.baseLayer = baseLayer;

--- a/packages/core/src/styles/Overlay.scss
+++ b/packages/core/src/styles/Overlay.scss
@@ -8,7 +8,6 @@
     left: 0;
     right: 0;
     background-color: $c-overlay;
-    z-index: z("default");
 
     // Active animation
     opacity: 0;

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -9,7 +9,6 @@ $component-name: #{$prefix}-popover;
     border-radius: $popover-border-radius;
     filter: drop-shadow($popover-drop-shadow);
     position: relative;
-    z-index: z(popover);
 
     // Elements
     &__arrow {

--- a/packages/core/src/styles/Popup.scss
+++ b/packages/core/src/styles/Popup.scss
@@ -16,7 +16,6 @@
     justify-content: center;
     align-items: center;
     text-align: center;
-    z-index: z("popup");
 }
 
 // -------------------------------------
@@ -33,7 +32,6 @@
         box-shadow: $poup-box-shadow;
         position: relative;
         overflow: hidden;
-        z-index: z("front");
         transition: width .15s;
 
         // Active animation

--- a/packages/core/src/styles/RenderToLayer.scss
+++ b/packages/core/src/styles/RenderToLayer.scss
@@ -1,0 +1,7 @@
+@import "./mixins";
+
+.#{$prefix}-base-layer {
+    position: relative;
+    // #FIXME: for compatibility with ic-framework. Should remove in the future.
+    z-index: 1000;
+}

--- a/packages/core/src/styles/RenderToLayer.scss
+++ b/packages/core/src/styles/RenderToLayer.scss
@@ -1,7 +1,9 @@
 @import "./mixins";
 
 .#{$prefix}-base-layer {
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
     // #FIXME: for compatibility with ic-framework. Should remove in the future.
     z-index: 1000;
 }

--- a/packages/core/src/styles/_mixins.scss
+++ b/packages/core/src/styles/_mixins.scss
@@ -41,34 +41,3 @@
     appearance: none;
     user-select: none;
 }
-
-// -------------------------------------
-//   z-index helper
-// -------------------------------------
-
-@function map-has-nested-keys($map, $keys...) {
-    @each $key in $keys {
-        @if not map-has-key($map, $key) {
-            @return false;
-        }
-        $map: map-get($map, $key);
-    }
-
-    @return true;
-}
-
-@function map-deep-get($map, $keys...) {
-    @each $key in $keys {
-        $map: map-get($map, $key);
-    }
-
-    @return $map;
-}
-
-@function z($layers...) {
-    @if not map-has-nested-keys($z-layers, $layers...) {
-        @warn "No layer found for `#{inspect($layers...)}` in $z-layers map. Property omitted.";
-    }
-
-    @return map-deep-get($z-layers, $layers...);
-}

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -104,19 +104,3 @@ $popover-drop-shadow: 0 2px 3px hsba(0, 0, 0, 40);
 
 $ease-out-quad: cubic-bezier(.25, .46, .45, .94);
 $ease-out-cubic: cubic-bezier(.215, .61, .355, 1);
-
-// -------------------------------------
-//   z-index layers
-// -------------------------------------
-
-$z-layers: (
-    "popup":        1000,
-    "modal":        999,
-    "popover":      100,
-    "top":          99,
-    "front":        9,
-    "base":         1,
-    "default":      0,
-    "below":        -1,
-    "hidden":       -9999,
-);


### PR DESCRIPTION
### Purpose
Components that are rendered into an external layer (a *base layer*) were set with pre-defined `z-index` to stack above other components. The problem is you'll be unable to place a component set with a lower `z-index` above one with a higher `z-index`.

For example, a `<Popover>` (defined at `z-index` of `100`) will always be blocked by a `<Modal>` (defined at `z-index` of `999` in ic-framework. Not yet available in gypcrete.) But in practice, it's often to render a `<Popover>` above the later, in the case of “opening a menu inside a modal”.

This PR assumes every render-to-layer component that is opened later, should be place more closed to foreground. Therefore every newly-inserted base layer should be place above previous layers. And by creating a stacking context for every base layer, it can be done automatically without explicitly setting `z-index` on the layers.

### Implement
1. Create a stacking context for each base layer
2. Remove pre-defined `z-index` from render-to-layer components
