### PR TITLE
Remove <List> vertical spacing inside certain components

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 .*/__tests__/.*
 <PROJECT_ROOT>/node_modules/stylelint/*
 <PROJECT_ROOT>/node_modules/radium/*
+<PROJECT_ROOT>/node_modules/create-react-context/*
 
 [include]
 packages/*/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [Core] Update `<List>` to wrap its own body with `<Section>`. (#166)
-- [Core] Update `<ListRow>` to remove vertical margin from nested `<List>`. (#166)
+- ~~[Core] Update `<ListRow>` to remove vertical margin from nested `<List>`. (#166)~~
+- [Core] Remove vertical margin from `<List>` by context when placed inside `<ListRow>` or `<Popover>`. (#169)
 - [Storybook] Add examples for `<Section>`. (#166)
 - [Core] Removed padding in `<ColumnView>` body. (#167)
 - [Core] `<HeaderRow>` can now disable an area by setting `false` to it. Styles updated.  (#167)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "create-react-context": "^0.2.3",
     "document-offset": "^1.0.4",
     "keycode": "^2.1.9",
     "react-flow-types": "^0.1.1"

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -7,6 +7,7 @@ import prefixClass from './utils/prefixClass';
 import icBEM from './utils/icBEM';
 
 import Section from './Section';
+import ListSpacingContext from './contexts/listSpacing';
 
 export const COMPONENT_NAME = prefixClass('list');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
@@ -36,16 +37,21 @@ function List({
     const rootClassName = classNames(bemClass.toString(), className);
 
     return (
-        <Section
-            className={rootClassName}
-            title={title}
-            desc={desc}
-            bodySpacing={false}
-            {...otherProps}>
-            <ul className={BEM.body.toString()}>
-                {children}
-            </ul>
-        </Section>
+        <ListSpacingContext.Consumer>
+            {spacing => (
+                <Section
+                    className={rootClassName}
+                    title={title}
+                    desc={desc}
+                    bodySpacing={false}
+                    verticalSpacing={spacing}
+                    {...otherProps}>
+                    <ul className={BEM.body.toString()}>
+                        {children}
+                    </ul>
+                </Section>
+            )}
+        </ListSpacingContext.Consumer>
     );
 }
 

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import ListSpacingContext from './contexts/listSpacing';
+
 import { statusPropTypes } from './mixins/withStatus';
 
 import prefixClass from './utils/prefixClass';
@@ -9,7 +11,6 @@ import getStateClassnames from './utils/getStateClassnames';
 import icBEM from './utils/icBEM';
 import wrapIfNotElement from './utils/wrapIfNotElement';
 
-import { TYPE_SYMBOL as LIST_TYPE_SYMBOL } from './List';
 import { STATUS_CODE } from './StatusIcon';
 
 import './styles/ListRow.scss';
@@ -20,17 +21,6 @@ export const BEM = {
     root: ROOT_BEM,
     body: ROOT_BEM.element('body'),
     footer: ROOT_BEM.element('footer'),
-};
-
-const renderListWithoutSpacing = (nestedList) => {
-    const isElement = React.isValidElement(nestedList);
-
-    if (isElement && nestedList.type.typeSymbol === LIST_TYPE_SYMBOL) {
-        return React.cloneElement(nestedList, {
-            verticalSpacing: false,
-        });
-    }
-    return nestedList;
 };
 
 class ListRow extends PureComponent {
@@ -90,14 +80,15 @@ class ListRow extends PureComponent {
         const rootClassName = classNames(bemClass.toString(), stateClass, className);
 
         return (
-            <li className={rootClassName} {...wrapperProps}>
-                <div className={BEM.body.toString()}>
-                    {children}
-                </div>
-
-                {this.renderFooter()}
-                {renderListWithoutSpacing(nestedList)}
-            </li>
+            <ListSpacingContext.Provider value={false}>
+                <li className={rootClassName} {...wrapperProps}>
+                    <div className={BEM.body.toString()}>
+                        {children}
+                    </div>
+                    {this.renderFooter()}
+                    {nestedList}
+                </li>
+            </ListSpacingContext.Provider>
         );
     }
 }

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import ListSpacingContext from './contexts/listSpacing';
+
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 
@@ -31,12 +33,14 @@ function Popover({
     const rootClassName = classNames(bemClass.toString(), className);
 
     return (
-        <div className={rootClassName} {...otherProps}>
-            <span className={BEM.arrow} style={arrowStyle} />
-            <div className={BEM.container}>
-                {children}
+        <ListSpacingContext.Provider value={false}>
+            <div className={rootClassName} {...otherProps}>
+                <span className={BEM.arrow} style={arrowStyle} />
+                <div className={BEM.container}>
+                    {children}
+                </div>
             </div>
-        </div>
+        </ListSpacingContext.Provider>
     );
 }
 

--- a/packages/core/src/__tests__/List.test.js
+++ b/packages/core/src/__tests__/List.test.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
-import List, { BEM as LIST_BEM } from '../List';
+import List from '../List';
 import Section from '../Section';
+
+import ListSpacingContext from '../contexts/listSpacing';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
@@ -12,29 +14,36 @@ it('renders without crashing', () => {
     ReactDOM.render(element, div);
 });
 
-it('renders a <ul> inside a <Section> without body spacing', () => {
+it('consumes context to render a <Section> with spacing configs', () => {
     const wrapper = shallow(<List>Foo Bar</List>);
+    expect(wrapper.is(ListSpacingContext.Consumer)).toBeTruthy();
 
-    expect(wrapper.is(Section)).toBeTruthy();
-    expect(wrapper.prop('bodySpacing')).toBeFalsy();
+    const renderedElement = wrapper.prop('children')(true);
+    expect(renderedElement.type).toBe(Section);
+    expect(renderedElement.props.verticalSpacing).toBe(true);
+    expect(renderedElement.props.bodySpacing).toBe(false);
+});
 
-    expect(wrapper.children('ul').exists()).toBeTruthy();
-    expect(wrapper.children('ul').text()).toBe('Foo Bar');
+it('renders a <ul> inside root <Section>', () => {
+    const wrapper = mount(<List>Foo Bar</List>);
+
+    expect(wrapper.find(Section).find('ul').exists()).toBeTruthy();
+    expect(wrapper.find(Section).find('ul').text()).toBe('Foo Bar');
 });
 
 it('renders in variants with "normal" as default', () => {
-    const wrapper = shallow(<List>Foo Bar</List>);
-    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('normal')}`)).toBeTruthy();
+    const wrapper = mount(<List>Foo Bar</List>);
+    expect(wrapper.find(Section).hasClass('gyp-list--normal')).toBeTruthy();
 
     wrapper.setProps({ variant: 'setting' });
-    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('setting')}`)).toBeTruthy();
+    expect(wrapper.find(Section).hasClass('gyp-list--setting')).toBeTruthy();
 
     wrapper.setProps({ variant: 'button' });
-    expect(wrapper.hasClass(`${LIST_BEM.root.modifier('button')}`)).toBeTruthy();
+    expect(wrapper.find(Section).hasClass('gyp-list--button')).toBeTruthy();
 });
 
 it('passes unknown props to wrapper <Section>', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
         <List
             id="foo"
             verticalSpacing={false} />

--- a/packages/core/src/__tests__/ListRow.test.js
+++ b/packages/core/src/__tests__/ListRow.test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
-import List from '../List';
 import ListRow, { BEM as ROW_BEM } from '../ListRow';
+import ListSpacingContext from '../contexts/listSpacing';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
@@ -12,11 +12,11 @@ it('renders without crashing', () => {
     ReactDOM.render(element, div);
 });
 
-it('renders as a <li> element', () => {
+it('renders a <li> element with class name of root wrapper', () => {
     const wrapper = shallow(<ListRow>Foo</ListRow>);
 
-    expect(wrapper.type()).toBe('li');
-    expect(wrapper.hasClass(`${ROW_BEM.root}`));
+    expect(wrapper.find('li').exists()).toBeTruthy();
+    expect(wrapper.find('li').hasClass(`${ROW_BEM.root}`));
 });
 
 it('renders children inside a body wrapper', () => {
@@ -53,7 +53,7 @@ it('handles highlight modifier', () => {
     const wrapper = shallow(<ListRow highlight>Foo</ListRow>);
     const expectedClassName = ROW_BEM.root.modifier('highlight').toString();
 
-    expect(wrapper.hasClass(expectedClassName)).toBeTruthy();
+    expect(wrapper.find('li').hasClass(expectedClassName)).toBeTruthy();
 });
 
 it('renders nested item inside <li> but outside of body wrapper', () => {
@@ -67,11 +67,9 @@ it('renders nested item inside <li> but outside of body wrapper', () => {
     expect(wrapper.find(`.${ROW_BEM.body}`).find('span[data-test]').exists()).toBeFalsy();
 });
 
-it('overrides nested <List> to remove its vertical spacing', () => {
-    const wrapper = shallow(
-        <ListRow nestedList={<List>Bar</List>}>
-            Foo
-        </ListRow>
-    );
-    expect(wrapper.find(List).prop('verticalSpacing')).toBeFalsy();
+it('provides context for nested list spacing', () => {
+    const wrapper = shallow(<ListRow>Foo bar</ListRow>);
+
+    expect(wrapper.find(ListSpacingContext.Provider).exists()).toBeTruthy();
+    expect(wrapper.find(ListSpacingContext.Provider).prop('value')).toBe(false);
 });

--- a/packages/core/src/__tests__/Popover.test.js
+++ b/packages/core/src/__tests__/Popover.test.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
 import Popover, { PurePopover, BEM } from '../Popover';
+import ListSpacingContext from '../contexts/listSpacing';
 
 describe('<Popover> with mixins', () => {
     it('should render without crashing', () => {
@@ -14,16 +15,23 @@ describe('<Popover> with mixins', () => {
 });
 
 describe('Pure <Popover>', () => {
+    it('provides context for children list spacing', () => {
+        const wrapper = shallow(<PurePopover />);
+
+        expect(wrapper.find(ListSpacingContext.Provider).exists()).toBeTruthy();
+        expect(wrapper.find(ListSpacingContext.Provider).prop('value')).toBe(false);
+    });
+
     it('renders class names in respond to placement prop', () => {
         const wrapper = shallow(<PurePopover placement="bottom" />);
-        expect(wrapper.hasClass(
+        expect(wrapper.children('div').hasClass(
             BEM.root
                 .modifier('bottom')
                 .toString({ stripBlock: true })
         )).toBeTruthy();
 
         wrapper.setProps({ placement: 'top' });
-        expect(wrapper.hasClass(
+        expect(wrapper.children('div').hasClass(
             BEM.root
                 .modifier('top')
                 .toString({ stripBlock: true })

--- a/packages/core/src/contexts/listSpacing.js
+++ b/packages/core/src/contexts/listSpacing.js
@@ -1,0 +1,6 @@
+// #FIXME: use React navive context API when upgraded to v16+
+import createReactContext from 'create-react-context';
+
+const ListSpacingContext = createReactContext(true);
+
+export default ListSpacingContext;

--- a/packages/core/src/styles/Popover.scss
+++ b/packages/core/src/styles/Popover.scss
@@ -5,6 +5,7 @@ $component-name: #{$prefix}-popover;
     background-color: $c-popover-background;
     min-width: rem($popover-min-width);
     max-width: rem($popover-max-width);
+    padding-top: rem($popover-top-padding);
     padding-bottom: rem($popover-bottom-padding);
     border-radius: $popover-border-radius;
     filter: drop-shadow($popover-drop-shadow);

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -91,11 +91,12 @@ $popup-container-width: 256px;
 $popup-border-radius: 8px;
 $poup-box-shadow: 0 2px 8px hsba(0, 0, 0, 40);
 
-$popover-min-width: 208px;
+$popover-min-width: 240px;
 $popover-max-width: 320px;
 $popover-max-height: 320px;
 $popover-arrow-size: 11px;
-$popover-bottom-padding: 8px;
+$popover-top-padding: 8px;
+$popover-bottom-padding: 16px;
 $popover-border-radius: 8px;
 $popover-drop-shadow: 0 2px 3px hsba(0, 0, 0, 40);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,6 +2489,13 @@ create-react-class@^15.6.0, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -3568,6 +3575,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -4067,6 +4086,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 handlebars@^4.0.2:
   version "4.0.10"
@@ -8360,6 +8383,10 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
# Purpose
`<List>` is now wrapped by `<Section>`, introduced in #166, with a notable vertical spacing by default.
However it used to have smaller spacing and thus it now looks awkward when placed inside certain components, like `<ListRow>` and `<Popover>`.

This PR tries to remove the extra spacing from `<List>` by default when it's put in given components.

# Changes
- [Core] Add context for configuring vertical spacing for `<List>`.
- [Core] Remove vertical margin from `<List>` by context when placed inside `<ListRow>` or `<Popover>`.

# Screenshots
![popover](https://user-images.githubusercontent.com/365035/45195800-f5de8780-b28b-11e8-9dd9-a823c43159c7.png)
![list](https://user-images.githubusercontent.com/365035/45195798-f4ad5a80-b28b-11e8-91d8-c7456c2197c0.jpg)