### PR TITLE
Reduce useless render calls in 'closable()' mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ N/A
 - [Core] Remove flow type annotation. (#180)
 - [Core] Adapt React Portal in `renderToLayer()` HOC mixin. (#188)
 - [Core] Refactor `anchored()` mixin to extrac its positioning logic, and adapt memoize approach to not rely on lifecycle methods. (#190)
+- [Core] Refacto `closable()` mixin to reduce useless render calls. (#192)
 - [Storybook] Upgrade to `@storybook/react@^4.0.0` to support Babel 7. (#187)
 - [Build] Upgrade to `enzyme@3.7.0`; fix tests for that. (#183)
 - [Build] Upgrade to Babel v7; switch to project-scope Babel config. (#185)

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -45,10 +45,11 @@ const closable = ({
             },
         };
 
-        state = {
-            closeDelayTimeout: null,
-            clickedInside: false,
-        };
+        constructor(props) {
+            super(props);
+            this.clickedInside = false;
+            this.closeDelayTimeout = null;
+        }
 
         componentDidMount() {
             document.addEventListener('keyup', this.handleDocumentKeyup);
@@ -60,7 +61,7 @@ const closable = ({
             document.removeEventListener('keyup', this.handleDocumentKeyup);
             document.removeEventListener('click', this.handleDocumentClickOrTouch);
             document.removeEventListener('touchend', this.handleDocumentClickOrTouch);
-            clearTimeout(this.state.closeDelayTimeout);
+            clearTimeout(this.closeDelayTimeout);
         }
 
         getOptions() {
@@ -82,11 +83,10 @@ const closable = ({
          * before trigger the `onClose` event.
          */
         delayedClose = (event) => {
-            const timeout = setTimeout(
+            this.closeDelayTimeout = setTimeout(
                 () => this.props.onClose(event),
                 TOUCH_CLOSE_DELAY,
             );
-            this.setState({ closeDelayTimeout: timeout });
         }
 
         captureInsideEvents = (node) => {
@@ -108,8 +108,9 @@ const closable = ({
         handleDocumentClickOrTouch = (event) => {
             const options = this.getOptions();
 
-            if (this.state.clickedInside) {
-                this.setState({ clickedInside: false });
+            if (this.clickedInside) {
+                // already scheduled close when clicked inside, skip here.
+                this.clickedInside = false;
                 return;
             }
 
@@ -120,9 +121,9 @@ const closable = ({
 
         handleInsideClickOrTouch = (event) => {
             const options = this.getOptions();
-            this.setState({ clickedInside: true });
 
             if (options.onClickInside) {
+                this.clickedInside = true;
                 this.delayedClose(event);
             }
         }


### PR DESCRIPTION
# Summary
`clickedInside` and `closeDelayTimeout` are only used inside internal event listeners to determine if an outside-click event can be ignored when an inside-click event has already scheduled a close callback.
    
They were previously put inside component states, therefore triggers useless `render()` calls as they change while they never affect render results.
    
Moving them to instance variables saves a few calls to `render()`.