### PR TITLE
Add multi-line mode for <TextInputRow>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Added
+- [Form] New `multiLine` mode for `<TextInputRow>`. It renders a `<textarea>` instead,and auto-grows as user types. (#155)
+- [Storybook] Add examples for multi-line usage of `<TextInputRow>`. (#155)
 
 ## [1.8.0]
 ### Added

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -27,6 +27,7 @@ class TextInputRow extends PureComponent {
         multiLine: PropTypes.bool,
         // input props
         placeholder: PropTypes.string,
+        onChange: PropTypes.func,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func,
         // from formRow()
@@ -37,6 +38,7 @@ class TextInputRow extends PureComponent {
     static defaultProps = {
         multiLine: false,
         placeholder: 'Unset',
+        onChange: () => {},
         onFocus: () => {},
         onBlur: () => {},
         ineditable: false,
@@ -47,6 +49,10 @@ class TextInputRow extends PureComponent {
         focused: false,
         inputHeight: 'auto',
     };
+
+    componentDidMount() {
+        this.updateInputHeight();
+    }
 
     setInputRef = (ref) => {
         this.inputRef = ref;
@@ -61,14 +67,29 @@ class TextInputRow extends PureComponent {
      */
     getInputNode = this.getInputRef;
 
+    updateInputHeight(inputNode = this.getInputRef()) {
+        const newHeight = inputNode.scrollHeight;
+        this.setState({ inputHeight: newHeight });
+    }
+
     handleInputFocus = (event) => {
-        this.setState({ focused: true });
+        const inputNode = event.target;
+
+        this.setState(
+            { focused: true },
+            () => this.updateInputHeight(inputNode)
+        );
         this.props.onFocus(event);
     }
 
     handleInputBlur = (event) => {
         this.setState({ focused: false });
         this.props.onBlur(event);
+    }
+
+    handleInputChange = (event) => {
+        this.updateInputHeight(event.target);
+        this.props.onChange(event);
     }
 
     renderInput({
@@ -92,6 +113,7 @@ class TextInputRow extends PureComponent {
             return (
                 <textarea
                     style={textareaStyle}
+                    onChange={this.handleInputChange}
                     {...sharedProps}
                     {...inputProps} />
             );
@@ -100,6 +122,7 @@ class TextInputRow extends PureComponent {
         return (
             <input
                 type="text"
+                onChange={this.props.onChange}
                 {...sharedProps}
                 {...inputProps} />
         );
@@ -113,6 +136,7 @@ class TextInputRow extends PureComponent {
             // placeholder,
             onFocus,
             onBlur,
+            onChange,
             // row props
             ineditable,
             rowProps,

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -24,6 +24,7 @@ export const BEM = {
 class TextInputRow extends PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
+        multiLine: PropTypes.bool,
         // input props
         placeholder: PropTypes.string,
         onFocus: PropTypes.func,
@@ -35,6 +36,7 @@ class TextInputRow extends PureComponent {
 
     static defaultProps = {
         placeholder: 'Unset',
+        multiLine: false,
         onFocus: () => {},
         onBlur: () => {},
         ineditable: false,
@@ -45,9 +47,18 @@ class TextInputRow extends PureComponent {
         focused: false,
     };
 
-    getInputNode() {
-        return this.inputRef;
+    setInputRef = (ref) => {
+        this.inputRef = ref;
     }
+
+    getInputRef = () => this.inputRef;
+
+    /**
+     * Use `getInputRef()` instead.
+     * Should remove in v2.
+     * @deprecated
+     */
+    getInputNode = this.getInputRef;
 
     handleInputFocus = (event) => {
         this.setState({ focused: true });
@@ -59,14 +70,26 @@ class TextInputRow extends PureComponent {
         this.props.onBlur(event);
     }
 
-    renderInput(inputProps) {
+    renderInput(multiLine, inputProps) {
+        const sharedProps = {
+            ref: this.setInputRef,
+            className: BEM.input.toString(),
+            onFocus: this.handleInputFocus,
+            onBlur: this.handleInputBlur,
+        };
+
+        if (multiLine) {
+            return (
+                <textarea
+                    {...sharedProps}
+                    {...inputProps} />
+            );
+        }
+
         return (
             <input
-                ref={(ref) => { this.inputRef = ref; }}
                 type="text"
-                className={BEM.input.toString()}
-                onFocus={this.handleInputFocus}
-                onBlur={this.handleInputBlur}
+                {...sharedProps}
                 {...inputProps} />
         );
     }
@@ -74,6 +97,7 @@ class TextInputRow extends PureComponent {
     render() {
         const {
             label,
+            multiLine,
             // input props
             // placeholder,
             onFocus,
@@ -97,13 +121,13 @@ class TextInputRow extends PureComponent {
                 {label}
             </span>
         );
+        const input = this.renderInput(multiLine, inputProps);
 
         return (
             <ListRow className={rootClassName} {...rowProps}>
                 <TextLabel
                     basic={keyLabel}
-                    aside={this.renderInput(inputProps)} />
-
+                    aside={input} />
                 {children}
             </ListRow>
         );

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -26,6 +26,7 @@ class TextInputRow extends PureComponent {
         label: PropTypes.node.isRequired,
         multiLine: PropTypes.bool,
         // input props
+        value: PropTypes.string,
         placeholder: PropTypes.string,
         onChange: PropTypes.func,
         onFocus: PropTypes.func,
@@ -37,6 +38,7 @@ class TextInputRow extends PureComponent {
 
     static defaultProps = {
         multiLine: false,
+        value: undefined,
         placeholder: 'Unset',
         onChange: () => {},
         onFocus: () => {},
@@ -52,6 +54,12 @@ class TextInputRow extends PureComponent {
 
     componentDidMount() {
         this.updateInputHeight(this.getInputRef());
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.value !== prevProps.value) {
+            this.updateInputHeight(this.getInputRef());
+        }
     }
 
     setInputRef = (ref) => {
@@ -133,10 +141,11 @@ class TextInputRow extends PureComponent {
             label,
             // multiLine,
             // input props
+            // value,
             // placeholder,
+            onChange,
             onFocus,
             onBlur,
-            onChange,
             // row props
             ineditable,
             rowProps,

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -35,8 +35,8 @@ class TextInputRow extends PureComponent {
     };
 
     static defaultProps = {
-        placeholder: 'Unset',
         multiLine: false,
+        placeholder: 'Unset',
         onFocus: () => {},
         onBlur: () => {},
         ineditable: false,
@@ -45,6 +45,7 @@ class TextInputRow extends PureComponent {
 
     state = {
         focused: false,
+        inputHeight: 'auto',
     };
 
     setInputRef = (ref) => {
@@ -70,7 +71,11 @@ class TextInputRow extends PureComponent {
         this.props.onBlur(event);
     }
 
-    renderInput(multiLine, inputProps) {
+    renderInput({
+        multiLine,
+        style: inputStyle = {},
+        ...inputProps
+    }) {
         const sharedProps = {
             ref: this.setInputRef,
             className: BEM.input.toString(),
@@ -78,9 +83,15 @@ class TextInputRow extends PureComponent {
             onBlur: this.handleInputBlur,
         };
 
+        const textareaStyle = {
+            ...inputStyle,
+            height: this.state.inputHeight,
+        };
+
         if (multiLine) {
             return (
                 <textarea
+                    style={textareaStyle}
                     {...sharedProps}
                     {...inputProps} />
             );
@@ -97,7 +108,7 @@ class TextInputRow extends PureComponent {
     render() {
         const {
             label,
-            multiLine,
+            // multiLine,
             // input props
             // placeholder,
             onFocus,
@@ -108,7 +119,7 @@ class TextInputRow extends PureComponent {
             // React props
             className,
             children,
-            ...inputProps,
+            ...renderInputProps,
         } = this.props;
 
         const bemClass = BEM.root
@@ -121,7 +132,7 @@ class TextInputRow extends PureComponent {
                 {label}
             </span>
         );
-        const input = this.renderInput(multiLine, inputProps);
+        const input = this.renderInput(renderInputProps);
 
         return (
             <ListRow className={rootClassName} {...rowProps}>

--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -51,7 +51,7 @@ class TextInputRow extends PureComponent {
     };
 
     componentDidMount() {
-        this.updateInputHeight();
+        this.updateInputHeight(this.getInputRef());
     }
 
     setInputRef = (ref) => {
@@ -67,7 +67,7 @@ class TextInputRow extends PureComponent {
      */
     getInputNode = this.getInputRef;
 
-    updateInputHeight(inputNode = this.getInputRef()) {
+    updateInputHeight(inputNode) {
         const newHeight = inputNode.scrollHeight;
         this.setState({ inputHeight: newHeight });
     }

--- a/packages/form/src/__tests__/TextInputRow.test.js
+++ b/packages/form/src/__tests__/TextInputRow.test.js
@@ -31,6 +31,20 @@ describe('Pure <TextInputRow>', () => {
         expect(wrapper.find('input').prop('tabIndex')).toBe(3);
     });
 
+    it('renders a <textarea> inside with unknown props under multiLine mode', () => {
+        const wrapper = mount(
+            <PureTextInputRow
+                multiLine
+                label="foo"
+                defaultValue="bar" />
+        );
+        expect(wrapper.find('textarea').exists()).toBeTruthy();
+
+        wrapper.setProps({ id: 'foo', tabIndex: 3 });
+        expect(wrapper.find('textarea').prop('id')).toBe('foo');
+        expect(wrapper.find('textarea').prop('tabIndex')).toBe(3);
+    });
+
     it('enters and leaves focused state on input events', () => {
         const focusedModifier = BEM.root
             .modifier('focused')
@@ -50,6 +64,35 @@ describe('Pure <TextInputRow>', () => {
         wrapper.find('input').simulate('blur');
         expect(wrapper.state('focused')).toBeFalsy();
         expect(wrapper.hasClass(focusedModifier)).toBeFalsy();
+    });
+
+    it('auto-grows on mount, on focus and on change under multiLine mode', () => {
+        /**
+         * Patch `this.getInputRef` on component instance
+         * so we can see if the value gets applied on mount.
+         */
+        class PatchedRow extends PureTextInputRow {
+            getInputRef = jest.fn(() => ({ scrollHeight: 30 }));
+        }
+
+        const wrapper = mount(
+            <PatchedRow
+                multiLine
+                label="foo"
+                defaultValue="bar" />
+        );
+
+        expect(wrapper.find('textarea').prop('style')).toEqual({ height: 30 });
+
+        wrapper.find('textarea').simulate('focus', {
+            target: { scrollHeight: 40 },
+        });
+        expect(wrapper.find('textarea').prop('style')).toEqual({ height: 40 });
+
+        wrapper.find('textarea').simulate('change', {
+            target: { scrollHeight: 90 },
+        });
+        expect(wrapper.find('textarea').prop('style')).toEqual({ height: 90 });
     });
 
     it('accepts additional children', () => {

--- a/packages/storybook/examples/Form.TextInputRow/ControlledRow.js
+++ b/packages/storybook/examples/Form.TextInputRow/ControlledRow.js
@@ -1,0 +1,34 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import TextInputRow from '@ichef/gypcrete-form/src/TextInputRow';
+
+class ControlledRow extends PureComponent {
+    static propTypes = {
+        initValue: PropTypes.string.isRequired,
+    };
+
+    state = {
+        value: this.props.initValue,
+    };
+
+    handleInputChange = (event) => {
+        this.setState({ value: event.target.value });
+    }
+
+    render() {
+        const {
+            initValue,
+            ...otherProps
+        } = this.props;
+
+        return (
+            <TextInputRow
+                label="Controlled row"
+                value={this.state.value}
+                onChange={this.handleInputChange}
+                {...otherProps} />
+        );
+    }
+}
+
+export default ControlledRow;

--- a/packages/storybook/examples/Form.TextInputRow/MultiLineUsage.js
+++ b/packages/storybook/examples/Form.TextInputRow/MultiLineUsage.js
@@ -2,35 +2,49 @@ import React from 'react';
 
 import List from '@ichef/gypcrete/src/List';
 import TextInputRow from '@ichef/gypcrete-form/src/TextInputRow';
+
 import ControlledRow from './ControlledRow';
 
-function BasicUsage() {
+const EXAMPLE_TEXT = (`
+Lorem ipsum dolor sit amet,
+
+consectetur adipiscing elit.
+Donec vitae nibh sem.
+`).trim();
+
+function MultiLineUsage() {
     return (
         <List title="Configs">
             <TextInputRow
+                multiLine
                 label="Module name"
-                defaultValue="Points module" />
+                defaultValue={EXAMPLE_TEXT} />
 
-            <ControlledRow initValue="Points module" />
+            <ControlledRow
+                multiLine
+                initValue={EXAMPLE_TEXT} />
 
             <TextInputRow
+                multiLine
                 disabled
                 label="Disabled row"
-                value="Points module" />
+                value={EXAMPLE_TEXT} />
 
             <TextInputRow
+                multiLine
                 readOnly
                 label="Read-only row"
-                value="Points module" />
+                value={EXAMPLE_TEXT} />
 
 
             <TextInputRow
+                multiLine
                 label="Secret code"
-                value="Foo bar"
+                value={EXAMPLE_TEXT}
                 status="error"
                 errorMsg="Cannot authenticate with this code." />
         </List>
     );
 }
 
-export default BasicUsage;
+export default MultiLineUsage;

--- a/packages/storybook/examples/Form.TextInputRow/index.js
+++ b/packages/storybook/examples/Form.TextInputRow/index.js
@@ -6,8 +6,10 @@ import { withInfo } from '@storybook/addon-info';
 import TextInputRow from '@ichef/gypcrete-form/src/TextInputRow';
 
 import BasicUsage from './BasicUsage';
+import MultiLineUsage from './MultiLineUsage';
 
 storiesOf('[Form] TextInputRow', module)
     .add('basic usage', withInfo()(BasicUsage))
+    .add('multi-line usage', withInfo()(MultiLineUsage))
     // Props table
     .addPropsTable(() => <TextInputRow />);


### PR DESCRIPTION
# Purpose
Allow `<TextInputRow>` to render an auto-growing `<textarea>` instead for multi-line contents.

# Changes
- Add `multiLine` prop to `<TextInputRow>` to render `<textarea>`
- Add examples and update tests for updated `<TextInputRow>`

# Screenshot
![2018-04-27 5 32 21](https://user-images.githubusercontent.com/365035/39355865-f8c9e1e6-4a40-11e8-81a1-5ad0eccec687.png)
