### PR TITLE
Fix <Modal> not rendering its content and prevent unexpected closing behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+### Bugs Fix
+- [Core] Fix `<Modal>` not rendering its content (#139)
 
 ## [1.7.0]
 ### Added
-- [Core] Migrate <Modal> from ic-framework-react and ic-framework. (#137)
+- [Core] Migrate `<Modal>` from ic-framework-react and ic-framework. (#137)
 
 ### Changed
 - [Core] `<HeaderRow>` now accepts `children` and renders. (#136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Bugs Fix
+### Fixed
 - [Core] Fix `<Modal>` not rendering its content (#139)
 - [Core] Remove the `Closable` HOC from `<Modal>` to prevent unexpected closing behaviors occur when more than one modals are open. (#139)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Bugs Fix
 - [Core] Fix `<Modal>` not rendering its content (#139)
+- [Core] Remove the `Closable` HOC from `<Modal>` to prevent unexpected closing behaviors occur when more than one modals are open. (#139)
+
+### Changed
+- [Storybook] Refine the showcase of `<Modal>` component. (#139)
 
 ## [1.7.0]
 ### Added

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -95,6 +95,7 @@ function Modal({
     onClose,
     // React props
     className,
+    children,
 }) {
     const bemClass = BEM.root.modifier(size);
     const rootClassName = classNames(bemClass.toString(), className);
@@ -105,7 +106,9 @@ function Modal({
             <ClosableModalContent
                 className={BEM.closable}
                 header={header} bodyClassName={bodyClassName}
-                bodyPadding={bodyPadding} onClose={onClose} />
+                bodyPadding={bodyPadding} onClose={onClose}>
+                {children}
+            </ClosableModalContent>
         </article>
     );
 }

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import Overlay from './Overlay';
 import HeaderRow from './HeaderRow';
 import TextLabel from './TextLabel';
-import closable from './mixins/closable';
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 import renderToLayer from './mixins/renderToLayer';
@@ -80,13 +79,6 @@ ModalContent.defaultProps = {
     bodyPadding: false,
 };
 
-const ClosableModalContent = closable({
-    onEscape: true,
-    onClickOutside: true,
-    onClickInside: false,
-})(ModalContent);
-
-
 function Modal({
     size,
     header,
@@ -103,12 +95,12 @@ function Modal({
     return (
         <article className={rootClassName}>
             <Overlay />
-            <ClosableModalContent
+            <ModalContent
                 className={BEM.closable}
                 header={header} bodyClassName={bodyClassName}
                 bodyPadding={bodyPadding} onClose={onClose}>
                 {children}
-            </ClosableModalContent>
+            </ModalContent>
         </article>
     );
 }

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -45,6 +45,12 @@ describe('Pure <PureModal>', () => {
                               .toString({ stripBlock: true });
         expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
     });
+
+    it('renders content of the modal', () => {
+        const content = <div>TestContent</div>;
+        const wrapper = shallow(<PureModal>{content}</PureModal>);
+        expect(wrapper.contains([content])).toBeTruthy();
+    });
 });
 
 describe('<PureModal> with a header row', () => {

--- a/packages/storybook/examples/Modal/index.js
+++ b/packages/storybook/examples/Modal/index.js
@@ -9,16 +9,16 @@ import BasicModalExample, { ClosableModalExample } from './BasicModal';
 
 storiesOf('Modal', module)
     .add('basic usage', withInfo()(() => <BasicModalExample bodyPadding><div>Modal Content</div></BasicModalExample>))
-    .add('small modal', withInfo()(() =>
-        (<BasicModalExample bodyPadding size="small" header="Small Modal">
+    .add('small modal', withInfo()(() => (
+        <BasicModalExample bodyPadding size="small" header="Small Modal">
             <div>Modal Content</div>
         </BasicModalExample>)))
-    .add('large modal', withInfo()(() =>
-        (<BasicModalExample bodyPadding size="large" header="Large Modal">
+    .add('large modal', withInfo()(() => (
+        <BasicModalExample bodyPadding size="large" header="Large Modal">
             <div>Modal Content</div>
         </BasicModalExample>)))
-    .add('full modal', withInfo()(() =>
-        (<BasicModalExample bodyPadding size="full" header="Full Modal">
+    .add('full modal', withInfo()(() => (
+        <BasicModalExample bodyPadding size="full" header="Full Modal">
             <div>Modal Content</div>
         </BasicModalExample>)))
     .add('closable modal', withInfo()(() => <ClosableModalExample />))

--- a/packages/storybook/examples/Modal/index.js
+++ b/packages/storybook/examples/Modal/index.js
@@ -8,10 +8,10 @@ import Modal from '@ichef/gypcrete/src/Modal';
 import BasicModalExample, { ClosableModalExample } from './BasicModal';
 
 storiesOf('Modal', module)
-    .add('basic usage', withInfo()(() => <BasicModalExample bodyPadding />))
-    .add('small modal', withInfo()(() => <BasicModalExample bodyPadding size="small" header="Small Modal" />))
-    .add('large modal', withInfo()(() => <BasicModalExample bodyPadding size="large" header="Large Modal" />))
-    .add('full modal', withInfo()(() => <BasicModalExample bodyPadding size="full" header="Full Modal" />))
+    .add('basic usage', withInfo()(() => <BasicModalExample bodyPadding><div>Modal Content</div></BasicModalExample>))
+    .add('small modal', withInfo()(() => <BasicModalExample bodyPadding size="small" header="Small Modal"><div>Modal Content</div></BasicModalExample>))
+    .add('large modal', withInfo()(() => <BasicModalExample bodyPadding size="large" header="Large Modal"><div>Modal Content</div></BasicModalExample>))
+    .add('full modal', withInfo()(() => <BasicModalExample bodyPadding size="full" header="Full Modal"><div>Modal Content</div></BasicModalExample>))
     .add('closable modal', withInfo()(() => <ClosableModalExample />))
     // Props table
     .addPropsTable(() => <Modal />);

--- a/packages/storybook/examples/Modal/index.js
+++ b/packages/storybook/examples/Modal/index.js
@@ -9,9 +9,18 @@ import BasicModalExample, { ClosableModalExample } from './BasicModal';
 
 storiesOf('Modal', module)
     .add('basic usage', withInfo()(() => <BasicModalExample bodyPadding><div>Modal Content</div></BasicModalExample>))
-    .add('small modal', withInfo()(() => <BasicModalExample bodyPadding size="small" header="Small Modal"><div>Modal Content</div></BasicModalExample>))
-    .add('large modal', withInfo()(() => <BasicModalExample bodyPadding size="large" header="Large Modal"><div>Modal Content</div></BasicModalExample>))
-    .add('full modal', withInfo()(() => <BasicModalExample bodyPadding size="full" header="Full Modal"><div>Modal Content</div></BasicModalExample>))
+    .add('small modal', withInfo()(() =>
+        (<BasicModalExample bodyPadding size="small" header="Small Modal">
+            <div>Modal Content</div>
+        </BasicModalExample>)))
+    .add('large modal', withInfo()(() =>
+        (<BasicModalExample bodyPadding size="large" header="Large Modal">
+            <div>Modal Content</div>
+        </BasicModalExample>)))
+    .add('full modal', withInfo()(() =>
+        (<BasicModalExample bodyPadding size="full" header="Full Modal">
+            <div>Modal Content</div>
+        </BasicModalExample>)))
     .add('closable modal', withInfo()(() => <ClosableModalExample />))
     // Props table
     .addPropsTable(() => <Modal />);


### PR DESCRIPTION
- Fix the problem that `<Modal>` is not rendering modal content
- Prevent unexpected closing behaviors occur when more than one modals are open.

### Implementations

1. Pass children back to `<ClosableModalContent>`
2. Add `<div>Modal Content</div>` into examples  in the storybook
3. Add a test case to test if the modal content is rendered properly
4. Remove the `Closable` HOC from `<Modal>` to prevent unexpected closing behaviors occur when more than one modals are open.