### PR TITLE
Update column styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Update `<List>` to wrap its own body with `<Section>`. (#166)
 - [Core] Update `<ListRow>` to remove vertical margin from nested `<List>`. (#166)
 - [Storybook] Add examples for `<Section>`. (#166)
+- [Core] Removed padding in `<ColumnView>` body. (#167)
+- [Core] `<HeaderRow>` can now disable an area by setting `false` to it. Styles updated.  (#167)
 
 ## [1.8.1]
 ### Added

--- a/packages/core/src/HeaderRow.js
+++ b/packages/core/src/HeaderRow.js
@@ -1,7 +1,6 @@
-// @flow
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import type { ReactChildren } from 'react-flow-types';
 import './styles/HeaderRow.scss';
 
 import prefixClass from './utils/prefixClass';
@@ -16,14 +15,6 @@ export const BEM = {
     right: ROOT_BEM.element('right'),
 };
 
-export type Props = {
-    left?: ReactChildren,
-    center?: ReactChildren,
-    right?: ReactChildren,
-    className?: string, // eslint-disable-line react/require-default-props
-    children?: ReactChildren,
-};
-
 function HeaderRow({
     left,
     center,
@@ -32,7 +23,7 @@ function HeaderRow({
     className,
     children,
     ...otherProps,
-}: Props) {
+}) {
     const rootClassName = classNames(
         BEM.root.toString(),
         className,
@@ -47,6 +38,12 @@ function HeaderRow({
         </div>
     );
 }
+
+HeaderRow.propTypes = {
+    left: PropTypes.node,
+    center: PropTypes.node,
+    right: PropTypes.node,
+};
 
 HeaderRow.defaultProps = {
     left: undefined,

--- a/packages/core/src/HeaderRow.js
+++ b/packages/core/src/HeaderRow.js
@@ -15,6 +15,32 @@ export const BEM = {
     right: ROOT_BEM.element('right'),
 };
 
+// --------------------
+//  Helper Component
+// --------------------
+
+export function HeaderArea({ content, ...props }) {
+    if (content === false) {
+        return null;
+    }
+    return <div {...props}>{content}</div>;
+}
+
+HeaderArea.propTypes = {
+    content: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.oneOf([false]),
+    ]),
+};
+
+HeaderArea.defaultProps = {
+    content: undefined,
+};
+
+// --------------------
+//  Main Component
+// --------------------
+
 function HeaderRow({
     left,
     center,
@@ -31,18 +57,18 @@ function HeaderRow({
 
     return (
         <div className={rootClassName} {...otherProps}>
-            <div className={BEM.left}>{left}</div>
-            <div className={BEM.center}>{center}</div>
-            <div className={BEM.right}>{right}</div>
+            <HeaderArea content={left} className={BEM.left} />
+            <HeaderArea content={center} className={BEM.center} />
+            <HeaderArea content={right} className={BEM.right} />
             {children}
         </div>
     );
 }
 
 HeaderRow.propTypes = {
-    left: PropTypes.node,
-    center: PropTypes.node,
-    right: PropTypes.node,
+    left: HeaderArea.propTypes.content,
+    center: HeaderArea.propTypes.content,
+    right: HeaderArea.propTypes.content,
 };
 
 HeaderRow.defaultProps = {

--- a/packages/core/src/__tests__/HeaderRow.test.js
+++ b/packages/core/src/__tests__/HeaderRow.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
-import HeaderRow from '../HeaderRow';
+import HeaderRow, { HeaderArea } from '../HeaderRow';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
@@ -11,12 +11,47 @@ it('renders without crashing', () => {
     ReactDOM.render(element, div);
 });
 
-it('renders optional children besides 3 defined areas', () => {
-    const wrapper = shallow(
-        <HeaderRow>
-            <div data-target>Hello World</div>
-        </HeaderRow>
-    );
-    expect(wrapper.text()).toBe('Hello World');
-    expect(wrapper.find('div[data-target]').exists()).toBeTruthy();
+describe('<HeaderArea> helper component', () => {
+    it("renders null when 'content' is explicitly set to 'false'", () => {
+        const wrapper = shallow(<HeaderArea content="Foo Bar" />);
+        expect(wrapper.is('div')).toBeTruthy();
+        expect(wrapper.text()).toBe('Foo Bar');
+
+        wrapper.setProps({ content: undefined });
+        expect(wrapper.is('div')).toBeTruthy();
+        expect(wrapper.text()).toBe('');
+
+        wrapper.setProps({ content: false });
+        expect(wrapper.html()).toBe(null);
+    });
+});
+
+describe('<HeaderRow>', () => {
+    it('renders 3 defined areas with <HeaderArea>', () => {
+        const mockedLeft = <span data-area="left" />;
+        const mockedCenter = <span data-area="center" />;
+        const mockedRight = <span data-area="right" />;
+
+        const wrapper = shallow(
+            <HeaderRow
+                left={mockedLeft}
+                center={mockedCenter}
+                right={mockedRight} />
+        );
+        expect(wrapper.containsAllMatchingElements([
+            <HeaderArea content={mockedLeft} />,
+            <HeaderArea content={mockedCenter} />,
+            <HeaderArea content={mockedRight} />,
+        ])).toBeTruthy();
+    });
+
+
+    it('renders optional children besides 3 defined areas', () => {
+        const wrapper = shallow(
+            <HeaderRow>
+                <div data-target>Hello World</div>
+            </HeaderRow>
+        );
+        expect(wrapper.find('div[data-target]').exists()).toBeTruthy();
+    });
 });

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -22,6 +22,7 @@ $component: #{$prefix}-column-view;
         flex: 1 1 auto;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
+        padding-bottom: rem($column-body-bottom-padding);
     }
 
     &__footer {

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -19,7 +19,6 @@ $component: #{$prefix}-column-view;
     }
 
     &__body {
-        padding: 0 rem($column-body-padding);
         flex: 1 1 auto;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;

--- a/packages/core/src/styles/HeaderRow.scss
+++ b/packages/core/src/styles/HeaderRow.scss
@@ -4,10 +4,12 @@ $component: #{$prefix}-header-row;
 .#{$component} {
     min-height: rem($row-base-height);
     background-color: $c-header-bg;
-    border-bottom: 1px solid $c-divider-header;
     padding: rem($header-row-padding);
     box-sizing: border-box;
     display: flex;
+    box-shadow: $header-row-box-shadow;
+    // Create a new stacking context so box-shadow is harder to be blocked
+    position: relative;
 
     &__left,
     &__right {

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -69,6 +69,8 @@ $search-input-border-color: $c-gray;
 $search-input-border-radius: 6px;
 $search-input-padding: 8px;
 
+$column-body-bottom-padding: 24px;
+
 $section-vertical-margin: 24px;
 $section-horizontal-padding: 16px;
 

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -83,6 +83,7 @@ $list-row-footer-font-size: $font-size-small;
 $list-row-footer-line-height: $line-height-small;
 
 $header-row-padding: 4px;
+$header-row-box-shadow: 0 3px 3px hsba(0, 0, 0, 16);
 
 $popup-container-width: 256px;
 $popup-border-radius: 8px;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -84,8 +84,6 @@ $list-row-footer-line-height: $line-height-small;
 
 $header-row-padding: 4px;
 
-$column-body-padding: 16px;
-
 $popup-container-width: 256px;
 $popup-border-radius: 8px;
 $poup-box-shadow: 0 2px 8px hsba(0, 0, 0, 40);

--- a/packages/storybook/examples/HeaderRow/OptionalArea.js
+++ b/packages/storybook/examples/HeaderRow/OptionalArea.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import HeaderRow from '@ichef/gypcrete/src/HeaderRow';
+import Button from '@ichef/gypcrete/src/Button';
+import TextLabel from '@ichef/gypcrete/src/TextLabel';
+
+import DebugBox from 'utils/DebugBox';
+
+function OptionalArea() {
+    const rightBtn = <Button align="reverse" icon="row-padding" basic="Save" />;
+    const centerLabel = <TextLabel basic="Header Title" />;
+
+    return (
+        <DebugBox>
+            <HeaderRow
+                left={false}
+                center={centerLabel}
+                right={rightBtn} />
+        </DebugBox>
+    );
+}
+
+export default OptionalArea;

--- a/packages/storybook/examples/HeaderRow/index.js
+++ b/packages/storybook/examples/HeaderRow/index.js
@@ -6,10 +6,10 @@ import { withInfo } from '@storybook/addon-info';
 import HeaderRow from '@ichef/gypcrete/src/HeaderRow';
 
 import BasicUsage from './BasicUsage';
+import OptionalArea from './OptionalArea';
 
 storiesOf('HeaderRow', module)
-    .add('Basic usage',
-        withInfo()(BasicUsage)
-    )
+    .add('Basic usage', withInfo()(BasicUsage))
+    .add('Optional area', withInfo()(OptionalArea))
     // Props table
     .addPropsTable(() => <HeaderRow />);

--- a/packages/storybook/examples/HeaderRow/index.js
+++ b/packages/storybook/examples/HeaderRow/index.js
@@ -10,6 +10,10 @@ import OptionalArea from './OptionalArea';
 
 storiesOf('HeaderRow', module)
     .add('Basic usage', withInfo()(BasicUsage))
-    .add('Optional area', withInfo()(OptionalArea))
+    .add(
+        'Optional area',
+        withInfo('Remove an area from DOM by explictly setting it to false.')(OptionalArea)
+    )
+
     // Props table
     .addPropsTable(() => <HeaderRow />);


### PR DESCRIPTION
# Purpose
Update styles for `<ColumnView>` and `<HeaderRow>` to better match design.

# Changes
- [Core] Removed padding in `<ColumnView>` body.
- [Core] `<HeaderRow>` can now disable an area by setting `false` to it. Styles updated.

# Screenshot
### ColumnView
![2018-08-16 3 41 08](https://user-images.githubusercontent.com/365035/44195944-2ccdeb80-a16d-11e8-91db-0e0059de6adf.png)

### HeaderRow
![2018-08-17 4 36 35](https://user-images.githubusercontent.com/365035/44256435-c06ded80-a23b-11e8-9eac-08c662dbbcbd.png)
