### PR TITLE
Add the showCheckAll prop to disable checkAll option in <SelectList>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [Core] Add new `<Section>` as a general content wrapper with optional title and description text. (#166)
+- [Form] Add the `showCheckAll` prop to disable `checkAll` option in `<SelectList>`. (#170)
 
 ### Changed
 - [Core] Update `<List>` to wrap its own body with `<Section>`. (#166)

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -51,6 +51,7 @@ function getInitialCheckedState(fromValues) {
 class SelectList extends PureComponent {
     static propTypes = {
         multiple: PropTypes.bool,
+        showCheckAll: PropTypes.bool,
         minCheck: PropTypes.number,
         allOptionLabel: PropTypes.node,
         values: PropTypes.arrayOf(valueType),
@@ -60,6 +61,7 @@ class SelectList extends PureComponent {
 
     static defaultProps = {
         multiple: false,
+        showCheckAll: true,
         minCheck: 0,
         allOptionLabel: 'All',
         values: undefined,
@@ -112,7 +114,7 @@ class SelectList extends PureComponent {
     }
 
     handleOptionChange = (optionValue, isChecked) => {
-        const { multiple, minCheck } = this.props;
+        const { multiple, showCheckAll, minCheck } = this.props;
         const { checkedState } = this.state;
 
         let nextState = checkedState;
@@ -186,9 +188,11 @@ class SelectList extends PureComponent {
     }
 
     render() {
+        const { multiple, showCheckAll } = this.props;
+
         return (
             <List>
-                {this.props.multiple && this.renderCheckAllOption()}
+                {multiple && showCheckAll && this.renderCheckAllOption()}
                 {this.renderOptions()}
             </List>
         );

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -114,7 +114,7 @@ class SelectList extends PureComponent {
     }
 
     handleOptionChange = (optionValue, isChecked) => {
-        const { multiple, showCheckAll, minCheck } = this.props;
+        const { multiple, minCheck } = this.props;
         const { checkedState } = this.state;
 
         let nextState = checkedState;

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -137,6 +137,20 @@ describe('Multiple response mode', () => {
         expect(wrapper.find(Option).at(0).prop('label')).toBe('Check All');
     });
 
+    it('should not renders the "All" option if showCheckAll is false', () => {
+        const wrapper = shallow(
+            <SelectList multiple showCheckAll={false}>
+                <Option label="Foo" value="foo" />
+                <Option label="Bar" value="bar" />
+            </SelectList>
+        );
+
+        expect(wrapper.find(Option).at(0).props()).toMatchObject({
+            label: 'Foo',
+            value: 'foo',
+        });
+    });
+
     it('triggers onChange with sorted values', () => {
         const handleChange = jest.fn();
         const wrapper = shallow(

--- a/packages/storybook/examples/Form.SelectList/MultipleWithoutCheckAll.js
+++ b/packages/storybook/examples/Form.SelectList/MultipleWithoutCheckAll.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import SelectList from '@ichef/gypcrete-form/src/SelectList';
+import Option from '@ichef/gypcrete-form/src/SelectOption';
+
+function MultipleWithoutCheckAll() {
+    return (
+        <SelectList
+            multiple
+            showCheckAll={false}
+            defaultValues={['1']}
+            onChange={action('change')}>
+            <Option label="Option A" value="1" />
+            <Option label="Option B" value="2" />
+            <Option label="Option C" value="3" />
+        </SelectList>
+    );
+}
+
+export default MultipleWithoutCheckAll;

--- a/packages/storybook/examples/Form.SelectList/index.js
+++ b/packages/storybook/examples/Form.SelectList/index.js
@@ -9,6 +9,7 @@ import SingleControlled from './SingleControlled';
 import SingleUncontrolled from './SingleUncontrolled';
 import MultipleUncontrolled from './MultipleUncontrolled';
 import MultipleControlled from './MultipleControlled';
+import MultipleWithoutCheckAll from './MultipleWithoutCheckAll';
 import MultipleReadOnlyOption from './MultipleReadOnlyOption';
 import MultipleMinCheck from './MultipleMinCheck';
 
@@ -17,6 +18,7 @@ storiesOf('[Form] SelectList', module)
     .add('single (controlled)', withInfo()(SingleControlled))
     .add('multiple (uncontrolled)', withInfo()(MultipleUncontrolled))
     .add('multiple (controlled)', withInfo()(MultipleControlled))
+    .add('multiple (without checkAll)', withInfo()(MultipleWithoutCheckAll))
     .add('with read-only options', withInfo()(MultipleReadOnlyOption))
     .add('has minimum checks', withInfo()(MultipleMinCheck))
     // Props table


### PR DESCRIPTION
# Purpose

Add the `showCheckAll` prop to disable `checkAll` option in `<SelectList>` (By default, there is a `checkAll` option in the multiple `<SelectList>`).

![storybook 2018-09-10 16-04-25](https://user-images.githubusercontent.com/1139698/45284501-5501fd80-b513-11e8-878e-0790adf5dfb7.jpg)



# Changes

- Add the `showCheckAll` prop to disable `checkAll` option in `<SelectList>`
