### PR TITLE
Add <SplitView>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Core] Add new `<SplitView>` and `<SplitViewColumn>`. (#178)
+- [Storybook] Add examples for `<SplitView>` and its usage with `<ColumView>`. (#178)
+
 ### Changed
 - [Core] `closable()` mixin is now triggered on `touchend` events on touch devices. (#176)
+- [Core] Update `<ColumnView>` layout styles; allow overriding bottom padding. (#178)
 - [Storybook] Update examples for `<Popover>` to add a row of hyperlink `<Button>`. (#176)
 - [Storybook] Split stories into different package-based sections. (#177)
 

--- a/packages/core/src/ColumnView.js
+++ b/packages/core/src/ColumnView.js
@@ -26,12 +26,18 @@ export function ColumnPart({ children, ...otherProps }) {
 function ColumnView({
     header,
     footer,
+    bottomPadding,
     // React props
     className,
     children,
     ...wrapperProps,
 }) {
     const rootClassName = classNames(BEM.root.toString(), className);
+    const bodyStyle = {};
+
+    if (bottomPadding) {
+        bodyStyle.paddingBottom = bottomPadding;
+    }
 
     return (
         <div className={rootClassName} {...wrapperProps}>
@@ -39,7 +45,7 @@ function ColumnView({
                 {header}
             </ColumnPart>
 
-            <div className={BEM.body.toString()}>
+            <div className={BEM.body.toString()} style={bodyStyle}>
                 {children}
             </div>
 
@@ -53,11 +59,13 @@ function ColumnView({
 ColumnView.propTypes = {
     header: PropTypes.node,
     footer: PropTypes.node,
+    bottomPadding: PropTypes.string,
 };
 
 ColumnView.defaultProps = {
     header: undefined,
     footer: undefined,
+    bottomPadding: undefined,
 };
 
 export default ColumnView;

--- a/packages/core/src/ColumnView.js
+++ b/packages/core/src/ColumnView.js
@@ -1,8 +1,6 @@
-// @flow
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import type { ReactChildren } from 'react-flow-types';
 import './styles/ColumnView.scss';
 
 import prefixClass from './utils/prefixClass';
@@ -17,17 +15,7 @@ export const BEM = {
     footer: ROOT_BEM.element('footer'),
 };
 
-export type Props = {
-    header?: ReactChildren,
-    footer?: ReactChildren,
-    /* eslint-disable react/require-default-props */
-    className?: string,
-    children?: ReactChildren,
-    /* eslint-enable react/require-default-props */
-};
-
-// eslint-disable-next-line react/require-default-props
-export function ColumnPart({ children, ...otherProps }: { children?: ReactChildren }) {
+export function ColumnPart({ children, ...otherProps }) {
     if (!children) {
         return null;
     }
@@ -42,7 +30,7 @@ function ColumnView({
     className,
     children,
     ...wrapperProps,
-}: Props) {
+}) {
     const rootClassName = classNames(BEM.root.toString(), className);
 
     return (

--- a/packages/core/src/SplitView.js
+++ b/packages/core/src/SplitView.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import icBEM from './utils/icBEM';
+import prefixClass from './utils/prefixClass';
+
+import './styles/SplitView.scss';
+
+export const COMPONENT_NAME = prefixClass('splitview');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+    root: ROOT_BEM,
+    column: ROOT_BEM.element('column'),
+};
+
+function SplitView({
+    className,
+    children,
+    ...otherProps
+}) {
+    const rootClassName = classNames(ROOT_BEM.toString(), className);
+
+    return (
+        <div className={rootClassName} {...otherProps}>
+            {children}
+        </div>
+    );
+}
+
+export default SplitView;

--- a/packages/core/src/SplitViewColumn.js
+++ b/packages/core/src/SplitViewColumn.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { BEM } from './SplitView';
+import './styles/SplitView.scss';
+
+function SplitViewColumn({
+    wide,
+    // React props
+    className,
+    children,
+    ...otherProps
+}) {
+    const columnBEM = BEM.column.modifier('wide', wide);
+    const columnClassName = classNames(columnBEM.toString(), className);
+
+    return (
+        <div className={columnClassName} {...otherProps}>
+            {children}
+        </div>
+    );
+}
+
+SplitViewColumn.propTypes = {
+    wide: PropTypes.bool,
+};
+
+SplitViewColumn.defaultProps = {
+    wide: false,
+};
+
+export default SplitViewColumn;

--- a/packages/core/src/__tests__/ColumnView.test.js
+++ b/packages/core/src/__tests__/ColumnView.test.js
@@ -39,6 +39,17 @@ describe('<ColumnView>', () => {
         expect(wrapper.find(`.${COLUMN_BEM.body}`).text()).toBe('Foo bar');
     });
 
+    it('can override bottom padding on body wrapper', () => {
+        const wrapper = shallow(
+            <ColumnView bottomPadding="0">
+                Foo bar
+            </ColumnView>
+        );
+        expect(wrapper.find(`.${COLUMN_BEM.body}`).prop('style')).toEqual({
+            paddingBottom: '0',
+        });
+    });
+
     it('renders header in a header <ColumnPart>', () => {
         const wrapper = shallow(
             <ColumnView header={<span data-test="header" />} />

--- a/packages/core/src/__tests__/SplitView.test.js
+++ b/packages/core/src/__tests__/SplitView.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import SplitView, { BEM } from '../SplitView';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <SplitView />;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders with BEM class as column of <SplitView>', () => {
+    const wrapper = shallow(<SplitView />);
+
+    expect(wrapper.hasClass(BEM.root.toString())).toBeTruthy();
+});

--- a/packages/core/src/__tests__/SplitViewColumn.test.js
+++ b/packages/core/src/__tests__/SplitViewColumn.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import SplitViewColumn from '../SplitViewColumn';
+import { BEM } from '../SplitView';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    const element = <SplitViewColumn />;
+
+    ReactDOM.render(element, div);
+});
+
+it('renders with BEM class as column of <SplitView>', () => {
+    const wrapper = shallow(<SplitViewColumn />);
+
+    expect(wrapper.hasClass(BEM.column.toString())).toBeTruthy();
+});
+
+it('adds wide modifier to class names when specified', () => {
+    const wrapper = shallow(<SplitViewColumn wide />);
+    const expectedClassName = BEM.column
+        .modifier('wide')
+        .toString({ stripBlock: true });
+
+    expect(wrapper.hasClass(expectedClassName)).toBeTruthy();
+});

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -34,6 +34,8 @@ import Section from './Section';
 import List from './List';
 import ListRow from './ListRow';
 import ColumnView from './ColumnView';
+import SplitView from './SplitView';
+import SplitViewColumn from './SplitViewColumn';
 import Overlay from './Overlay';
 import Popup from './Popup';
 import PopupButton from './PopupButton';
@@ -71,6 +73,8 @@ export {
     List,
     ListRow,
     ColumnView,
+    SplitView,
+    SplitViewColumn,
     Overlay,
     Popup,
     PopupButton,

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -19,7 +19,7 @@ $component: #{$prefix}-column-view;
     }
 
     &__body {
-        flex: 1 1 auto;
+        flex: 1 1 100%;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
         padding-bottom: rem($column-body-bottom-padding);

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -18,6 +18,10 @@ $component: #{$prefix}-column-view;
         flex: 0 0 auto;
     }
 
+    &__header {
+        z-index: 1;
+    }
+
     &__body {
         flex: 1 1 100%;
         overflow-y: scroll;

--- a/packages/core/src/styles/SplitView.scss
+++ b/packages/core/src/styles/SplitView.scss
@@ -1,0 +1,31 @@
+@import "./mixins";
+
+.#{$prefix}-splitview {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    // if nested in Flexbox
+    flex: 1 1 auto;
+
+    &,
+    &__column {
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    &__column {
+        min-width: rem($splitview-narrow-min-width);
+        max-width: rem($splitview-narrow-max-width);
+        flex: 1 0 25%;
+
+        & + & {
+            border-left: 1px solid $c-divider-splitview;
+        }
+
+        &--wide {
+            min-width: rem($splitview-wide-min-width);
+            max-width: none;
+            flex: 3 1 50%;
+        }
+    }
+}

--- a/packages/core/src/styles/_colors.scss
+++ b/packages/core/src/styles/_colors.scss
@@ -84,6 +84,7 @@ $c-divider-row:             hsba(0, 0, 0, 30);
 $c-divider-row-disabled:    hsba(0, 0, 0, 33);
 $c-divider-header:          hsba(0, 0, 0, 100);
 $c-divider-header-disabled: hsba(0, 0, 0, 1);
+$c-divider-splitview:       $c-divider-row;
 
 // Switch colors
 $c-switch-bg-on:  $c-green;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -109,6 +109,10 @@ $modal-max-height:       80vh;
 $modal-border-radius:    $popover-border-radius;
 $modal-box-shadow:       $poup-box-shadow;
 
+$splitview-narrow-min-width: 240px;
+$splitview-narrow-max-width: 400px;
+$splitview-wide-min-width:   360px;
+
 // -------------------------------------
 // Timing Functions
 //

--- a/packages/storybook/examples/core/SplitView/BasicUsage.js
+++ b/packages/storybook/examples/core/SplitView/BasicUsage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import SplitView from '@ichef/gypcrete/src/SplitView';
+import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
+
+import DebugBox from 'utils/DebugBox';
+import ColoredBox from 'utils/ColoredBox';
+
+function BasicUsage() {
+    return (
+        <DebugBox width="40rem" height="24rem">
+            <SplitView>
+                <SplitViewColumn>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(255, 235, 235)">
+                        Narrow Column
+                    </ColoredBox>
+                </SplitViewColumn>
+
+                <SplitViewColumn wide>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(235, 245, 255)">
+                        Narrow Column
+                    </ColoredBox>
+                </SplitViewColumn>
+            </SplitView>
+        </DebugBox>
+    );
+}
+
+export default BasicUsage;

--- a/packages/storybook/examples/core/SplitView/ContainsColumnView.js
+++ b/packages/storybook/examples/core/SplitView/ContainsColumnView.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import SplitView from '@ichef/gypcrete/src/SplitView';
+import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
+
+import DebugBox from 'utils/DebugBox';
+import ColoredBox from 'utils/ColoredBox';
+
+import DemoColumnView from './DemoColumnView';
+
+function ContainsColumnView() {
+    return (
+        <DebugBox width="40rem" height="24rem">
+            <SplitView>
+                <SplitViewColumn>
+                    <DemoColumnView>
+                        <ColoredBox
+                            width="100%"
+                            height="30rem"
+                            color="rgb(255, 235, 235)">
+                            Narrow Column
+                        </ColoredBox>
+                    </DemoColumnView>
+                </SplitViewColumn>
+
+                <SplitViewColumn wide>
+                    <DemoColumnView>
+                        <ColoredBox
+                            width="100%"
+                            height="30rem"
+                            color="rgb(235, 245, 255)">
+                            Narrow Column
+                        </ColoredBox>
+                    </DemoColumnView>
+                </SplitViewColumn>
+            </SplitView>
+        </DebugBox>
+    );
+}
+
+export default ContainsColumnView;

--- a/packages/storybook/examples/core/SplitView/DemoColumnView.js
+++ b/packages/storybook/examples/core/SplitView/DemoColumnView.js
@@ -18,9 +18,9 @@ function ColumnHeader() {
 
 const HEADER = <ColumnHeader />;
 
-function DemoColumnView({ children }) {
+function DemoColumnView({ children, ...props }) {
     return (
-        <ColumnView header={HEADER}>
+        <ColumnView header={HEADER} {...props}>
             {children}
         </ColumnView>
     );

--- a/packages/storybook/examples/core/SplitView/DemoColumnView.js
+++ b/packages/storybook/examples/core/SplitView/DemoColumnView.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import ColumnView from '@ichef/gypcrete/src/ColumnView';
+import HeaderRow from '@ichef/gypcrete/src/HeaderRow';
+import TextLabel from '@ichef/gypcrete/src/TextLabel';
+
+function ColumnHeader() {
+    const label = (
+        <TextLabel
+            align="center"
+            basic="Column Header" />
+    );
+
+    return (
+        <HeaderRow center={label} />
+    );
+}
+
+const HEADER = <ColumnHeader />;
+
+function DemoColumnView({ children }) {
+    return (
+        <ColumnView header={HEADER}>
+            {children}
+        </ColumnView>
+    );
+}
+
+export default DemoColumnView;

--- a/packages/storybook/examples/core/SplitView/InsideColumnView.js
+++ b/packages/storybook/examples/core/SplitView/InsideColumnView.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import SplitView from '@ichef/gypcrete/src/SplitView';
+import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
+
+import DebugBox from 'utils/DebugBox';
+import ColoredBox from 'utils/ColoredBox';
+
+import DemoColumnView from './DemoColumnView';
+
+function InsideColumnView() {
+    return (
+        <DebugBox width="40rem" height="24rem">
+            <DemoColumnView>
+                <SplitView>
+                    <SplitViewColumn>
+                        <ColoredBox
+                            width="100%"
+                            height="30rem"
+                            color="rgb(255, 235, 235)">
+                            Narrow Column
+                        </ColoredBox>
+                    </SplitViewColumn>
+
+                    <SplitViewColumn wide>
+                        <ColoredBox
+                            width="100%"
+                            height="30rem"
+                            color="rgb(235, 245, 255)">
+                            Narrow Column
+                        </ColoredBox>
+                    </SplitViewColumn>
+                </SplitView>
+            </DemoColumnView>
+        </DebugBox>
+    );
+}
+
+export default InsideColumnView;

--- a/packages/storybook/examples/core/SplitView/InsideColumnView.js
+++ b/packages/storybook/examples/core/SplitView/InsideColumnView.js
@@ -11,7 +11,7 @@ import DemoColumnView from './DemoColumnView';
 function InsideColumnView() {
     return (
         <DebugBox width="40rem" height="24rem">
-            <DemoColumnView>
+            <DemoColumnView bottomPadding="0">
                 <SplitView>
                     <SplitViewColumn>
                         <ColoredBox

--- a/packages/storybook/examples/core/SplitView/index.js
+++ b/packages/storybook/examples/core/SplitView/index.js
@@ -1,0 +1,12 @@
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import SplitView from '@ichef/gypcrete/src/SplitView';
+import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
+import getPropTables from 'utils/getPropTables';
+
+import BasicUsage from './BasicUsage';
+
+storiesOf('@ichef/gypcrete|SplitView', module)
+    .add('basic usage', withInfo()(BasicUsage))
+    .add('props', getPropTables([SplitView, SplitViewColumn]));

--- a/packages/storybook/examples/core/SplitView/index.js
+++ b/packages/storybook/examples/core/SplitView/index.js
@@ -6,7 +6,11 @@ import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
 import getPropTables from 'utils/getPropTables';
 
 import BasicUsage from './BasicUsage';
+import ContainsColumnView from './ContainsColumnView';
+import InsideColumnView from './InsideColumnView';
 
 storiesOf('@ichef/gypcrete|SplitView', module)
     .add('basic usage', withInfo()(BasicUsage))
+    .add('contains <ColumnView>', withInfo()(ContainsColumnView))
+    .add('inside <ColumnView>', withInfo()(InsideColumnView))
     .add('props', getPropTables([SplitView, SplitViewColumn]));

--- a/packages/storybook/utils/ColoredBox.js
+++ b/packages/storybook/utils/ColoredBox.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ColoredBox({ width, height, color, children }) {
+    const style = {
+        background: color,
+        width,
+        height,
+    };
+    return (
+        <div style={style}>
+            {children}
+        </div>
+    );
+}
+
+ColoredBox.propTypes = {
+    width: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string
+    ]),
+    height: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string
+    ]),
+    color: PropTypes.string,
+};
+
+ColoredBox.defaultProps = {
+    width: undefined,
+    height: undefined,
+    color: undefined,
+};
+
+export default ColoredBox;


### PR DESCRIPTION
# Purpose
Add `<SplitView>` from ic-framework.
This should mark the final migration from ic-framework.

# Changes
- [Core] Add new `<SplitView>` and `<SplitViewColumn>`.
- [Core] Update `<ColumnView>` layout styles; allow overriding bottom padding.

# Screenshot
![2018-10-24 4 41 21](https://user-images.githubusercontent.com/365035/47418458-b83aad00-d7ac-11e8-8cd8-6614b8d6604a.png)

