### PR TITLE
Fix <Button> tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
     - yarn lint
 
 script:
-    - yarn test
+    - yarn test --bail
 
 # Send coverage data to Coveralls
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Storybook] Fix the showcase of `<Tooltip>` component. (#129)
 - [Core] Change aside label of `<Text>` to inherit parent color but with 70% opacity. (#131)
 - [Storybook] Update examples for `<Button>` (#131)
+- Fix CI not aware of failing tests with `--bail` workaround. (#132)
 
 ### Minor Breaking
 - [Core] `<Popup>` is no longer wrapped with `closable()` mixin, will not respond to ESC key now. (#127)

--- a/packages/core/src/__tests__/Button.test.js
+++ b/packages/core/src/__tests__/Button.test.js
@@ -29,15 +29,9 @@ describe('Pure <Button>', () => {
         expect(wrapper.find('button').prop('type')).toBe('button');
     });
 
-    it('handles primary modifier', () => {
-        const wrapper = shallow(<PureButton primary>Label</PureButton>);
-
-        expect(wrapper.hasClass('gyp-button--primary')).toBeTruthy();
-    });
-
     it('handles color modifiers', () => {
         let wrapper = shallow(<PureButton>Label</PureButton>);
-        expect(wrapper.hasClass('gyp-button--blue')).toBeTruthy();
+        expect(wrapper.hasClass('gyp-button--black')).toBeTruthy();
 
         wrapper = shallow(<PureButton color="red">Label</PureButton>);
         expect(wrapper.hasClass('gyp-button--red')).toBeTruthy();
@@ -45,8 +39,8 @@ describe('Pure <Button>', () => {
         wrapper = shallow(<PureButton color="white">Label</PureButton>);
         expect(wrapper.hasClass('gyp-button--white')).toBeTruthy();
 
-        wrapper = shallow(<PureButton color="black">Label</PureButton>);
-        expect(wrapper.hasClass('gyp-button--black')).toBeTruthy();
+        wrapper = shallow(<PureButton color="blue">Label</PureButton>);
+        expect(wrapper.hasClass('gyp-button--blue')).toBeTruthy();
     });
 
     it('handles solid modifier', () => {


### PR DESCRIPTION
### Implement
1. Fix failing `<Button>` tests.
2. Workaround fix CI not aware of failing tests.

Jest exits with `0` even with failing tests.
This PR adds a quick workaround by adding `--bail` option to `yarn test` script.
It make Jest to break and exit with 1 immediately on first failure.