### PR TITLE
Fix <Popover>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+### Fixed
+- [Core] Fix some content might exceed `<Popover>` container. (#147)
+- [Form] Fix `<Popover>` inside `<SelectRow>` should not be closed until user clicks on the checkbox. (#147)
 
 ## [1.7.2]
 ### Fixed

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -28,6 +28,9 @@ $component-name: #{$prefix}-popover;
         overflow-x: hidden;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
+        // Fix popover content might exceed container boundary on Safari & Chrome
+        // by force-create a stacking context here
+        transform: scale(1);
     }
 
     // Position

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -122,16 +122,15 @@ class SelectRow extends PureComponent {
             this.setState({ cachedValues: newValues });
         }
         this.props.onChange(newValues);
+        this.handlePopoverClose();
     }
 
     renderPopover(selectListProps) {
-        const closableOptions = this.props.multiple ? undefined : { onClickInside: true };
-
         return (
             <Popover
                 anchor={this.anchorNode}
                 className={BEM.popover.toString()}
-                closable={closableOptions}
+                closable={{ onClickInside: false }}
                 onClose={this.handlePopoverClose}>
                 <SelectList
                     values={this.state.cachedValues}


### PR DESCRIPTION
# Purpose
Address issues related to `<Popover>` 

# Changes
- [Core] Fix some content might exceed `<Popover>` container
- [Form] Fix `<Popover>` inside `<SelectRow>` should not be closed until user clicks on the checkbox.

# Screenshot
![2018-03-15 6 49 03](https://user-images.githubusercontent.com/365035/37503233-277a520a-2912-11e8-9f4e-9d49cf2b4a20.png)
