### PR TITLE
Update components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
 
     "flow.enabled": true,
     "flow.useNPMPackagedFlow": true,
-    "javascript.validate.enable": false
+    "javascript.validate.enable": false,
+    "jest.pathToConfig": "configs/jest.config.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- N/A
+### Changed
+- [Core] `<HeaderRow>` now accepts `children` and renders. (#136)
+- [Form] `<SelectOption>` now accepts and passes unknown props to its inner `<Checkbox>`. (#136)
 
 ## [1.6.0]
 ### Added

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,13 +1,12 @@
 {
     "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "src": ["src"]
-        },
         "lib": [
             "es2017"
         ]
     },
+    "exclude": [
+      "node_modules"
+    ],
     "typeAcquisition": {
         "include": [
             "jest"

--- a/packages/core/src/HeaderRow.js
+++ b/packages/core/src/HeaderRow.js
@@ -21,6 +21,7 @@ export type Props = {
     center?: ReactChildren,
     right?: ReactChildren,
     className?: string, // eslint-disable-line react/require-default-props
+    children?: ReactChildren,
 };
 
 function HeaderRow({
@@ -29,6 +30,7 @@ function HeaderRow({
     right,
     // React props
     className,
+    children,
     ...otherProps,
 }: Props) {
     const rootClassName = classNames(
@@ -41,6 +43,7 @@ function HeaderRow({
             <div className={BEM.left}>{left}</div>
             <div className={BEM.center}>{center}</div>
             <div className={BEM.right}>{right}</div>
+            {children}
         </div>
     );
 }

--- a/packages/core/src/__tests__/HeaderRow.test.js
+++ b/packages/core/src/__tests__/HeaderRow.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
 
 import HeaderRow from '../HeaderRow';
 
@@ -8,4 +9,14 @@ it('renders without crashing', () => {
     const element = <HeaderRow left="Left" center="Title" right="Right" />;
 
     ReactDOM.render(element, div);
+});
+
+it('renders optional children besides 3 defined areas', () => {
+    const wrapper = shallow(
+        <HeaderRow>
+            <div data-target>Hello World</div>
+        </HeaderRow>
+    );
+    expect(wrapper.text()).toBe('Hello World');
+    expect(wrapper.find('div[data-target]').exists()).toBeTruthy();
 });

--- a/packages/form/src/SelectOption.js
+++ b/packages/form/src/SelectOption.js
@@ -12,7 +12,14 @@ export const valueType = PropTypes.oneOfType([
     PropTypes.bool,
 ]);
 
-function SelectOption({ label, value, readOnly, checked, onChange }) {
+function SelectOption({
+    label,
+    value,
+    readOnly,
+    checked,
+    onChange,
+    ...checkboxProps,
+}) {
     const handleCheckboxChange = (event) => {
         onChange(value, event.target.checked);
     };
@@ -23,7 +30,8 @@ function SelectOption({ label, value, readOnly, checked, onChange }) {
                 checked={checked}
                 disabled={readOnly}
                 basic={label}
-                onChange={handleCheckboxChange} />
+                onChange={handleCheckboxChange}
+                {...checkboxProps} />
         </ListRow>
     );
 }

--- a/packages/form/src/__tests__/SelectOption.test.js
+++ b/packages/form/src/__tests__/SelectOption.test.js
@@ -43,3 +43,10 @@ it('does not break when without explicit onChange', () => {
 
     wrapper.find('input').simulate('change', { target: { checked: true } });
 });
+
+it('accepts unknown props and passes to <Checkbox> inside', () => {
+    const wrapper = mount(
+        <SelectOption label="foo" value="bar" bold />
+    );
+    expect(wrapper.find(Checkbox).prop('bold')).toBeTruthy();
+});


### PR DESCRIPTION
### Changes
- [Core] `<HeaderRow>` now accepts `children` and renders.
- [Form] `<SelectOption>` now accepts and passes unknown props to its inner `<Checkbox>`.