### PR TITLE
[Fix] Bottom border of the list title lacks a right margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [Form] Fix Popover inside `<SelectRow>` should not auto-close under multiple selection mode. (#158)
 - [Core] Fix `<ListRow>` footer should not render empty `<p>` tags. (#159)
+- [Core] Fix the bug that the bottom border of the title in the normal `<List>` lacks a right margin. (#163)
 
 ## [1.8.0]
 ### Added

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -41,6 +41,7 @@ $component: #{$prefix}-list;
         .#{$component}__title,
         .#{$component}__desc {
             margin-left: rem($list-row-padding-horizontal);
+            margin-right: rem($list-row-padding-horizontal);
         }
     }
 


### PR DESCRIPTION
# Purpose

Fix the bug that the bottom border of the title in the normal `<List>` lacks a right margin.

- Asana: https://app.asana.com/0/347798529122928/739456602042129

![storybook 2018-07-11 16-57-44](https://user-images.githubusercontent.com/1139698/42561425-adb5b9c0-852b-11e8-8061-4b7366a5c67f.jpg)



# Changes

- Add a right margin to the title in the normal `<List>`.