### PR TITLE
Add a function to close the `<Modal>` when users click `<Overlay>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [Core] Fix `<Modal>` not rendering its content (#139)
 - [Core] Remove the `Closable` HOC from `<Modal>` to prevent unexpected closing behaviors occur when more than one modals are open. (#139)
+- [Core] Add a function to close the `<Modal>` when users click `<Overlay>` and the onClose prop exists. (#140)
 
 ### Changed
 - [Storybook] Refine the showcase of `<Modal>` component. (#139)
+- [Storybook] Add the showcase of two overlaying `<Modal>`. (#140)
 
 ## [1.7.0]
 ### Added

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -1,6 +1,7 @@
 import React, {
   cloneElement,
-  isValidElement
+  isValidElement,
+  PureComponent
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -79,30 +80,45 @@ ModalContent.defaultProps = {
     bodyPadding: false,
 };
 
-function Modal({
-    size,
-    header,
-    bodyClassName,
-    bodyPadding,
-    onClose,
-    // React props
-    className,
-    children,
-}) {
-    const bemClass = BEM.root.modifier(size);
-    const rootClassName = classNames(bemClass.toString(), className);
+class Modal extends PureComponent {
+    constructor(props) {
+        super(props);
+        this.handleOverlayClicked = this.handleOverlayClicked.bind(this);
+    }
 
-    return (
-        <article className={rootClassName}>
-            <Overlay />
-            <ModalContent
-                className={BEM.closable}
-                header={header} bodyClassName={bodyClassName}
-                bodyPadding={bodyPadding} onClose={onClose}>
-                {children}
-            </ModalContent>
-        </article>
-    );
+    handleOverlayClicked(e) {
+        const { onClose } = this.props;
+        // Prevent onClick events being propagated to outer modals
+        e.stopPropagation();
+        if (onClose) { onClose(); }
+    }
+
+    render() {
+        const {
+            size,
+            header,
+            bodyClassName,
+            bodyPadding,
+            onClose,
+            // React props
+            className,
+            children,
+        } = this.props;
+        const bemClass = BEM.root.modifier(size);
+        const rootClassName = classNames(bemClass.toString(), className);
+
+        return (
+            <article className={rootClassName}>
+                <Overlay onClick={this.handleOverlayClicked} />
+                <ModalContent
+                    className={BEM.closable}
+                    header={header} bodyClassName={bodyClassName}
+                    bodyPadding={bodyPadding} onClose={onClose}>
+                    {children}
+                </ModalContent>
+            </article>
+        );
+    }
 }
 
 Modal.propTypes = {

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -81,15 +81,10 @@ ModalContent.defaultProps = {
 };
 
 class Modal extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.handleOverlayClicked = this.handleOverlayClicked.bind(this);
-    }
-
-    handleOverlayClicked(e) {
+    handleOverlayClick = (event) => {
         const { onClose } = this.props;
         // Prevent onClick events being propagated to outer modals
-        e.stopPropagation();
+        event.stopPropagation();
         if (onClose) { onClose(); }
     }
 
@@ -109,11 +104,12 @@ class Modal extends PureComponent {
 
         return (
             <article className={rootClassName}>
-                <Overlay onClick={this.handleOverlayClicked} />
+                <Overlay onClick={this.handleOverlayClick} />
                 <ModalContent
-                    className={BEM.closable}
-                    header={header} bodyClassName={bodyClassName}
-                    bodyPadding={bodyPadding} onClose={onClose}>
+                    header={header}
+                    bodyClassName={bodyClassName}
+                    bodyPadding={bodyPadding}
+                    onClose={onClose}>
                     {children}
                 </ModalContent>
             </article>

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -51,6 +51,22 @@ describe('Pure <PureModal>', () => {
         const wrapper = shallow(<PureModal>{content}</PureModal>);
         expect(wrapper.contains([content])).toBeTruthy();
     });
+
+    it('calls handleOverlayClicked on Overlay click', () => {
+        const wrapper = mount(<PureModal />);
+        const spy = jest.spyOn(wrapper.instance(), 'handleOverlayClicked');
+        wrapper.instance().forceUpdate();
+        wrapper.find(Overlay).simulate('click');
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('calls onClick on Overlay click if the onClose prop is not null', () => {
+        const mockOnClick = jest.fn();
+        const wrapper = mount(<PureModal onClose={mockOnClick} />);
+        wrapper.instance().forceUpdate();
+        wrapper.find(Overlay).simulate('click');
+        expect(mockOnClick).toHaveBeenCalled();
+    });
 });
 
 describe('<PureModal> with a header row', () => {

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -52,9 +52,9 @@ describe('Pure <PureModal>', () => {
         expect(wrapper.contains([content])).toBeTruthy();
     });
 
-    it('calls handleOverlayClicked on Overlay click', () => {
+    it('calls handleOverlayClick on Overlay click', () => {
         const wrapper = mount(<PureModal />);
-        const spy = jest.spyOn(wrapper.instance(), 'handleOverlayClicked');
+        const spy = jest.spyOn(wrapper.instance(), 'handleOverlayClick');
         wrapper.instance().forceUpdate();
         wrapper.find(Overlay).simulate('click');
         expect(spy).toHaveBeenCalled();

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -28,10 +28,7 @@ $component: #{$prefix}-modal;
 //   Modal Elements
 // -------------------------------------
 .#{$prefix}-modal {
-    // Closable
-    &__closable {
-        width: 100%;
-    } // Container
+    // Container
     &__container {
         width: $modal-width-full;
         height: $modal-height;

--- a/packages/storybook/examples/Modal/BasicModal.js
+++ b/packages/storybook/examples/Modal/BasicModal.js
@@ -8,7 +8,7 @@ function BasicModalExample(props) {
     return (
         <Modal {...props}>
             <div>
-                Content of Modal
+                {props.children}
             </div>
         </Modal>
     );

--- a/packages/storybook/examples/Modal/index.js
+++ b/packages/storybook/examples/Modal/index.js
@@ -22,5 +22,11 @@ storiesOf('Modal', module)
             <div>Modal Content</div>
         </BasicModalExample>)))
     .add('closable modal', withInfo()(() => <ClosableModalExample />))
+    .add('closable overlaying modals', withInfo()(() => (<ClosableModalExample size="large">
+        <div>Outer Modal</div>
+        <ClosableModalExample size="small">
+            <div>Inner Modal</div>
+        </ClosableModalExample>
+    </ClosableModalExample>)))
     // Props table
     .addPropsTable(() => <Modal />);


### PR DESCRIPTION
Add a function to close the `<Modal>` when users click the outer `<Overlay>` and the onClose prop exists.

When there are multiple `<Modal>`s open at the same time, the inner `<Modal>` is to be closed first when users click the outer `<Overlay>` .

Please note that `Closable` HOC cannot be used in `<Modal>`, since it registers closing events to the document which causes the outer `<Modal>` to be closed first.

### Implementations

- Add an onClick event to `<Overlay>` to stop the propagation of click events.
- Call onClose if it exists and `<Overlay>` is clicked.

### Screenshot
![screencast 2018-03-06 11-34-52](https://user-images.githubusercontent.com/1139698/37013027-a736984c-2132-11e8-8fa3-a0373f87ba91.gif)
