### PR TITLE
Extract <Section> layout from <List>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Added
+- [Core] Add new `<Section>` as a general content wrapper with optional title and description text. (#166)
+
+### Changed
+- [Core] Update `<List>` to wrap its own body with `<Section>`. (#166)
+- [Core] Update `<ListRow>` to remove vertical margin from nested `<List>`. (#166)
+- [Storybook] Add examples for `<Section>`. (#166)
 
 ## [1.8.1]
 ### Added

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -1,8 +1,6 @@
-// @flow
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import type { ReactChildren } from 'react-flow-types';
 import './styles/List.scss';
 
 import prefixClass from './utils/prefixClass';
@@ -22,16 +20,6 @@ const SETTING = 'setting';
 const BUTTON = 'button';
 const LIST_VARIANTS = [NORMAL, SETTING, BUTTON];
 
-export type Props = {
-    variant: typeof NORMAL | typeof SETTING | typeof BUTTON,
-    title?: string,
-    desc?: ReactChildren,
-
-    /* eslint-disable react/require-default-props */
-    className?: string,
-    children?: ReactChildren,
-    /* eslint-enable react/require-default-props */
-};
 
 function List({
     variant,
@@ -41,7 +29,7 @@ function List({
     className,
     children,
     ...otherProps,
-}: Props) {
+}) {
     const bemClass = BEM.root.modifier(variant);
     const rootClassName = classNames(bemClass.toString(), className);
 

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -20,6 +20,8 @@ const SETTING = 'setting'; // #TODO: design deprecated
 const BUTTON = 'button';
 const LIST_VARIANTS = [NORMAL, SETTING, BUTTON];
 
+export const TYPE_SYMBOL = Symbol('List');
+
 function List({
     variant,
     // <Section> props
@@ -58,5 +60,9 @@ List.defaultProps = {
     title: undefined,
     desc: undefined,
 };
+
+// For `<ListRow>` to check if `nestedList` is a `<List>.
+// Ref for this symbol approach: https://github.com/iCHEF/gypcrete/pull/157
+List.typeSymbol = TYPE_SYMBOL;
 
 export default List;

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -6,23 +6,23 @@ import './styles/List.scss';
 import prefixClass from './utils/prefixClass';
 import icBEM from './utils/icBEM';
 
+import Section from './Section';
+
 export const COMPONENT_NAME = prefixClass('list');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 export const BEM = {
     root: ROOT_BEM,
-    title: ROOT_BEM.element('title'),
     body: ROOT_BEM.element('body'),
-    desc: ROOT_BEM.element('desc'),
 };
 
 const NORMAL = 'normal';
-const SETTING = 'setting';
+const SETTING = 'setting'; // #TODO: design deprecated
 const BUTTON = 'button';
 const LIST_VARIANTS = [NORMAL, SETTING, BUTTON];
 
-
 function List({
     variant,
+    // <Section> props
     title,
     desc,
     // React props
@@ -33,17 +33,17 @@ function List({
     const bemClass = BEM.root.modifier(variant);
     const rootClassName = classNames(bemClass.toString(), className);
 
-    const titleNode = <div className={BEM.title.toString()}>{title}</div>;
-    const descNode = <div className={BEM.desc.toString()}>{desc}</div>;
-
     return (
-        <div className={rootClassName} {...otherProps}>
-            {title && titleNode}
+        <Section
+            className={rootClassName}
+            title={title}
+            desc={desc}
+            bodySpacing={false}
+            {...otherProps}>
             <ul className={BEM.body.toString()}>
                 {children}
             </ul>
-            {desc && descNode}
-        </div>
+        </Section>
     );
 }
 

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -22,7 +22,7 @@ export const BEM = {
     footer: ROOT_BEM.element('footer'),
 };
 
-const overrideNestedList = (nestedList) => {
+const renderListWithoutSpacing = (nestedList) => {
     const isElement = React.isValidElement(nestedList);
 
     if (isElement && nestedList.type.typeSymbol === LIST_TYPE_SYMBOL) {
@@ -96,7 +96,7 @@ class ListRow extends PureComponent {
                 </div>
 
                 {this.renderFooter()}
-                {overrideNestedList(nestedList)}
+                {renderListWithoutSpacing(nestedList)}
             </li>
         );
     }

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -1,10 +1,7 @@
-// @flow
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import type { ReactChildren } from 'react-flow-types';
-import type { Props as StatusIconProps } from './StatusIcon';
 import { statusPropTypes } from './mixins/withStatus';
 
 import prefixClass from './utils/prefixClass';
@@ -24,22 +21,7 @@ export const BEM = {
     footer: ROOT_BEM.element('footer'),
 };
 
-export type Props = {
-    highlight?: boolean,
-    nestedList?: ReactChildren,
-    desc?: ReactChildren,
-    status?: $PropertyType<StatusIconProps, 'status'>,
-    // #FIXME: Use type import
-    statusOptions?: { [string]: any },
-    errorMsg?: string,
-
-    /* eslint-disable react/require-default-props */
-    className?: string,
-    children?: ReactChildren,
-    /* eslint-enable react/require-default-props */
-};
-
-class ListRow extends PureComponent<Props, Props, any> {
+class ListRow extends PureComponent {
     static propTypes = {
         highlight: PropTypes.bool,
         nestedList: PropTypes.node,

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -9,6 +9,7 @@ import getStateClassnames from './utils/getStateClassnames';
 import icBEM from './utils/icBEM';
 import wrapIfNotElement from './utils/wrapIfNotElement';
 
+import { TYPE_SYMBOL as LIST_TYPE_SYMBOL } from './List';
 import { STATUS_CODE } from './StatusIcon';
 
 import './styles/ListRow.scss';
@@ -19,6 +20,17 @@ export const BEM = {
     root: ROOT_BEM,
     body: ROOT_BEM.element('body'),
     footer: ROOT_BEM.element('footer'),
+};
+
+const overrideNestedList = (nestedList) => {
+    const isElement = React.isValidElement(nestedList);
+
+    if (isElement && nestedList.type.typeSymbol === LIST_TYPE_SYMBOL) {
+        return React.cloneElement(nestedList, {
+            verticalSpacing: false,
+        });
+    }
+    return nestedList;
 };
 
 class ListRow extends PureComponent {
@@ -84,7 +96,7 @@ class ListRow extends PureComponent {
                 </div>
 
                 {this.renderFooter()}
-                {nestedList}
+                {overrideNestedList(nestedList)}
             </li>
         );
     }

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import icBEM from './utils/icBEM';
+import prefixClass from './utils/prefixClass';
+import './styles/Section.scss';
+
+export const COMPONENT_NAME = prefixClass('section');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    title: ROOT_BEM.element('title'),
+    body: ROOT_BEM.element('body'),
+    desc: ROOT_BEM.element('desc'),
+};
+
+function Section({
+    title,
+    desc,
+    // React props
+    className,
+    children,
+}) {
+    const bemClass = BEM.root;
+    const rootClassName = classNames(bemClass.toString(), className);
+
+    const titleArea = title && (
+        <div className={BEM.title.toString()}>
+            {title}
+        </div>
+    );
+
+    const descArea = desc && (
+        <div className={BEM.desc.toString()}>
+            {desc}
+        </div>
+    );
+
+    return (
+        <div className={rootClassName}>
+            {titleArea}
+            <div className={BEM.body.toString()}>
+                {children}
+            </div>
+            {descArea}
+        </div>
+    );
+}
+
+Section.propTypes = {
+    title: PropTypes.node,
+    desc: PropTypes.node,
+};
+
+Section.defaultProps = {
+    title: undefined,
+    desc: undefined,
+};
+
+export default Section;

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -18,19 +18,32 @@ export const BEM = {
 function Section({
     title,
     desc,
+    verticalSpacing, // add margin to above and below <Section>
+    bodySpacing, // add padding to body for components that are not row-based
     // React props
     className,
     children,
 }) {
-    const bemClass = BEM.root;
-    const rootClassName = classNames(bemClass.toString(), className);
+    // Class names
+    const rootClassName = classNames(
+        BEM.root
+            .modifier('no-margin', !verticalSpacing)
+            .toString(),
+        className,
+    );
+    const bodyClassName = classNames(
+        BEM.body
+            .modifier('padded', bodySpacing)
+            .toString(),
+        className,
+    );
 
+    // Conditional parts
     const titleArea = title && (
         <div className={BEM.title.toString()}>
             {title}
         </div>
     );
-
     const descArea = desc && (
         <div className={BEM.desc.toString()}>
             {desc}
@@ -40,7 +53,7 @@ function Section({
     return (
         <div className={rootClassName}>
             {titleArea}
-            <div className={BEM.body.toString()}>
+            <div className={bodyClassName}>
                 {children}
             </div>
             {descArea}
@@ -51,11 +64,15 @@ function Section({
 Section.propTypes = {
     title: PropTypes.node,
     desc: PropTypes.node,
+    verticalSpacing: PropTypes.bool,
+    bodySpacing: PropTypes.bool,
 };
 
 Section.defaultProps = {
     title: undefined,
     desc: undefined,
+    verticalSpacing: true,
+    bodySpacing: true,
 };
 
 export default Section;

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -31,12 +31,9 @@ function Section({
             .toString(),
         className,
     );
-    const bodyClassName = classNames(
-        BEM.body
-            .modifier('padded', bodySpacing)
-            .toString(),
-        className,
-    );
+    const bodyClassName = BEM.body
+        .modifier('padded', bodySpacing)
+        .toString();
 
     // Conditional parts
     const titleArea = title && (

--- a/packages/core/src/__tests__/List.test.js
+++ b/packages/core/src/__tests__/List.test.js
@@ -3,12 +3,23 @@ import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
 import List, { BEM as LIST_BEM } from '../List';
+import Section from '../Section';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
     const element = <List title="Title">Hello world</List>;
 
     ReactDOM.render(element, div);
+});
+
+it('renders a <ul> inside a <Section> without body spacing', () => {
+    const wrapper = shallow(<List>Foo Bar</List>);
+
+    expect(wrapper.is(Section)).toBeTruthy();
+    expect(wrapper.prop('bodySpacing')).toBeFalsy();
+
+    expect(wrapper.children('ul').exists()).toBeTruthy();
+    expect(wrapper.children('ul').text()).toBe('Foo Bar');
 });
 
 it('renders in variants with "normal" as default', () => {
@@ -22,27 +33,17 @@ it('renders in variants with "normal" as default', () => {
     expect(wrapper.hasClass(`${LIST_BEM.root.modifier('button')}`)).toBeTruthy();
 });
 
-it('renders children inside a <ul>', () => {
-    const wrapper = shallow(<List>Foo Bar</List>);
+it('passes unknown props to wrapper <Section>', () => {
+    const wrapper = shallow(
+        <List
+            id="foo"
+            verticalSpacing={false} />
+    );
 
-    expect(wrapper.find('ul')).toHaveLength(1);
-    expect(wrapper.find('ul').text()).toBe('Foo Bar');
-});
-
-it('renders title in <div> when specified', () => {
-    const wrapper = shallow(<List>Foo</List>);
-    expect(wrapper.find(`.${LIST_BEM.title}`).exists()).toBeFalsy();
-
-    wrapper.setProps({ title: 'Bar' });
-    expect(wrapper.find(`.${LIST_BEM.title}`)).toHaveLength(1);
-    expect(wrapper.find(`.${LIST_BEM.title}`).text()).toBe('Bar');
-});
-
-it('renders desc in <div> when specified', () => {
-    const wrapper = shallow(<List>Foo</List>);
-    expect(wrapper.find(`.${LIST_BEM.desc}`).exists()).toBeFalsy();
-
-    wrapper.setProps({ desc: <span data-test="foo" /> });
-    expect(wrapper.find(`.${LIST_BEM.desc}`)).toHaveLength(1);
-    expect(wrapper.find(`.${LIST_BEM.desc}`).find('[data-test="foo"]')).toHaveLength(1);
+    expect(wrapper.find(Section).props()).toEqual(
+        expect.objectContaining({
+            id: 'foo',
+            verticalSpacing: false,
+        })
+    );
 });

--- a/packages/core/src/__tests__/ListRow.test.js
+++ b/packages/core/src/__tests__/ListRow.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
+import List from '../List';
 import ListRow, { BEM as ROW_BEM } from '../ListRow';
 
 it('renders without crashing', () => {
@@ -64,4 +65,13 @@ it('renders nested item inside <li> but outside of body wrapper', () => {
 
     expect(wrapper.find('span[data-test]')).toHaveLength(1);
     expect(wrapper.find(`.${ROW_BEM.body}`).find('span[data-test]').exists()).toBeFalsy();
+});
+
+it('overrides nested <List> to remove its vertical spacing', () => {
+    const wrapper = shallow(
+        <ListRow nestedList={<List>Bar</List>}>
+            Foo
+        </ListRow>
+    );
+    expect(wrapper.find(List).prop('verticalSpacing')).toBeFalsy();
 });

--- a/packages/core/src/__tests__/Section.test.js
+++ b/packages/core/src/__tests__/Section.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import Section, { BEM as SECTION_BEM } from '../Section';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <Section title="Title">Hello world</Section>;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders title in <div> only when specified', () => {
+    const wrapper = shallow(<Section>Foo</Section>);
+    expect(wrapper.find(`.${SECTION_BEM.title}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ title: 'Bar' });
+    expect(wrapper.find(`.${SECTION_BEM.title}`)).toHaveLength(1);
+    expect(wrapper.find(`.${SECTION_BEM.title}`).text()).toBe('Bar');
+});
+
+it('renders desc in <div> only when specified', () => {
+    const wrapper = shallow(<Section>Foo</Section>);
+    expect(wrapper.find(`.${SECTION_BEM.desc}`).exists()).toBeFalsy();
+
+    wrapper.setProps({ desc: 'Bar' });
+    expect(wrapper.find(`.${SECTION_BEM.desc}`)).toHaveLength(1);
+    expect(wrapper.find(`.${SECTION_BEM.desc}`).text()).toBe('Bar');
+});
+
+it('renders children in a section body', () => {
+    const wrapper = shallow(<Section>Foo</Section>);
+
+    expect(wrapper.find(`.${SECTION_BEM.body}`).exists()).toBeTruthy();
+    expect(wrapper.find(`.${SECTION_BEM.body}`).text()).toBe('Foo');
+});
+
+it("removes class to discard padding for section body when 'bodySpacing' is false", () => {
+    const wrapper = shallow(<Section />);
+    const expectedClassName = SECTION_BEM.body.modifier('padded').toString();
+    expect(
+        wrapper.find(`.${SECTION_BEM.body}`).hasClass(expectedClassName)
+    ).toBeTruthy();
+
+    wrapper.setProps({ bodySpacing: false });
+    expect(
+        wrapper.find(`.${SECTION_BEM.body}`).hasClass(expectedClassName)
+    ).toBeFalsy();
+});
+
+it("adds class to remove vertical margin when 'verticalSpacing' is false", () => {
+    const wrapper = shallow(<Section />);
+    const expectedClassName = SECTION_BEM.root.modifier('no-margin').toString();
+    expect(wrapper.hasClass(expectedClassName)).toBeFalsy();
+
+    wrapper.setProps({ verticalSpacing: false });
+    expect(wrapper.hasClass(expectedClassName)).toBeTruthy();
+});
+

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -30,6 +30,7 @@ import SearchInput from './SearchInput';
 // Containers
 import InfiniteScroll from './InfiniteScroll';
 import HeaderRow from './HeaderRow';
+import Section from './Section';
 import List from './List';
 import ListRow from './ListRow';
 import ColumnView from './ColumnView';
@@ -66,6 +67,7 @@ export {
 
     InfiniteScroll,
     HeaderRow,
+    Section,
     List,
     ListRow,
     ColumnView,

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -16,6 +16,9 @@ $component: #{$prefix}-list;
     // --------------------
     &--setting {
         // #TODO: design deprecated
+        margin-left: rem($section-horizontal-padding);
+        margin-right: rem($section-horizontal-padding);
+
         .#{$component}__body {
             background-color: white;
             border: 1px solid $c-divider-row;

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -2,8 +2,6 @@
 $component: #{$prefix}-list;
 
 .#{$component} {
-    padding: rem($list-vertical-margin) 0;
-
     // --------------------
     //  Elements
     // --------------------
@@ -13,48 +11,24 @@ $component: #{$prefix}-list;
         margin: 0;
     }
 
-    &__title,
-    &__desc {
-        font-size: rem($aside-text-font-size);
-        line-height: rem($aside-text-line-height);
-        white-space: pre-wrap;
-    }
-
-    &__title {
-        font-weight: $font-weight-bold;
-        padding: rem(12px) 0 rem(4px);
-    }
-
-    &__desc {
-        padding-top: rem(8px);
-        margin-right: rem($list-row-padding-horizontal);
-    }
-
     // --------------------
     //  Variants
     // --------------------
-    &--normal {
-        .#{$component}__title {
-            border-bottom: 2px solid $c-divider-header;
-        }
-
-        .#{$component}__title,
-        .#{$component}__desc {
-            margin-left: rem($list-row-padding-horizontal);
-            margin-right: rem($list-row-padding-horizontal);
-        }
-    }
-
     &--setting {
+        // #TODO: design deprecated
         .#{$component}__body {
             background-color: white;
             border: 1px solid $c-divider-row;
             border-radius: rem($list-border-radius);
         }
 
-        .#{$component}__title,
-        .#{$component}__desc {
-            margin-left: rem($list-border-radius);
+        .#{$prefix}-section__title {
+            padding-bottom: rem(2px);
+            border-bottom: none;
         }
+    }
+
+    &--button {
+        // #TODO: implement button list
     }
 }

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -1,0 +1,30 @@
+@import "./mixins";
+
+$component-name: #{$prefix}-section;
+
+.#{$component-name} {
+    margin-top: rem($section-vertical-margin);
+    margin-bottom: rem($section-vertical-margin);
+
+    // --------------------
+    //  Elements
+    // --------------------
+    &__title,
+    &__desc {
+        @include small-text;
+
+        white-space: pre-wrap;
+        margin-left: rem($section-horizontal-padding);
+        margin-right: rem($section-horizontal-padding);
+    }
+
+    &__title {
+        font-weight: $font-weight-bold;
+        padding-bottom: rem(1px);
+        border-bottom: 1px solid $c-divider-header;
+    }
+
+    &__desc {
+        padding-top: rem(2px); // take padding from row layout for now.
+    }
+}

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -25,6 +25,23 @@ $component-name: #{$prefix}-section;
     }
 
     &__desc {
-        padding-top: rem(2px); // take padding from row layout for now.
+        // take padding from row layout as reference
+        padding-top: rem(2px);
+    }
+
+    &__body {
+        &--padded {
+            // for aligning non-row components
+            padding-left: rem($section-horizontal-padding);
+            padding-right: rem($section-horizontal-padding);
+        }
+    }
+
+    // --------------------
+    //  Modifiers
+    // --------------------
+    &--no-margin {
+        margin-top: 0;
+        margin-bottom: 0;
     }
 }

--- a/packages/core/src/styles/_colors.scss
+++ b/packages/core/src/styles/_colors.scss
@@ -48,7 +48,7 @@ $c-comp-bg-active: $c-row-bg-active;
 // Divider lines
 $c-divider-row:             hsba(0, 0, 0, 10);
 $c-divider-row-disabled:    hsba(0, 0, 0, 33);
-$c-divider-header:          hsba(0, 0, 0, 30);
+$c-divider-header:          hsba(0, 0, 0, 100);
 $c-divider-header-disabled: hsba(0, 0, 0, 1);
 
 // Switch colors

--- a/packages/core/src/styles/_mixins.scss
+++ b/packages/core/src/styles/_mixins.scss
@@ -41,3 +41,21 @@
     appearance: none;
     user-select: none;
 }
+
+// -------------------------------------
+//   Default typography
+// -------------------------------------
+@mixin small-text {
+    font-size: rem($font-size-small);
+    line-height: rem($line-height-small);
+}
+
+@mixin base-text {
+    font-size: rem($font-size-base);
+    line-height: rem($line-height-base);
+}
+
+@mixin large-text {
+    font-size: rem($font-size-large);
+    line-height: rem($line-height-large);
+}

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -73,7 +73,6 @@ $section-vertical-margin: 24px;
 $section-horizontal-padding: 16px;
 
 $list-border-radius: 8px;
-$list-vertical-margin: 8px;
 
 $list-row-padding-horizontal: 16px;
 $list-row-padding-vertical: 4px;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -69,6 +69,9 @@ $search-input-border-color: $c-gray;
 $search-input-border-radius: 6px;
 $search-input-padding: 8px;
 
+$section-vertical-margin: 24px;
+$section-horizontal-padding: 16px;
+
 $list-border-radius: 8px;
 $list-vertical-margin: 8px;
 

--- a/packages/storybook/examples/List/SettingList.js
+++ b/packages/storybook/examples/List/SettingList.js
@@ -12,7 +12,7 @@ import DebugBox from 'utils/DebugBox';
 
 function SettingList() {
     return (
-        <DebugBox width="30rem" style={{ padding: '0 1rem' }}>
+        <DebugBox width="30rem">
             <List variant="setting" title="List title" desc="Help text here">
                 <ListRow>
                     <TextLabel basic="Hello World" />

--- a/packages/storybook/examples/Section/DemoContent.js
+++ b/packages/storybook/examples/Section/DemoContent.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const styles = {
+    width: '100%',
+    lineHeight: '200px',
+    textAlign: 'center',
+    background: '#eee',
+};
+
+function DemoContent() {
+    return (
+        <div style={styles}>
+            Section Content
+        </div>
+    );
+}
+
+export default DemoContent;

--- a/packages/storybook/examples/Section/index.js
+++ b/packages/storybook/examples/Section/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Section from '@ichef/gypcrete/src/Section';
+import DebugBox from 'utils/DebugBox';
+import DemoContent from './DemoContent';
+
+storiesOf('Section', module)
+    .add('Plain section', withInfo('Plain <Section> with spacing around container')(() => (
+        <DebugBox>
+            <Section>
+                <DemoContent />
+            </Section>
+        </DebugBox>
+    )))
+    .add('With title & desc', withInfo('<Section> with title and desc areas')(() => (
+        <DebugBox>
+            <Section title="Section title" desc="Description text">
+                <DemoContent />
+            </Section>
+        </DebugBox>
+    )))
+    .add('Without vertical spacing', withInfo('Removes spacing above and below <Section>')(() => (
+        <DebugBox>
+            <Section
+                verticalSpacing={false}
+                title="Section title"
+                desc="Description text">
+                <DemoContent />
+            </Section>
+        </DebugBox>
+    )))
+    .add('Without body padding', withInfo(
+        'Removes horizontal padding for Section body, usually for <List>'
+    )(() => (
+        <DebugBox>
+            <Section
+                bodySpacing={false}
+                title="Section title"
+                desc="Description text">
+                <DemoContent />
+            </Section>
+        </DebugBox>
+    )))
+
+    .add('PropTypes', withInfo({ propTables: [Section], source: false })(() => <div />));

--- a/packages/storybook/utils/DebugBox.js
+++ b/packages/storybook/utils/DebugBox.js
@@ -5,6 +5,7 @@ const defaultBoxStyle = {
     boxShadow: '0 0 1px red',
     marginBottom: 15,
     position: 'relative',
+    overflow: 'hidden',
 };
 
 function DebugBox({ width, height, style, children }) {


### PR DESCRIPTION
# Purpose
Extract the section layout into a new `<Section>` component out from `<List>`, so the it can be a more generalized wrapper which gives any content an optional title and desc block.

It can also provide left/right padding to components that *are not* row-based before putting into a container like `<ColumnView>`

# Changes
- [Core] Add new `<Section>` layout component
- [Core] Update `<List>` to use `<Section>` as its own wrapper
- [Core] Update `<ListRow>` to force-set `verticalSpacing={false}` to nested `<List>` (and be passed to its inner `<Section>`)

# Screenshot
![2018-08-14 6 36 47](https://user-images.githubusercontent.com/365035/44087195-91ac3606-9ff1-11e8-87b2-7c3d5673e9fb.png)
