### PR TITLE
Preserve white spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Core] Update styles to match design for: `<List>`. (#159)
 - [Core] `<Button>`s are now `bold` by default. (#159)
+- [Core] The following components now preserve white spaces: (#160)
+    * `<Text>` (which is in most row-components)
+    * `<List>` (in title and desc)
+    * `<ListRow>` (in desc)
+    * `<Tag>`
+    * `<Tooltip>`
 
 ### Fixed
 - [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Core] Update styles to match design for: `<List>`. (#159)
 - [Core] `<Button>`s are now `bold` by default. (#159)
-- [Core] `<Text>` and `rowComp()` now preserve white space by default. (#159)
 
 ### Fixed
 - [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -51,7 +51,6 @@ export type Props = {
     basicRow: AnyReactElement,
     noGrow: boolean,
     bold: boolean,
-    preserveWhiteSpace: boolean,
     errorMsg?: string,
     statusIcon?: ReactChildren, // #FIXME: use type from withStatus()
     basic: $PropertyType<BasicRowProps, 'basic'>,
@@ -68,7 +67,6 @@ class Text extends PureComponent {
         basicRow: PropTypes.element,
         noGrow: PropTypes.bool,
         bold: PropTypes.bool,
-        preserveWhiteSpace: PropTypes.bool,
 
         ...withStatusPropTypes,
         // errorMsg: string,
@@ -86,7 +84,6 @@ class Text extends PureComponent {
         basicRow: <BasicRow />,
         noGrow: false,
         bold: false,
-        preserveWhiteSpace: true,
         errorMsg: undefined,
         statusIcon: undefined,
         ...BasicRow.defaultProps,
@@ -131,19 +128,12 @@ class Text extends PureComponent {
     }
 
     render() {
-        const {
-            align,
-            noGrow,
-            bold,
-            preserveWhiteSpace,
-            className,
-        } = this.props;
+        const { align, noGrow, bold, className } = this.props;
 
         const bemClass = BEM.root
             .modifier(align)
             .modifier('no-grow', noGrow)
-            .modifier('bold', bold)
-            .modifier('pre', preserveWhiteSpace);
+            .modifier('bold', bold);
 
         const rootClassName = classNames(bemClass.toString(), className);
 

--- a/packages/core/src/__tests__/Text.test.js
+++ b/packages/core/src/__tests__/Text.test.js
@@ -106,10 +106,4 @@ describe('Pure <Text>', () => {
 
         expect(wrapper.hasClass('gyp-text--bold')).toBeTruthy();
     });
-
-    it('can render in preserve-whitespace mode', () => {
-        const wrapper = shallow(<PureText preserveWhiteSpace basic="foo" />);
-
-        expect(wrapper.hasClass('gyp-text--pre')).toBeTruthy();
-    });
 });

--- a/packages/core/src/mixins/__tests__/rowComp.test.js
+++ b/packages/core/src/mixins/__tests__/rowComp.test.js
@@ -32,7 +32,6 @@ it('renders <Text> into wrapped component', () => {
 
     expect(textWrapper.exists()).toBeTruthy();
     expect(textWrapper.prop('bold')).toBeTruthy();
-    expect(textWrapper.prop('preserveWhiteSpace')).toBeTruthy();
     expect(textWrapper.prop('basic')).toBe('Basic text');
     expect(textWrapper.prop('tag')).toBe('Tag');
     expect(textWrapper.prop('aside')).toBe('Aside text');

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -117,7 +117,6 @@ const rowComp = ({
             aside: PropTypes.node,
             tag: PropTypes.node,
             bold: PropTypes.bool,
-            preserveWhiteSpace: PropTypes.bool,
 
             // State props
             active: PropTypes.bool,
@@ -139,7 +138,6 @@ const rowComp = ({
             aside: null,
             tag: null,
             bold: false,
-            preserveWhiteSpace: true,
 
             active: false,
             highlight: false,
@@ -185,14 +183,12 @@ const rowComp = ({
             const {
                 align,
                 icon,
-                // text props
                 basic,
                 aside,
                 tag,
                 bold,
-                preserveWhiteSpace,
             } = this.props;
-            const textProps = { basic, aside, tag, bold, preserveWhiteSpace };
+            const textProps = { basic, aside, tag, bold };
             const textLayoutProps = getTextLayoutProps(align, !!icon);
 
             // Render icon element
@@ -217,7 +213,6 @@ const rowComp = ({
                 aside,
                 tag,
                 bold,
-                preserveWhiteSpace,
 
                 active,
                 highlight,

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -17,6 +17,7 @@ $component: #{$prefix}-list;
     &__desc {
         font-size: rem($aside-text-font-size);
         line-height: rem($aside-text-line-height);
+        white-space: pre-wrap;
     }
 
     &__title {

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -38,6 +38,7 @@ $component: #{$prefix}-list-row;
         line-height: rem($list-row-footer-line-height);
         padding-top: rem($list-row-footer-padding-top);
         padding-bottom: rem($list-row-footer-padding-bottom);
+        white-space: pre-wrap;
 
         p {
             margin: 0 0 rem($list-row-footer-padding-bottom);

--- a/packages/core/src/styles/Tag.scss
+++ b/packages/core/src/styles/Tag.scss
@@ -21,6 +21,7 @@
     background-clip: padding-box;
     display: inline-block;
     vertical-align: text-top;
+    white-space: pre-wrap;
 
     & > span {
         color: $c-white;

--- a/packages/core/src/styles/Text.scss
+++ b/packages/core/src/styles/Text.scss
@@ -16,6 +16,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
+    white-space: pre-wrap;
 }
 
 // ===============
@@ -26,6 +27,7 @@
     &__row {
         display: flex;
         align-items: flex-start;
+        white-space: pre-wrap;
     }
 
     &__basic {

--- a/packages/core/src/styles/Text.scss
+++ b/packages/core/src/styles/Text.scss
@@ -55,12 +55,6 @@
         }
     }
 
-    &--pre {
-        .#{$prefix}-text__row {
-            white-space: pre-wrap;
-        }
-    }
-
     &--center {
         .#{$prefix}-text__row {
             justify-content: center;

--- a/packages/core/src/styles/Tooltip.scss
+++ b/packages/core/src/styles/Tooltip.scss
@@ -17,6 +17,7 @@
     display: inline-block;
     vertical-align: text-top;
     position: relative;
+    white-space: pre-wrap;
 
     // ----------------------
     //  <Tooltip> elements


### PR DESCRIPTION
# Purpose
Preserve white spaces on core components.

# Changes
- Reverted the optional `preserveWhitespace` prop on `<Text>` that was introduced in #159, since there are more places that needs to preserve white spaces and it's hard to maintain a unified prop way for that.
- Preserve white spaces on the following components:
  * `<Text>` (which is in most row-components)
  * `<List>` (in title and desc)
  * `<ListRow>` (in desc)
  * `<Tag>`
  * `<Tooltip>`

# Discussion
I was thinking if we can introduce a span-level text component that manages styles (e.g. white-space preserving, text ellipsis) for text, and fill every text with that component.

But that will be a major breaking change, so I guess it should hold until 2.0