### PR TITLE
Fix Popover inside <SelectRow> to not auto-close under multiple mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Form] Add new `SelectOption.typeSymbol` for element type comparison. (#157)
 - [Form] Add `getElementTypeSymbol` helper for getting type symbol from React Element. (#157)
 
+### Fixed
+- [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)
+
 ## [1.8.0]
 ### Added
 - [ImageEditor] Add new package `@ichef/gypcrete-imageeditor`. (#148, #149, #150, #151)

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -122,7 +122,10 @@ class SelectRow extends PureComponent {
             this.setState({ cachedValues: newValues });
         }
         this.props.onChange(newValues);
-        this.handlePopoverClose();
+
+        if (!this.props.multiple) {
+            this.handlePopoverClose();
+        }
     }
 
     renderPopover(selectListProps) {

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -10,10 +10,7 @@ import {
     TextLabel,
 } from '@ichef/gypcrete';
 
-import { PurePopover } from '@ichef/gypcrete/lib/Popover';
-import anchored from '@ichef/gypcrete/lib/mixins/anchored';
-import closable from '@ichef/gypcrete/lib/mixins/closable';
-import renderToLayer from '@ichef/gypcrete/lib/mixins/renderToLayer';
+import Popover from '@ichef/gypcrete/lib/Popover';
 import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
 import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
 
@@ -31,15 +28,11 @@ export const BEM = {
     placeholder: ROOT_BEM.element('placeholder'),
 };
 
-export const Popover = renderToLayer(
-    closable({
-        onEscape: true,
-        onClickOutside: true,
-        onClickInside: false,
-    })(
-        anchored()(PurePopover)
-    )
-);
+const CLOSABLE_CONFIG = {
+    onEscape: true,
+    onClickOutside: true,
+    onClickInside: false,
+};
 
 /**
  * Generate a value-label map from all `<SelectOption>`s.
@@ -133,7 +126,7 @@ class SelectRow extends PureComponent {
             <Popover
                 anchor={this.anchorNode}
                 className={BEM.popover.toString()}
-                closable={{ onClickInside: false }}
+                closable={CLOSABLE_CONFIG}
                 onClose={this.handlePopoverClose}>
                 <SelectList
                     values={this.state.cachedValues}

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -4,11 +4,12 @@ import { shallow } from 'enzyme';
 
 import {
     Button,
+    Popover,
     Text,
     TextLabel,
 } from '@ichef/gypcrete';
 
-import SelectRow, { PureSelectRow, Popover, BEM } from '../SelectRow';
+import SelectRow, { PureSelectRow, BEM } from '../SelectRow';
 import SelectList from '../SelectList';
 import Option from '../SelectOption';
 
@@ -27,7 +28,7 @@ describe('formRow(SelectRow)', () => {
     });
 });
 
-describe('Pure <SelectRow>', () => {
+describe('Pure <SelectRow>: UI', () => {
     it('renders a <Button> if the row is editable', () => {
         const wrapper = shallow(
             <PureSelectRow label="Select" />
@@ -60,7 +61,7 @@ describe('Pure <SelectRow>', () => {
         expect(wrapper.find(Popover).find(SelectList).exists()).toBeTruthy();
     });
 
-    it('removed <Popover> when it requests close', () => {
+    it('removes <Popover> when it requests close', () => {
         const wrapper = shallow(
             <PureSelectRow label="Select" />
         );
@@ -70,6 +71,28 @@ describe('Pure <SelectRow>', () => {
         wrapper.find(Popover).simulate('close');
         wrapper.setState({ popoverOpen: false });
         expect(wrapper.find(Popover).exists()).toBeFalsy();
+    });
+
+    it('removes <Popover> when value change under single-select mode', () => {
+        const wrapper = shallow(
+            <PureSelectRow label="Select" />
+        );
+
+        // Single-select mode: auto close Popover
+        expect(wrapper.find(Button).simulate('click'));
+        expect(wrapper.find(Popover).exists()).toBeTruthy();
+
+        wrapper.find(SelectList).simulate('change', [1]);
+        expect(wrapper.find(Popover).exists()).toBeFalsy();
+
+        // Multi-select mode: Popover remains
+        wrapper.setProps({ multiple: true });
+
+        expect(wrapper.find(Button).simulate('click'));
+        expect(wrapper.find(Popover).exists()).toBeTruthy();
+
+        wrapper.find(SelectList).simulate('change', [2]);
+        expect(wrapper.find(Popover).exists()).toBeTruthy();
     });
 
     it('passes children to <SelectList> inside <Popover>', () => {
@@ -84,7 +107,9 @@ describe('Pure <SelectRow>', () => {
         expect(element.props.children)
             .toEqual(wrapper.find(SelectList).prop('children'));
     });
+});
 
+describe('Pure <SelectRow>: Data', () => {
     it('caches selected values from <SelectList> when uncontrolled', () => {
         const wrapper = shallow(
             <PureSelectRow multiple label="Select" />


### PR DESCRIPTION
# Purpose
The popover inside `<SelectRow>` is closed automatically after value changes.
While this is desired behavior under single-selection mode, it should be prevented under multiple mode.

# Changes
- [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode.
- [Form] Refactor `<SelectRow>` to use `<Popover>` directly from core package, and controls its `closable` behavior via props.

# Demo
![popover](https://user-images.githubusercontent.com/365035/39741970-6b7d7226-52ce-11e8-8152-d0f0944354c6.gif)
