### PR TITLE
Remove usage of React.findDOMNode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] [Form] [ImageEditor] Peer dependency changes:
     * Switch from `babel-runtime` to `@babel/runtime-corejs2`. (#185)
     * Upgrade to `react@^16.6.0` and `react-dom@^16.6.0`. (#187)
+- [Core] `anchored()` HOC mixin no longer uses `ReactDOM.findDOMNode()` to find the actual node for you. You should now manually set ref to both *anchor* element and *wrappred* element instead. Please read #189 for more info.
 
 ### Changed
 - [Core] Remove flow type annotation. (#180)

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -90,7 +90,7 @@ class Modal extends PureComponent {
         const { onClose } = this.props;
         // Prevent onClick events being propagated to outer modals
         event.stopPropagation();
-        if (onClose) { onClose(); }
+        onClose();
     }
 
     render() {

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -6,7 +6,10 @@ import ListSpacingContext from './contexts/listSpacing';
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 
-import anchored, { anchoredPropTypes, ANCHORED_PLACEMENT } from './mixins/anchored';
+import anchored, {
+    anchoredPropTypes,
+    ANCHORED_PLACEMENT,
+} from './mixins/anchored';
 import closable from './mixins/closable';
 import renderToLayer from './mixins/renderToLayer';
 
@@ -24,6 +27,7 @@ function Popover({
     // from anchored()
     placement,
     arrowStyle,
+    nodeRef,
     // React props
     className,
     children,
@@ -34,7 +38,7 @@ function Popover({
 
     return (
         <ListSpacingContext.Provider value={false}>
-            <div className={rootClassName} {...otherProps}>
+            <div className={rootClassName} ref={nodeRef} {...otherProps}>
                 <span className={BEM.arrow} style={arrowStyle} />
                 <div className={BEM.container}>
                     {children}
@@ -47,11 +51,13 @@ function Popover({
 Popover.propTypes = {
     placement: anchoredPropTypes.placement,
     arrowStyle: anchoredPropTypes.arrowStyle,
+    nodeRef: anchoredPropTypes.nodeRef,
 };
 
 Popover.defaultProps = {
     placement: ANCHORED_PLACEMENT.BOTTOM,
     arrowStyle: {},
+    nodeRef: undefined,
 };
 
 export { Popover as PurePopover };

--- a/packages/core/src/Tooltip.js
+++ b/packages/core/src/Tooltip.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
 
-import anchored, { ANCHORED_PLACEMENT } from './mixins/anchored';
+import anchored, {
+    anchoredPropTypes,
+    ANCHORED_PLACEMENT,
+} from './mixins/anchored';
 import renderToLayer from './mixins/renderToLayer';
 import './styles/Tooltip.scss';
 
@@ -21,8 +23,10 @@ const BOTTOM = 'bottom';
 export const TOOLTIP_PLACEMENT = { TOP, BOTTOM };
 
 function Tooltip({
+    // from anchored()
     placement,
     arrowStyle,
+    nodeRef,
     // React props
     className,
     children,
@@ -32,7 +36,7 @@ function Tooltip({
     const rootClassName = classNames(className, `${bemClass}`);
 
     return (
-        <span className={rootClassName} {...otherProps}>
+        <span className={rootClassName} ref={nodeRef} {...otherProps}>
             {children}
             <span className={BEM.arrow} style={arrowStyle} />
         </span>
@@ -40,13 +44,15 @@ function Tooltip({
 }
 
 Tooltip.propTypes = {
-    placement: PropTypes.oneOf(Object.values(TOOLTIP_PLACEMENT)),
-    arrowStyle: PropTypes.objectOf(PropTypes.number),
+    placement: anchoredPropTypes.placement,
+    arrowStyle: anchoredPropTypes.arrowStyle,
+    nodeRef: anchoredPropTypes.nodeRef,
 };
 
 Tooltip.defaultProps = {
     placement: TOP,
     arrowStyle: {},
+    nodeRef: undefined,
 };
 
 export { Tooltip as PureTooltip };

--- a/packages/core/src/mixins/__tests__/anchored.test.js
+++ b/packages/core/src/mixins/__tests__/anchored.test.js
@@ -20,7 +20,10 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 
-import anchored, { ANCHORED_PLACEMENT } from '../anchored';
+import anchored, {
+    anchoredPropTypes,
+    ANCHORED_PLACEMENT,
+} from '../anchored';
 
 // --------------------
 //  Mocking components
@@ -57,14 +60,17 @@ class Anchor extends PureComponent {
     }
 }
 
-function Box({ style }) {
+function Box({ style, nodeRef }) {
     const boxStyle = {
         ...style,
         width: BOX_SIZE,
         height: BOX_SIZE,
     };
-    return <div style={boxStyle} />;
+    return <div style={boxStyle} ref={nodeRef} />;
 }
+Box.propTypes = {
+    nodeRef: anchoredPropTypes.nodeRef.isRequired,
+};
 const AnchoredBoxBottom = anchored()(Box);
 const AnchoredBoxTop = anchored({ defaultPlacement: ANCHORED_PLACEMENT.TOP })(Box);
 

--- a/packages/core/src/mixins/__tests__/anchored.test.js
+++ b/packages/core/src/mixins/__tests__/anchored.test.js
@@ -15,7 +15,7 @@
  * └╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┘
  */
 
-import React, { PureComponent } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
@@ -32,34 +32,29 @@ const BOX_SIZE = 100;
 const ANCHOR_SIZE_SMALL = 20;
 const ANCHOR_SIZE_LARGE = 200;
 
-// <Anchor> needs to be a React Component so it has an backing instance.
-// eslint-disable-next-line react/prefer-stateless-function
-class Anchor extends PureComponent {
-    static propTypes = {
-        top: PropTypes.number.isRequired,
-        left: PropTypes.number.isRequired,
-        large: PropTypes.bool,
+// Anchor component
+const Anchor = React.forwardRef(({ top, left, large }, ref) => {
+    const anchorSize = large ? ANCHOR_SIZE_LARGE : ANCHOR_SIZE_SMALL;
+
+    const style = {
+        width: anchorSize,
+        height: anchorSize,
+        position: 'absolute',
+        top,
+        left,
     };
+    return <div id="anchor" style={style} ref={ref} />;
+});
+Anchor.propTypes = {
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+    large: PropTypes.bool,
+};
+Anchor.defaultProps = {
+    large: false,
+};
 
-    static defaultProps = {
-        large: false,
-    };
-
-    render() {
-        const { top, left, large } = this.props;
-        const anchorSize = large ? ANCHOR_SIZE_LARGE : ANCHOR_SIZE_SMALL;
-
-        const style = {
-            width: anchorSize,
-            height: anchorSize,
-            position: 'absolute',
-            top,
-            left,
-        };
-        return <div id="anchor" style={style} />;
-    }
-}
-
+// Positioned “wrapped” component
 function Box({ style, nodeRef }) {
     const boxStyle = {
         ...style,
@@ -71,6 +66,7 @@ function Box({ style, nodeRef }) {
 Box.propTypes = {
     nodeRef: anchoredPropTypes.nodeRef.isRequired,
 };
+
 const AnchoredBoxBottom = anchored()(Box);
 const AnchoredBoxTop = anchored({ defaultPlacement: ANCHORED_PLACEMENT.TOP })(Box);
 
@@ -112,6 +108,9 @@ HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
 const anchorRoot = document.createElement('div');
 const boxRoot = document.createElement('div');
 
+anchorRoot.id = 'anchor-root';
+boxRoot.id = 'box-root';
+
 document.body.appendChild(anchorRoot);
 document.body.appendChild(boxRoot);
 
@@ -126,45 +125,63 @@ it('renders without crashing', () => {
     ReactDOM.render(element, div);
 });
 
-it('can take an HTMLElement as anchor', () => {
-    mount(<Anchor top={10} left={10} />, { attachTo: anchorRoot });
-    const anchorNode = document.getElementById('anchor');
-
-    const wrapper = mount(
-        <AnchoredBoxTop anchor={anchorNode} />,
-        { attachTo: boxRoot }
+it('takes an HTMLElement as anchor', async () => {
+    /**
+     * Enzyme weirdly passes an instance of `WrapperComponent` to React ref
+     * when you directly mounts:
+     * ```js
+     * mount(<div ref={(ref) => { console.log(ref); }} />);
+     * // console prints: WrapperComponent
+     * ```
+     *
+     * But if you wrap the ref-target element with another layer of wrapper,
+     * if receives correct HTMLDivElement.
+     */
+    const anchorRef = React.createRef();
+    mount(
+        <><Anchor top={10} left={10} ref={anchorRef} /></>,
+        { attachTo: anchorRoot }
     );
 
+    const wrapper = mount(<AnchoredBoxTop anchor={anchorRef.current} />);
+
     expect(wrapper.find(Box).exists()).toBeTruthy();
-    expect(wrapper.instance().getAnchorDOMNode()).toBe(anchorNode);
+    expect(wrapper.instance().getAnchorDOMNode()).toBe(anchorRef.current);
 });
 
 it('re-adjusts position when assigned with another anchor', () => {
-    let anchorWrapper = mount(<Anchor top={20} left={10} />, { attachTo: anchorRoot });
-    const wrapper = mount(
-        <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
-        { attachTo: boxRoot }
+    const anchorRefOne = React.createRef();
+    const anchorRefTwo = React.createRef();
+    mount(
+        <>
+            <Anchor top={20} left={10} ref={anchorRefOne} />
+            <Anchor top={200} left={10} ref={anchorRefTwo} />
+        </>,
+        { attachTo: anchorRoot }
     );
 
+    const wrapper = mount(<AnchoredBoxTop anchor={anchorRefOne.current} />);
     expect(wrapper.find(Box).prop('placement')).toBe(ANCHORED_PLACEMENT.BOTTOM);
 
-    // Should not re-adjust if anchor isn't changed
+    // Should not re-adjust if anchor remains the same
     wrapper.setProps({ foo: true });
     expect(wrapper.find(Box).prop('placement')).toBe(ANCHORED_PLACEMENT.BOTTOM);
 
-    // Should re-adjust since anchor changes
-    anchorWrapper = mount(<Anchor top={200} left={10} />, { attachTo: anchorRoot });
-    wrapper.setProps({ anchor: anchorWrapper.instance() });
-
+    // Should re-adjust when anchor changes
+    wrapper.setProps({ anchor: anchorRefTwo.current });
     expect(wrapper.find(Box).prop('placement')).toBe(ANCHORED_PLACEMENT.TOP);
 });
 
 describe('Vertical placement', () => {
     it('renders above when anchor placed near bottom of viewport', () => {
-        const anchorWrapper = mount(<Anchor top={700} left={100} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor top={700} left={100} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
 
         let boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -172,7 +189,7 @@ describe('Vertical placement', () => {
         expect(boxWrapper.prop('style').top).toBe(700 - BOX_SIZE);
 
         boxWrapper = mount(
-            <AnchoredBoxBottom anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxBottom anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -181,10 +198,14 @@ describe('Vertical placement', () => {
     });
 
     it('renders below when anchor placed near top of viewport', () => {
-        const anchorWrapper = mount(<Anchor top={50} left={100} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor top={50} left={100} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
 
         let boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -192,7 +213,7 @@ describe('Vertical placement', () => {
         expect(boxWrapper.prop('style').top).toBe(50 + ANCHOR_SIZE_SMALL);
 
         boxWrapper = mount(
-            <AnchoredBoxBottom anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxBottom anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -203,9 +224,14 @@ describe('Vertical placement', () => {
 
 describe('Horizontal placement: small anchor', () => {
     it('aligns to the center of anchor when space is enough', () => {
-        const anchorWrapper = mount(<Anchor top={20} left={100} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor top={20} left={100} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
+
         const boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -218,9 +244,14 @@ describe('Horizontal placement: small anchor', () => {
     });
 
     it('aligns to the right side of anchor if space is not enough on right side', () => {
-        const anchorWrapper = mount(<Anchor top={20} left={1000} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor top={20} left={1000} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
+
         const boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -233,9 +264,14 @@ describe('Horizontal placement: small anchor', () => {
     });
 
     it('aligns to the left side of anchor if space is not enough on left side', () => {
-        const anchorWrapper = mount(<Anchor top={20} left={10} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor top={20} left={10} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
+
         const boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 
@@ -250,9 +286,14 @@ describe('Horizontal placement: small anchor', () => {
 
 describe('Horizontal placement: large anchor', () => {
     it('aligns to the center of anchor when anchor is wider than box', () => {
-        const anchorWrapper = mount(<Anchor large top={20} left={20} />, { attachTo: anchorRoot });
+        const anchorRef = React.createRef();
+        mount(
+            <><Anchor large top={20} left={20} ref={anchorRef} /></>,
+            { attachTo: anchorRoot }
+        );
+
         const boxWrapper = mount(
-            <AnchoredBoxTop anchor={anchorWrapper.instance()} />,
+            <AnchoredBoxTop anchor={anchorRef.current} />,
             { attachTo: boxRoot }
         ).find(Box);
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -31,8 +31,7 @@
   "peerDependencies": {
     "@babel/runtime-corejs2": "^7.1.0",
     "prop-types": "^15.5.8",
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react": "^16.6.0"
   },
   "dependencies": {
     "@ichef/gypcrete": "^1.10.0",
@@ -42,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",
+    "react-dom": "^16.6.0",
     "enzyme": "^3.7.0",
     "webpack": "^3.10.0"
   }

--- a/packages/imageeditor/package.json
+++ b/packages/imageeditor/package.json
@@ -31,8 +31,7 @@
   "peerDependencies": {
     "@babel/runtime-corejs2": "^7.1.0",
     "prop-types": "^15.5.8",
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react": "^16.6.0"
   },
   "dependencies": {
     "@ichef/gypcrete": "^1.10.0",
@@ -41,6 +40,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",
+    "react-dom": "^16.6.0",
     "enzyme": "^3.7.0",
     "webpack": "^3.10.0"
   }


### PR DESCRIPTION
# Purpose
As of React 16.6, `ReactDOM.findDOMNode()` is [added to list of deprecated API][1].
But even before that, usage of the API has been advised to be prevented.

This PR removes calls to the listed API from `anchored()` HOC mixin, and instead introduces an approach that requires you to manually set refs to both *anchor* element and *wrapped* element.

The `anchored(Component)` HOC now only accept an `HTMLElement` node for the `anchor` prop it's taking.
Also it now passes an additional `nodeRef` prop to the wrapped component, which is a `React.createRef()` to collect ref to the DOM node that should be positioned to anchor.

# Example
## Configuring wrapped component
```js
function Component({ placement, arrowStyle, style, nodeRef }) {
    return (
        <div ref={nodeRef} className={placement} style={style}>
            <div className="arrow" style={arrowStyle} />
            content body
        </div>
    );
}
const AnchoredComponent = anchored(options)(Component);
```

## setting anchor
The `anchored(Component)` HOC only renders if the `anchor` prop is a valid DOM node.
So please be sure to render it after the ref to anchor is set.

```js
class Example extends React.Component {
    static propTypes = {
        show: PropTypes.bool.isRequired,
    };

    anchorRef = React.createRef();

    render() {
        return (
            <div>
                <div className="anchor" ref={this.anchorRef} />
                {this.props.show && (
                    <AnchoredComponent anchor={this.anchorRef.current} />
                )}
            </div>
        );
    }
}
```

[1]: https://reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode