### PR TITLE
Remove input auto-blur in editable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     * `<ListRow>` (in desc)
     * `<Tag>`
     * `<Tooltip>`
+- [Core] Input inside `<EditableBasicRow>` does not blur on component status change anymore. (#161)
 
 ### Fixed
 - [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)

--- a/packages/core/src/EditableBasicRow.js
+++ b/packages/core/src/EditableBasicRow.js
@@ -129,10 +129,6 @@ class EditableBasicRow extends PureComponent<Props, Props, any> {
         if (nextProps.value !== this.props.value) {
             this.setState({ currentValue: nextProps.value });
         }
-
-        if (this.inputNode && nextProps.status !== this.props.status) {
-            this.inputNode.blur();
-        }
     }
 
     handleInputFocus = (event: Event) => {

--- a/packages/core/src/__tests__/EditableBasicRow.test.js
+++ b/packages/core/src/__tests__/EditableBasicRow.test.js
@@ -113,17 +113,6 @@ it('renders basic label with additional line-break when tag is textarea', () => 
     expect(wrapper.find(labelClass).text()).toBe('Foo\n\n');
 });
 
-it('blurs input when status changes', () => {
-    const mockedInputBlur = jest.fn();
-    const wrapper = mount(<EditableBasicRow />);
-    wrapper.instance().inputNode.blur = mockedInputBlur;
-
-    expect(mockedInputBlur).not.toHaveBeenCalled();
-
-    wrapper.setProps({ status: 'loading' });
-    expect(mockedInputBlur).toHaveBeenCalledTimes(1);
-});
-
 it('keeps input from keyboard navigation when input looks untouchable', () => {
     const wrapper = shallow(<EditableBasicRow readOnly={false} disabled={false} />);
     expect(wrapper.find('input').prop('tabIndex')).toBeUndefined();


### PR DESCRIPTION
# Purpose
Remove the auto-blur behavior when `<input>` inside `<EditableBasicRow>` (which is the foundation of *editable* row components) receives new `status` prop.

In React 16 the input might be blurred before it's new value is updated to DOM.
Therefore can result in incorrect `value` in the blur event.

Besides, it doesn't seem to make sense to blur on status change now.