### PR TITLE
Let SelectList accept the title and desc props 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [Core] Add new `<Section>` as a general content wrapper with optional title and description text. (#166)
 - [Form] Add the `showCheckAll` prop to disable `checkAll` option in `<SelectList>`. (#170)
+- [Form] Let `<SelectList>` accept the `title` and `desc` props. (#171)
 
 ### Changed
 - [Core] Update `<List>` to wrap its own body with `<Section>`. (#166)

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -57,6 +57,8 @@ class SelectList extends PureComponent {
         values: PropTypes.arrayOf(valueType),
         defaultValues: PropTypes.arrayOf(valueType),
         onChange: PropTypes.func,
+        title: PropTypes.string,
+        desc: PropTypes.node,
     };
 
     static defaultProps = {
@@ -67,6 +69,8 @@ class SelectList extends PureComponent {
         values: undefined,
         defaultValues: [],
         onChange: () => {},
+        title: undefined,
+        desc: undefined,
     };
 
     state = {
@@ -188,10 +192,15 @@ class SelectList extends PureComponent {
     }
 
     render() {
-        const { multiple, showCheckAll } = this.props;
+        const {
+            multiple,
+            showCheckAll,
+            title,
+            desc,
+         } = this.props;
 
         return (
-            <List>
+            <List title={title} desc={desc}>
                 {multiple && showCheckAll && this.renderCheckAllOption()}
                 {this.renderOptions()}
             </List>


### PR DESCRIPTION
# Purpose

Let `<SelectList>` accept the `title` and `desc` props to display the list title and description if they are provided.


# Changes

- Let `<SelectList>` accept the `title` and `desc` props.

