### PR TITLE
Fix 'closable()' not blocking 'onClose()' callback on inside-clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Changed
+- [Core] Fix `closable()` mixin to or not to call `onClose()` correctly on inside-clicks. (#193)
 
 ## [2.0.0]
 ### Breaking

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -48,123 +48,6 @@ it('takes runtime options', () => {
     });
 });
 
-it('triggers onClose() call on Escape key up if turned on', () => {
-    const ClosableFoo = closable({ onEscape: true })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    // Dispatch 'Enter' keyboard event, nothing happened
-    let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    // Dispatch 'Escape' keyboard event, triggers onClose()
-    keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(1);
-});
-
-it('does not trigger onClose() call on Escape key up if turned off', () => {
-    const ClosableFoo = closable({ onEscape: false })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
-it('triggers onClose() call on click/touch outside after a delay if turned on', () => {
-    const ClosableFoo = closable({ onClickOutside: true })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(1);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchend');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(2);
-});
-
-it('does not trigger onClose() call on any click/touch outside after a delay if turned off', () => {
-    const ClosableFoo = closable({ onClickOutside: false })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    event = new CustomEvent('touchstart');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
-it('triggers onClose() call on click/touch inside a delay if turned on', () => {
-    const ClosableFoo = closable({ onClickInside: true })(Foo);
-    const handleClose = jest.fn();
-
-    const wrapper = mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(1);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchend');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(2);
-});
-
-it('triggers onClose() call on click/touch inside a delay if turned off', () => {
-    const ClosableFoo = closable({ onClickInside: false })(Foo);
-    const handleClose = jest.fn();
-
-    const wrapper = mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchstart');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
 it('tears down event listeners on unmount', () => {
     const ClosableFoo = closable({
         onEscape: true,
@@ -188,4 +71,143 @@ it('tears down event listeners on unmount', () => {
 
     jest.runAllTimers();
     expect(handleClose).not.toHaveBeenCalled();
+});
+
+describe.each`
+    onEscape | shouldBeCalled | desc
+    ${true}  | ${true}        | ${'should'}
+    ${false} | ${false}       | ${'should not'}
+`('$desc call onClose() for ESC keys when onEscape=$onEscape', ({ onEscape, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onEscape })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onClickInside: true, onClickOutside: true },
+        { onClickInside: true, onClickOutside: false },
+        { onClickInside: false, onClickOutside: true },
+        { onClickInside: false, onClickOutside: true },
+    ])('when %p', ({ onClickInside, onClickOutside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onClickInside, onClickOutside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        // Dispatch 'Enter' keyboard event, nothing happened
+        let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
+        document.dispatchEvent(keyEvent);
+        expect(handleClose).toHaveBeenCalledTimes(0);
+
+        // Dispatch 'Escape' keyboard event, triggers onClose()
+        keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
+        document.dispatchEvent(keyEvent);
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        wrapper.unmount();
+    });
+});
+
+
+describe.each`
+    onClickInside | shouldBeCalled | desc
+    ${true}       | ${true}        | ${'should'}
+    ${false}      | ${false}       | ${'should not'}
+`('$desc call onClose() for inside-clicks when onClickInside=$onClickInside', ({ onClickInside, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onClickInside })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onEscape: true, onClickOutside: true },
+        { onEscape: true, onClickOutside: false },
+        { onEscape: false, onClickOutside: true },
+        { onEscape: false, onClickOutside: true },
+    ])('when %p', ({ onEscape, onClickOutside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onEscape, onClickOutside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        let event = new MouseEvent('click', { bubbles: true });
+        wrapper.instance().nodeRef.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        // jsdom doesn't support constructing TouchEvent yet.
+        event = new CustomEvent('touchend', { bubbles: true });
+        wrapper.instance().nodeRef.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 2 : 0);
+
+        wrapper.unmount();
+    });
+});
+
+describe.each`
+    onClickOutside | shouldBeCalled | desc
+    ${true}        | ${true}        | ${'should'}
+    ${false}       | ${false}       | ${'should not'}
+`('$desc call onClose() when onClickOutside=$onClickOutside', ({ onClickOutside, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onClickOutside })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onEscape: true, onClickInside: true },
+        { onEscape: true, onClickInside: false },
+        { onEscape: false, onClickInside: true },
+        { onEscape: false, onClickInside: true },
+    ])('when %p', ({ onEscape, onClickInside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onEscape, onClickInside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        let event = new MouseEvent('click');
+        document.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        // jsdom doesn't support constructing TouchEvent yet.
+        event = new CustomEvent('touchend');
+        document.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 2 : 0);
+
+        wrapper.unmount();
+    });
 });

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -121,9 +121,9 @@ const closable = ({
 
         handleInsideClickOrTouch = (event) => {
             const options = this.getOptions();
+            this.clickedInside = true;
 
             if (options.onClickInside) {
-                this.clickedInside = true;
                 this.delayedClose(event);
             }
         }

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -16,6 +16,9 @@ const TOUCH_CLOSE_DELAY = 100;
  * Formerlly `escapable()`.
  *
  * @param {object} options
+ * @param {boolean=} options.onEscape
+ * @param {boolean=} options.onClickOutside
+ * @param {boolean=} options.onClickInside
  */
 const closable = ({
     onEscape = true,


### PR DESCRIPTION
# Purpose
Current event handlers inside `closable()` mixin (in `core/` package) fail to recognize a inside-click when it's configured not to close under this scenario. Therefore it fails to block `onClose()` callbacks.

This PR fixes the issue by correctly marking a inside-click inside handlers.

# Changes
- [Core] Fix `closable()` mixin to or not to call `onClose()` correctly on inside-clicks.
- [Core] Update tests for `closable()` so it covers all config combinations.

# What's changes in the test file
The `it('triggers')` and `it('does not trigger')` test cases (6 cases in total) are replaced with `describe.each` and `test.each` test blocks.

It might be hard to read these changes from comparing diff, so please consider read the new test cases directly from the file.