### PR TITLE
Check <SelectOption> with symbol instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Added
+- [Form] Add new `SelectOption.typeSymbol` for element type comparison. (#157)
+- [Form] Add `getElementTypeSymbol` helper for getting type symbol from React Element. (#157)
 
 ## [1.8.0]
 ### Added

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -6,8 +6,13 @@ import {
     List,
 } from '@ichef/gypcrete';
 
-import Option, { valueType } from './SelectOption';
+import Option, {
+    valueType,
+    TYPE_SYMBOL as OPTION_TYPE_SYMBOL,
+} from './SelectOption';
+
 import parseSelectOptions from './utils/parseSelectOptions';
+import getElementTypeSymbol from './utils/getElementTypeSymbol';
 
 function getInitialCheckedState(fromValues) {
     const checkedState = new ImmutableMap();
@@ -158,7 +163,7 @@ class SelectList extends PureComponent {
 
     renderOptions() {
         return React.Children.map(this.props.children, (child) => {
-            if (child && child.type === Option) {
+            if (getElementTypeSymbol(child) === OPTION_TYPE_SYMBOL) {
                 return React.cloneElement(child, {
                     checked: this.state.checkedState.get(child.props.value),
                     onChange: this.handleOptionChange,

--- a/packages/form/src/SelectOption.js
+++ b/packages/form/src/SelectOption.js
@@ -12,6 +12,8 @@ export const valueType = PropTypes.oneOfType([
     PropTypes.bool,
 ]);
 
+export const TYPE_SYMBOL = Symbol('SelectOption');
+
 function SelectOption({
     label,
     value,
@@ -51,5 +53,15 @@ SelectOption.defaultProps = {
     checked: false,
     onChange: () => {},
 };
+
+/**
+ * `react-hot-loader` v4 wraps every single component with a proxy for its
+ * internal uses. This breaks the comparison of this component and type from
+ * any React.Element, because the later will always be a hot-loader proxy.
+ *
+ * I'm trying to add a new way for comparison so we can still be sure if an
+ * element is created from <SelectOption>.
+ */
+SelectOption.typeSymbol = TYPE_SYMBOL;
 
 export default SelectOption;

--- a/packages/form/src/utils/__tests__/getElementTypeSymbol.test.js
+++ b/packages/form/src/utils/__tests__/getElementTypeSymbol.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import getElementTypeSymbol from '../getElementTypeSymbol';
+
+const SYMBOL = Symbol('foo');
+
+it('looks for typeSymbol from a React.Element', () => {
+    const NormalComponent = () => null;
+    expect(getElementTypeSymbol(<NormalComponent />)).toBeNull();
+
+    const ComponentWithSymbol = () => null;
+    ComponentWithSymbol.typeSymbol = SYMBOL;
+    expect(getElementTypeSymbol(<ComponentWithSymbol />)).toBe(SYMBOL);
+});
+
+it('returns null for anything other than React.Element', () => {
+    expect(getElementTypeSymbol(undefined)).toBeNull();
+    expect(getElementTypeSymbol('string')).toBeNull();
+    expect(getElementTypeSymbol(123)).toBeNull();
+});

--- a/packages/form/src/utils/getElementTypeSymbol.js
+++ b/packages/form/src/utils/getElementTypeSymbol.js
@@ -1,0 +1,13 @@
+import { isValidElement } from 'react';
+
+function getElementTypeSymbol(element) {
+    let symbol;
+
+    if (isValidElement(element)) {
+        symbol = element.type.typeSymbol;
+    }
+
+    return symbol || null;
+}
+
+export default getElementTypeSymbol;

--- a/packages/form/src/utils/parseSelectOptions.js
+++ b/packages/form/src/utils/parseSelectOptions.js
@@ -1,5 +1,7 @@
 import { Children } from 'react';
-import SelectOption from '../SelectOption';
+import { TYPE_SYMBOL } from '../SelectOption';
+
+import getElementTypeSymbol from './getElementTypeSymbol';
 
 /**
  * Convert children of `<SelectOptions>` components to array of options.
@@ -11,7 +13,7 @@ function parseSelectOptions(children) {
     const results = [];
 
     Children.forEach(children, (child) => {
-        if (child && child.type === SelectOption) {
+        if (getElementTypeSymbol(child) === TYPE_SYMBOL) {
             results.push(child.props);
         }
     });


### PR DESCRIPTION
# Purpose
`react-hot-loader` v4 wraps every single component with a proxy for its internal uses.
This breaks `<SelectList>` when it reads configs from children and compares every child's `type` to `<SelectOption>`, because those `type`s are proxied.

To avoid the side effect, I've add a `SelectOption.typeSymbol` to be used for comparison instead.

# Changes
- [Form] Add new `SelectOption.typeSymbol` for element type comparison.
- [Form] Add `getElementTypeSymbol` helper for getting type symbol from React Element.
