### PR TITLE
Fix base layer should be as wide as viewport to not supress its content

### DIFF
--- a/packages/core/src/styles/RenderToLayer.scss
+++ b/packages/core/src/styles/RenderToLayer.scss
@@ -4,6 +4,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
     // #FIXME: for compatibility with ic-framework. Should remove in the future.
     z-index: 1000;
 }


### PR DESCRIPTION
Fixes the issue from: https://github.com/iCHEF/gypcrete/pull/129#issuecomment-357139990