### PR TITLE
Adapt React Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [Core] Remove flow type annotation. (#180)
+- [Core] Adapt React Portal in `renderToLayer()` HOC mixin. (#188)
+- [Storybook] Upgrade to `@storybook/react@^4.0.0` to support Babel 7. (#187)
 - [Build] Upgrade to `enzyme@3.7.0`; fix tests for that. (#183)
 - [Build] Upgrade to Babel v7; switch to project-scope Babel config. (#185)
 - [Build] Upgrade to `jest@23.6.0` to support Babel 7. (#185)
 - [Build] Upgrade to `eslint@5.8.0`, `eslint-config-ichef@2.0.0` and `eslint-config-airbnb@17.1.0`. (#186)
 - [Build] Upgrade to `react@16.6.1` and `prop-types@15.6.2`. (#187)
-- [Storybook] Upgrade to `@storybook/react@^4.0.0` to support Babel 7. (#187)
 
 ## [1.10.0]
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.0",
     "enzyme": "^3.7.0",
+    "react-is": "^16.6.1",
     "sinon": "^4.0.1",
     "webpack": "^3.10.0",
     "webpack-merge": "^4.1.2"

--- a/packages/core/src/Icon.js
+++ b/packages/core/src/Icon.js
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
+
+import './styles/_animations.scss';
 import './styles/Icon.scss';
 
 const COMPONENT_NAME = prefixClass('icon');

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -13,6 +13,7 @@ import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 import renderToLayer from './mixins/renderToLayer';
 
+import './styles/_animations.scss';
 import './styles/Modal.scss';
 
 export const MODAL_SIZE = ['small', 'large', 'full'];

--- a/packages/core/src/Overlay.js
+++ b/packages/core/src/Overlay.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 
+import './styles/_animations.scss';
 import './styles/Overlay.scss';
 
 export const COMPONENT_NAME = prefixClass('overlay');

--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -14,6 +14,7 @@ import Icon from './Icon';
 import Overlay from './Overlay';
 import TextLabel from './TextLabel';
 
+import './styles/_animations.scss';
 import './styles/Popup.scss';
 
 export const BUTTONS_DIRECTION = {

--- a/packages/core/src/mixins/__tests__/renderToLayer.test.js
+++ b/packages/core/src/mixins/__tests__/renderToLayer.test.js
@@ -53,7 +53,7 @@ it('append layer to body on mount and removes on unmount', () => {
 
 it('renders wrapped component via ReactPortal after layer is in DOM', () => {
     const wrapper = shallow(<LayerFoo />, { disableLifecycleMethods: true });
-    expect(wrapper.children().isEmpty()).toBeTruthy();
+    expect(wrapper.children().exists()).toBeFalsy();
 
     // Triggers layer appending
     wrapper.instance().componentDidMount();

--- a/packages/core/src/mixins/__tests__/renderToLayer.test.js
+++ b/packages/core/src/mixins/__tests__/renderToLayer.test.js
@@ -51,8 +51,12 @@ it('append layer to body on mount and removes on unmount', () => {
     expect(document.getElementById(layerId)).toBeNull();
 });
 
-it('renders wrapped component with ReactPortal', () => {
-    const wrapper = shallow(<LayerFoo />);
+it('renders wrapped component via ReactPortal after layer is in DOM', () => {
+    const wrapper = shallow(<LayerFoo />, { disableLifecycleMethods: true });
+    expect(wrapper.children().isEmpty()).toBeTruthy();
+
+    // Triggers layer appending
+    wrapper.instance().componentDidMount();
 
     expect(wrapper.type()).toBe(ReactIs.Portal);
     expect(wrapper.children().is(Foo)).toBeTruthy();

--- a/packages/core/src/mixins/__tests__/renderToLayer.test.js
+++ b/packages/core/src/mixins/__tests__/renderToLayer.test.js
@@ -1,19 +1,21 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import { mount, ReactWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
+import * as ReactIs from 'react-is';
 
+import randId from '../../utils/randId';
 import renderToLayer from '../renderToLayer';
+
+jest.mock('../../utils/randId');
 
 // --------------------
 //  Mocking components
 // --------------------
 
-// eslint-disable-next-line react/prefer-stateless-function
-class Foo extends PureComponent {
-    render() {
-        return <div className="bar">Hello World!</div>;
-    }
+function Foo() {
+    return <div className="bar">Hello World!</div>;
 }
+
 const LayerFoo = renderToLayer(Foo);
 
 
@@ -28,51 +30,30 @@ it('renders without crashing', () => {
     ReactDOM.render(element, div);
 });
 
-it('creates layer on mount and removes on unmount', () => {
-    const wrapper = mount(<LayerFoo />);
-    const layerId = wrapper.instance().baseLayer.id;
+it('creates a layer with unique ID on creation', () => {
+    randId.mockReturnValueOnce('MOCKED_ID');
 
-    // Make sure the layer is created
-    expect(document.getElementById(layerId)).not.toBeNull();
+    const wrapper = shallow(<LayerFoo />);
+
+    expect(randId).toHaveBeenCalled();
+    expect(wrapper.instance().baseLayer.id = 'MOCKED_ID');
+});
+
+it('append layer to body on mount and removes on unmount', () => {
+    const layerId = 'layer-1234';
+    randId.mockReturnValueOnce(layerId);
+
+    const wrapper = shallow(<LayerFoo />);
+
+    expect(document.getElementById(layerId)).toBe(wrapper.instance().baseLayer);
 
     wrapper.unmount();
-
-    // Now make sure the layer is removed from DOM tree
     expect(document.getElementById(layerId)).toBeNull();
 });
 
-it('should give up removing layer if reference to layer lost', () => {
-    const wrapper = mount(<LayerFoo />);
-    const layerId = wrapper.instance().baseLayer.id;
+it('renders wrapped component with ReactPortal', () => {
+    const wrapper = shallow(<LayerFoo />);
 
-    // Mock reference lost
-    wrapper.instance().baseLayer = null;
-    wrapper.unmount();
-
-    // Expect unmount to abort
-    expect(document.getElementById(layerId)).not.toBeNull();
-});
-
-// #FIXME: Fail in Enzyme 3 + React 15. Fix with Portal from React 16.
-it.skip('renders wrapped Component outside React root', () => {
-    const wrapper = mount(<LayerFoo />);
-    const layerWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
-
-    // Wrapper should not have children, because it's rendered somewhere else.
-    expect(wrapper.children().exists()).toBeFalsy();
-
-    expect(layerWrapper.find(Foo)).toHaveLength(1);
-    expect(layerWrapper.hasClass('bar')).toBeTruthy();
-    expect(layerWrapper.text()).toBe('Hello World!');
-});
-
-// #FIXME: Fail in Enzyme 3 + React 16. Fix with React Portal.
-it.skip('updates wrapped component when props change', () => {
-    const wrapper = mount(<LayerFoo />);
-    const layerWrapper = new ReactWrapper(wrapper.instance().componentRef, true);
-
-    expect(layerWrapper.props()).toEqual({});
-
-    wrapper.setProps({ inline: true });
-    expect(layerWrapper.props()).toEqual({ inline: true });
+    expect(wrapper.type()).toBe(ReactIs.Portal);
+    expect(wrapper.children().is(Foo)).toBeTruthy();
 });

--- a/packages/core/src/mixins/renderToLayer.js
+++ b/packages/core/src/mixins/renderToLayer.js
@@ -35,6 +35,10 @@ function renderToLayer(WrappedComponent) {
     class RenderToLayer extends Component {
         static displayName = `renderToLayer(${componentName})`;
 
+        state = {
+            inDOM: false,
+        };
+
         constructor(props) {
             super(props);
             this.baseLayer = createLayer();
@@ -42,6 +46,7 @@ function renderToLayer(WrappedComponent) {
 
         componentDidMount() {
             document.body.appendChild(this.baseLayer);
+            this.setState({ inDOM: true });
         }
 
         componentWillUnmount() {
@@ -49,7 +54,9 @@ function renderToLayer(WrappedComponent) {
         }
 
         render() {
-            return createPortal(
+            const { inDOM } = this.state;
+
+            return inDOM && createPortal(
                 <WrappedComponent {...this.props} />,
                 this.baseLayer,
             );

--- a/packages/core/src/mixins/renderToLayer.js
+++ b/packages/core/src/mixins/renderToLayer.js
@@ -1,28 +1,5 @@
-/**
- * renderToLayer() HOC mixin
- * =========================
- * Render a component to an node outside of React root, while still being
- * maintained under React virtual tree.
- *
- * Inspired by material-ui
- * @ref https://github.com/callemall/material-ui/blob/master/src/internal/RenderToLayer.js
- *
- * Original created by @cjies
- * @ref https://github.com/iCHEF/iC-framework-react/pull/66
- *
- * Converted to mixin pattern by @zhusee2
- * @ref https://facebook.github.io/react/blog/2016/07/13/mixins-considered-harmful.html
- *
- * Usage
- * -----
- * const ExternalComponent = renderToLayer(Component);
- */
-
 import React, { Component } from 'react';
-
-// Importing an unstable API method from react-dom
-// eslint-disable-next-line camelcase
-import ReactDOM, { unstable_renderSubtreeIntoContainer } from 'react-dom';
+import { createPortal } from 'react-dom';
 
 import prefixClass from '../utils/prefixClass';
 import getComponentName from '../utils/getComponentName';
@@ -33,79 +10,49 @@ import '../styles/RenderToLayer.scss';
 const COMPONENT_NAME = prefixClass('base-layer');
 const LAYER_ID_PREFIX = 'layer';
 
+export function createLayer() {
+    const layer = document.createElement('div');
+    layer.className = COMPONENT_NAME;
+    layer.id = randId({ prefix: LAYER_ID_PREFIX });
+
+    return layer;
+}
+
+/**
+ * renderToLayer() HOC mixin
+ * =========================
+ * Render a component to an node outside of React root,
+ * using `React.createPortal()`.
+ *
+ * @param {React.ComponentType<any>} WrappedComponent
+ *
+ * @example
+ * const ExternalComponent = renderToLayer(Component);
+ */
 function renderToLayer(WrappedComponent) {
     const componentName = getComponentName(WrappedComponent);
 
     class RenderToLayer extends Component {
         static displayName = `renderToLayer(${componentName})`;
 
-        constructor(...args) {
-            super(...args);
-
-            this.baseLayer = null;
-            this.componentRef = null;
+        constructor(props) {
+            super(props);
+            this.baseLayer = createLayer();
         }
 
         componentDidMount() {
-            this.createBaseLayer();
-            this.renderComponentToLayer();
-        }
-
-        componentWillReceiveProps(nextProps) {
-            this.renderComponentToLayer({ withProps: nextProps });
+            document.body.appendChild(this.baseLayer);
         }
 
         componentWillUnmount() {
-            if (!this.baseLayer) return;
-
-            ReactDOM.unmountComponentAtNode(this.baseLayer);
-            this.removeBaseLayer();
-        }
-
-        // -------------------------------------
-        //   Base Layer
-        // -------------------------------------
-
-        /**
-         * Create the base layer on <body> to render <Componenet>
-         */
-        createBaseLayer() {
-            const baseLayer = document.createElement('div');
-            baseLayer.className = COMPONENT_NAME;
-            baseLayer.id = randId({ prefix: LAYER_ID_PREFIX });
-
-            this.baseLayer = baseLayer;
-            document.body.appendChild(baseLayer);
-        }
-
-        /**
-         * Remove base layer from <body>
-         */
-        removeBaseLayer() {
             document.body.removeChild(this.baseLayer);
-            this.baseLayer = null;
-        }
-
-        // -------------------------------------
-        //   Render
-        // -------------------------------------
-
-        /**
-         * Renders passed-in <Componenet> to the external base layer,
-         * based on given props.
-         *
-         * @param {Object} withProps - current or next props of <RenderToLayer> wrapper
-         */
-        renderComponentToLayer({ withProps = this.props } = {}) {
-            this.componentRef = unstable_renderSubtreeIntoContainer(
-                this, // parentComponent
-                <WrappedComponent {...withProps} />,
-                this.baseLayer // container
-            );
         }
 
         render() {
-            return null;
+            return createPortal(
+                <WrappedComponent {...this.props} />,
+                this.baseLayer,
+            );
         }
     }
 

--- a/packages/core/src/mixins/renderToLayer.js
+++ b/packages/core/src/mixins/renderToLayer.js
@@ -46,6 +46,15 @@ function renderToLayer(WrappedComponent) {
 
         componentDidMount() {
             document.body.appendChild(this.baseLayer);
+
+            /**
+             * Render null before base layer is put in DOM for 'renderToLayer()' mixin.
+             *
+             * This is the current behavior of v1.x.
+             * It prevents an issue with 'anchored()' mixin where it can retrieve
+             * incorrect rects from self DOM node when calculating its own position,
+             * due to its parent node (the layer) isn't inserted to DOM yet.
+             */
             this.setState({ inDOM: true });
         }
 

--- a/packages/core/src/styles/index.scss
+++ b/packages/core/src/styles/index.scss
@@ -1,6 +1,5 @@
 @import "./mixins";
 @import "./states";
-@import "./animations";
 
 html {
     font-size: $root-font-size;


### PR DESCRIPTION
# Purpose
Use `ReactDOM.createPortal()` in `renderToLayer()` HOC mixin to replace previous `ReactDOM.unstable_renderSubtreeIntoContainer()` private API usage.

# Changes
- [Core] Adapt React Portal in `renderToLayer()` HOC mixin.
- [Core] Slightly change the way we import CSS Animation to work better in Storybook.