### PR TITLE
Update button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Core] Update styles for `<Popup>` to better match design. (#127)
 - [Core] Refactor `<Popup>` to simplify codes. (#127)
-- [Core] `<Popup>` does not trigger `onClose()` on ESC key by default. It can be turned back on with runtime options of `closable()` HOC mixin. (#127)
-- [Core] Update examples for `<Popup>`. (#127)
+- [Storybook] Update examples for `<Popup>`. (#127)
 - [Core] Remove `z-index` from components with `renderToLayer()` HOC mixin. They will now be stack based on the stacking context on the base layers. (#128)
 - [Storybook] Fix the showcase of `<Tooltip>` component. (#129)
+- [Core] Change aside label of `<Text>` to inherit parent color but with 70% opacity. (#131)
+- [Storybook] Update examples for `<Button>` (#131)
+
+### Minor Breaking
+- [Core] `<Popup>` is no longer wrapped with `closable()` mixin, will not respond to ESC key now. (#127)
+- [Core] Default color for `<Button>` is now black. (#131)
+- [Core] Remove `primary` prop from `<Button>` in favor of cross-component `bold` prop on `rowComp()`. (#131)
+
 
 ## [1.5.2]
 ### Changed

--- a/packages/core/src/Button.js
+++ b/packages/core/src/Button.js
@@ -19,7 +19,6 @@ export const BUTTON_COLOR = { BLUE, RED, WHITE, BLACK };
 function Button({
     color,
     solid,
-    primary,
 
     // React props
     className,
@@ -28,8 +27,7 @@ function Button({
 }) {
     const bemClass = ROOT_BEM
         .modifier(color)
-        .modifier('solid', solid)
-        .modifier('primary', primary);
+        .modifier('solid', solid);
 
     const rootClassName = classNames(className, `${bemClass}`);
 
@@ -44,13 +42,11 @@ function Button({
 Button.propTypes = {
     color: PropTypes.oneOf(Object.values(BUTTON_COLOR)),
     solid: PropTypes.bool,
-    primary: PropTypes.bool,
 };
 
 Button.defaultProps = {
     color: BLACK,
     solid: false,
-    primary: false,
 };
 
 // export for tests

--- a/packages/core/src/Button.js
+++ b/packages/core/src/Button.js
@@ -48,7 +48,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-    color: BLUE,
+    color: BLACK,
     solid: false,
     primary: false,
 };

--- a/packages/core/src/styles/Text.scss
+++ b/packages/core/src/styles/Text.scss
@@ -34,14 +34,9 @@
     }
 
     &__aside {
-        color: $c-text-aside;
         font-size: rem($aside-text-font-size);
         line-height: rem($aside-text-line-height);
-
-        .#{$prefix}-state-error &,
-        .#{$prefix}-list-row--highlight & {
-            color: inherit;
-        }
+        opacity: $aside-text-opacity;
     }
 }
 

--- a/packages/core/src/styles/_colors.scss
+++ b/packages/core/src/styles/_colors.scss
@@ -16,7 +16,6 @@ $c-text-editable: $c-blue;
 $c-text-disabled: hsba(0, 0, 0, 30);
 $c-text-readonly: $c-gray;
 $c-text-placeholder: hsba(0, 0, 0, 30);
-$c-text-aside:    hsba(0, 0, 30, 100);
 
 // Icon-only buttons
 $c-icon-header: $c-black;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -41,6 +41,7 @@ $basic-text-font-size: $font-size-large;
 $basic-text-line-height: $line-height-large;
 $aside-text-font-size: $font-size-base;
 $aside-text-line-height: $line-height-base;
+$aside-text-opacity: .7;
 
 $tag-font-size: $font-size-small;
 $tag-border-radius: 6px;

--- a/packages/storybook/examples/Button/BasicButton.js
+++ b/packages/storybook/examples/Button/BasicButton.js
@@ -9,11 +9,18 @@ function BasicButtonExample() {
         <FlexRow>
             <Button
                 primary
-                basic="Blue Button"
+                basic="Black Button"
                 aside="Default color"
                 tag="Tag"
                 icon="add"
                 onClick={action('clicked')} />
+
+            <Button
+                color="blue"
+                basic="Blue"
+                aside="Variants"
+                tag="Tag"
+                icon="add" />
 
             <Button
                 color="red"
@@ -25,13 +32,6 @@ function BasicButtonExample() {
             <Button
                 color="white"
                 basic="White"
-                aside="Variants"
-                tag="Tag"
-                icon="add" />
-
-            <Button
-                color="black"
-                basic="Black"
                 aside="Variants"
                 tag="Tag"
                 icon="add" />

--- a/packages/storybook/examples/Button/BasicButton.js
+++ b/packages/storybook/examples/Button/BasicButton.js
@@ -8,7 +8,7 @@ function BasicButtonExample() {
     return (
         <FlexRow>
             <Button
-                primary
+                bold
                 basic="Black Button"
                 aside="Default color"
                 tag="Tag"

--- a/packages/storybook/examples/Button/DisabledButton.js
+++ b/packages/storybook/examples/Button/DisabledButton.js
@@ -8,6 +8,7 @@ function DisabledButtonExample() {
         <div>
             <FlexRow>
                 <Button
+                    bold
                     disabled
                     basic="Black"
                     aside="Disabled"
@@ -33,6 +34,7 @@ function DisabledButtonExample() {
             </FlexRow>
             <FlexRow>
                 <Button
+                    bold
                     solid
                     disabled
                     basic="Black"

--- a/packages/storybook/examples/Button/DisabledButton.js
+++ b/packages/storybook/examples/Button/DisabledButton.js
@@ -5,18 +5,62 @@ import FlexRow from 'utils/FlexRow';
 
 function DisabledButtonExample() {
     return (
-        <FlexRow>
-            <Button
-                basic="Blue"
-                disabled />
-
-            <Button
-                solid
-                color="black"
-                basic="Black"
-                tag="Solid"
-                disabled />
-        </FlexRow>
+        <div>
+            <FlexRow>
+                <Button
+                    disabled
+                    basic="Black"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    disabled
+                    color="blue"
+                    basic="Blue"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    disabled
+                    color="red"
+                    basic="Red"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    disabled
+                    color="white"
+                    basic="White"
+                    aside="Disabled"
+                    tag="tag" />
+            </FlexRow>
+            <FlexRow>
+                <Button
+                    solid
+                    disabled
+                    basic="Black"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    solid
+                    disabled
+                    color="blue"
+                    basic="Blue"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    solid
+                    disabled
+                    color="red"
+                    basic="Red"
+                    aside="Disabled"
+                    tag="tag" />
+                <Button
+                    solid
+                    disabled
+                    color="white"
+                    basic="White"
+                    aside="Disabled"
+                    tag="tag" />
+            </FlexRow>
+        </div>
     );
 }
 

--- a/packages/storybook/examples/Button/SolidButton.js
+++ b/packages/storybook/examples/Button/SolidButton.js
@@ -7,6 +7,7 @@ function SolidButtonExample() {
     return (
         <FlexRow>
             <Button
+                bold
                 solid
                 basic="Black"
                 aside="Aside text"

--- a/packages/storybook/examples/Button/SolidButton.js
+++ b/packages/storybook/examples/Button/SolidButton.js
@@ -8,25 +8,29 @@ function SolidButtonExample() {
         <FlexRow>
             <Button
                 solid
+                basic="Black"
+                aside="Aside text"
+                tag="Solid" />
+
+            <Button
+                solid
+                color="blue"
                 basic="Blue"
+                aside="Aside text"
                 tag="Solid" />
 
             <Button
                 solid
                 color="red"
                 basic="Red"
+                aside="Aside text"
                 tag="Solid" />
 
             <Button
                 solid
                 color="white"
                 basic="White"
-                tag="Solid" />
-
-            <Button
-                solid
-                color="black"
-                basic="Black"
+                aside="Aside text"
                 tag="Solid" />
         </FlexRow>
     );

--- a/packages/storybook/examples/Popup/index.js
+++ b/packages/storybook/examples/Popup/index.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 // For props table
-import Popup, { EscapablePopup, PurePopup } from '@ichef/gypcrete/src/Popup';
+import Popup, { PurePopup } from '@ichef/gypcrete/src/Popup';
 
 import BasicPopupExample from './BasicPopup';
 import HorizontalButtonsExample from './HorizontalButtons';
@@ -12,4 +12,4 @@ storiesOf('Popup', module)
     .add('basic usage', withInfo()(BasicPopupExample))
     .add('horizontal buttons', withInfo()(HorizontalButtonsExample))
     // Props table
-    .addPropsTable(() => <Popup />, [EscapablePopup, PurePopup]);
+    .addPropsTable(() => <Popup />, [PurePopup]);


### PR DESCRIPTION
### Purpose
Update styles for `<Button>` to better match design

### Implement
- [Core] Change aside label of `<Text>` to inherit parent color but with 70% opacity.
- [Storybook] Update examples for `<Button>`

#### Minor breaking
- [Core] Default color for `<Button>` is now black.
- [Core] Remove `primary` prop from `<Button>` in favor of cross-component `bold` prop on `rowComp()`.

### Screenshots
![2018-01-12 4 38 14](https://user-images.githubusercontent.com/365035/34866389-5da0686a-f7b7-11e7-88ea-e2cfb38c03a7.png)
![2018-01-12 4 38 20](https://user-images.githubusercontent.com/365035/34866391-5f54c58e-f7b7-11e7-9cd2-1f69d288de7b.png)
![2018-01-12 4 38 26](https://user-images.githubusercontent.com/365035/34866394-6114c1e4-f7b7-11e7-8b8b-0edba9886806.png)
