### PR TITLE
Various UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Form] Add new `SelectOption.typeSymbol` for element type comparison. (#157)
 - [Form] Add `getElementTypeSymbol` helper for getting type symbol from React Element. (#157)
 
+### Changed
+- [Core] Update styles to match design for: `<List>`. (#159)
+- [Core] `<Button>`s are now `bold` by default. (#159)
+- [Core] `<Text>` and `rowComp()` now preserve white space by default. (#159)
+
 ### Fixed
 - [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)
+- [Core] Fix `<ListRow>` footer should not render empty `<p>` tags. (#159)
 
 ## [1.8.0]
 ### Added

--- a/packages/core/src/Button.js
+++ b/packages/core/src/Button.js
@@ -54,4 +54,7 @@ Button.defaultProps = {
 // export for tests
 export { Button as PureButton };
 
-export default rowComp({ defaultMinified: true })(Button);
+const RowCompButton = rowComp({ defaultMinified: true })(Button);
+RowCompButton.defaultProps.bold = true;
+
+export default RowCompButton;

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -67,8 +67,8 @@ class ListRow extends PureComponent<Props, Props, any> {
 
         return (
             <div className={BEM.footer.toString()}>
-                {wrapIfNotElement(errorMsg, { with: 'p' })}
-                {wrapIfNotElement(desc, { with: 'p' })}
+                {errorMsg && wrapIfNotElement(errorMsg, { with: 'p' })}
+                {desc && wrapIfNotElement(desc, { with: 'p' })}
             </div>
         );
     }

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -51,6 +51,7 @@ export type Props = {
     basicRow: AnyReactElement,
     noGrow: boolean,
     bold: boolean,
+    preserveWhiteSpace: boolean,
     errorMsg?: string,
     statusIcon?: ReactChildren, // #FIXME: use type from withStatus()
     basic: $PropertyType<BasicRowProps, 'basic'>,
@@ -67,6 +68,7 @@ class Text extends PureComponent {
         basicRow: PropTypes.element,
         noGrow: PropTypes.bool,
         bold: PropTypes.bool,
+        preserveWhiteSpace: PropTypes.bool,
 
         ...withStatusPropTypes,
         // errorMsg: string,
@@ -84,6 +86,7 @@ class Text extends PureComponent {
         basicRow: <BasicRow />,
         noGrow: false,
         bold: false,
+        preserveWhiteSpace: true,
         errorMsg: undefined,
         statusIcon: undefined,
         ...BasicRow.defaultProps,
@@ -128,12 +131,19 @@ class Text extends PureComponent {
     }
 
     render() {
-        const { align, noGrow, bold, className } = this.props;
+        const {
+            align,
+            noGrow,
+            bold,
+            preserveWhiteSpace,
+            className,
+        } = this.props;
 
         const bemClass = BEM.root
             .modifier(align)
             .modifier('no-grow', noGrow)
-            .modifier('bold', bold);
+            .modifier('bold', bold)
+            .modifier('pre', preserveWhiteSpace);
 
         const rootClassName = classNames(bemClass.toString(), className);
 

--- a/packages/core/src/__tests__/Text.test.js
+++ b/packages/core/src/__tests__/Text.test.js
@@ -106,4 +106,10 @@ describe('Pure <Text>', () => {
 
         expect(wrapper.hasClass('gyp-text--bold')).toBeTruthy();
     });
+
+    it('can render in preserve-whitespace mode', () => {
+        const wrapper = shallow(<PureText preserveWhiteSpace basic="foo" />);
+
+        expect(wrapper.hasClass('gyp-text--pre')).toBeTruthy();
+    });
 });

--- a/packages/core/src/mixins/__tests__/rowComp.test.js
+++ b/packages/core/src/mixins/__tests__/rowComp.test.js
@@ -32,6 +32,7 @@ it('renders <Text> into wrapped component', () => {
 
     expect(textWrapper.exists()).toBeTruthy();
     expect(textWrapper.prop('bold')).toBeTruthy();
+    expect(textWrapper.prop('preserveWhiteSpace')).toBeTruthy();
     expect(textWrapper.prop('basic')).toBe('Basic text');
     expect(textWrapper.prop('tag')).toBe('Tag');
     expect(textWrapper.prop('aside')).toBe('Aside text');

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -117,6 +117,7 @@ const rowComp = ({
             aside: PropTypes.node,
             tag: PropTypes.node,
             bold: PropTypes.bool,
+            preserveWhiteSpace: PropTypes.bool,
 
             // State props
             active: PropTypes.bool,
@@ -138,6 +139,7 @@ const rowComp = ({
             aside: null,
             tag: null,
             bold: false,
+            preserveWhiteSpace: true,
 
             active: false,
             highlight: false,
@@ -183,12 +185,14 @@ const rowComp = ({
             const {
                 align,
                 icon,
+                // text props
                 basic,
                 aside,
                 tag,
                 bold,
+                preserveWhiteSpace,
             } = this.props;
-            const textProps = { basic, aside, tag, bold };
+            const textProps = { basic, aside, tag, bold, preserveWhiteSpace };
             const textLayoutProps = getTextLayoutProps(align, !!icon);
 
             // Render icon element
@@ -213,6 +217,7 @@ const rowComp = ({
                 aside,
                 tag,
                 bold,
+                preserveWhiteSpace,
 
                 active,
                 highlight,

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -34,7 +34,7 @@ $component: #{$prefix}-list;
     // --------------------
     &--normal {
         .#{$component}__title {
-            border-bottom: 1px solid $c-divider-header;
+            border-bottom: 2px solid $c-divider-header;
         }
 
         .#{$component}__title,

--- a/packages/core/src/styles/Text.scss
+++ b/packages/core/src/styles/Text.scss
@@ -55,6 +55,12 @@
         }
     }
 
+    &--pre {
+        .#{$prefix}-text__row {
+            white-space: pre-wrap;
+        }
+    }
+
     &--center {
         .#{$prefix}-text__row {
             justify-content: center;


### PR DESCRIPTION
# Changes
- [Core] Update styles to match design for: `<List>`.
- [Core] `<Button>`is now `bold` by default.
- [Core] `<Text>` and `rowComp()` now preserve white space by default.
- [Core] Fix `<ListRow>` footer should not render empty `<p>` tags.