### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+N/A
+
+## [2.0.1]
 ### Changed
 - [Core] Fix `closable()` mixin to or not to call `onClose()` correctly on inside-clicks. (#193)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Changed
+- [Core] Fix `closable()` mixin to or not to call `onClose()` correctly on inside-clicks. (#193)
 
 ## [2.0.0]
 ### Breaking

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "commands": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-build",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "iCHEF web components library, built with React.",
   "private": true,
   "homepage": "https://ichef.github.io/gypcrete",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "iCHEF web components library, built with React.",
   "homepage": "https://ichef.github.io/gypcrete",
   "repository": "https://github.com/iCHEF/gypcrete/tree/master/packages/core",

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -48,123 +48,6 @@ it('takes runtime options', () => {
     });
 });
 
-it('triggers onClose() call on Escape key up if turned on', () => {
-    const ClosableFoo = closable({ onEscape: true })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    // Dispatch 'Enter' keyboard event, nothing happened
-    let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    // Dispatch 'Escape' keyboard event, triggers onClose()
-    keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(1);
-});
-
-it('does not trigger onClose() call on Escape key up if turned off', () => {
-    const ClosableFoo = closable({ onEscape: false })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
-    document.dispatchEvent(keyEvent);
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
-it('triggers onClose() call on click/touch outside after a delay if turned on', () => {
-    const ClosableFoo = closable({ onClickOutside: true })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(1);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchend');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(2);
-});
-
-it('does not trigger onClose() call on any click/touch outside after a delay if turned off', () => {
-    const ClosableFoo = closable({ onClickOutside: false })(Foo);
-    const handleClose = jest.fn();
-
-    mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    event = new CustomEvent('touchstart');
-    document.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
-it('triggers onClose() call on click/touch inside a delay if turned on', () => {
-    const ClosableFoo = closable({ onClickInside: true })(Foo);
-    const handleClose = jest.fn();
-
-    const wrapper = mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(1);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchend');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(2);
-});
-
-it('triggers onClose() call on click/touch inside a delay if turned off', () => {
-    const ClosableFoo = closable({ onClickInside: false })(Foo);
-    const handleClose = jest.fn();
-
-    const wrapper = mount(<ClosableFoo onClose={handleClose} />);
-    expect(handleClose).not.toHaveBeenCalled();
-
-    let event = new MouseEvent('click');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-
-    // jsdom doesn't support constructing TouchEvent yet.
-    event = new CustomEvent('touchstart');
-    wrapper.instance().nodeRef.dispatchEvent(event);
-
-    jest.runOnlyPendingTimers();
-    expect(handleClose).toHaveBeenCalledTimes(0);
-});
-
 it('tears down event listeners on unmount', () => {
     const ClosableFoo = closable({
         onEscape: true,
@@ -188,4 +71,143 @@ it('tears down event listeners on unmount', () => {
 
     jest.runAllTimers();
     expect(handleClose).not.toHaveBeenCalled();
+});
+
+describe.each`
+    onEscape | shouldBeCalled | desc
+    ${true}  | ${true}        | ${'should'}
+    ${false} | ${false}       | ${'should not'}
+`('$desc call onClose() for ESC keys when onEscape=$onEscape', ({ onEscape, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onEscape })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onClickInside: true, onClickOutside: true },
+        { onClickInside: true, onClickOutside: false },
+        { onClickInside: false, onClickOutside: true },
+        { onClickInside: false, onClickOutside: true },
+    ])('when %p', ({ onClickInside, onClickOutside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onClickInside, onClickOutside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        // Dispatch 'Enter' keyboard event, nothing happened
+        let keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Enter') });
+        document.dispatchEvent(keyEvent);
+        expect(handleClose).toHaveBeenCalledTimes(0);
+
+        // Dispatch 'Escape' keyboard event, triggers onClose()
+        keyEvent = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
+        document.dispatchEvent(keyEvent);
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        wrapper.unmount();
+    });
+});
+
+
+describe.each`
+    onClickInside | shouldBeCalled | desc
+    ${true}       | ${true}        | ${'should'}
+    ${false}      | ${false}       | ${'should not'}
+`('$desc call onClose() for inside-clicks when onClickInside=$onClickInside', ({ onClickInside, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onClickInside })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onEscape: true, onClickOutside: true },
+        { onEscape: true, onClickOutside: false },
+        { onEscape: false, onClickOutside: true },
+        { onEscape: false, onClickOutside: true },
+    ])('when %p', ({ onEscape, onClickOutside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onEscape, onClickOutside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        let event = new MouseEvent('click', { bubbles: true });
+        wrapper.instance().nodeRef.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        // jsdom doesn't support constructing TouchEvent yet.
+        event = new CustomEvent('touchend', { bubbles: true });
+        wrapper.instance().nodeRef.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 2 : 0);
+
+        wrapper.unmount();
+    });
+});
+
+describe.each`
+    onClickOutside | shouldBeCalled | desc
+    ${true}        | ${true}        | ${'should'}
+    ${false}       | ${false}       | ${'should not'}
+`('$desc call onClose() when onClickOutside=$onClickOutside', ({ onClickOutside, shouldBeCalled }) => {
+    const ClosableFoo = closable({ onClickOutside })(Foo);
+    const rootNode = document.createElement('div');
+
+    beforeAll(() => {
+        document.body.appendChild(rootNode);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(rootNode);
+    });
+
+    it.each([
+        { onEscape: true, onClickInside: true },
+        { onEscape: true, onClickInside: false },
+        { onEscape: false, onClickInside: true },
+        { onEscape: false, onClickInside: true },
+    ])('when %p', ({ onEscape, onClickInside }) => {
+        const handleClose = jest.fn();
+        const closableOptions = { onEscape, onClickInside };
+
+        const wrapper = mount(
+            <ClosableFoo closable={closableOptions} onClose={handleClose} />,
+            { attachTo: rootNode },
+        );
+
+        let event = new MouseEvent('click');
+        document.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
+
+        // jsdom doesn't support constructing TouchEvent yet.
+        event = new CustomEvent('touchend');
+        document.dispatchEvent(event);
+
+        jest.runOnlyPendingTimers();
+        expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 2 : 0);
+
+        wrapper.unmount();
+    });
 });

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -16,6 +16,9 @@ const TOUCH_CLOSE_DELAY = 100;
  * Formerlly `escapable()`.
  *
  * @param {object} options
+ * @param {boolean=} options.onEscape
+ * @param {boolean=} options.onClickOutside
+ * @param {boolean=} options.onClickInside
  */
 const closable = ({
     onEscape = true,
@@ -121,9 +124,9 @@ const closable = ({
 
         handleInsideClickOrTouch = (event) => {
             const options = this.getOptions();
+            this.clickedInside = true;
 
             if (options.onClickInside) {
-                this.clickedInside = true;
                 this.delayedClose(event);
             }
         }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-form",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Form components built on Gypcrete",
   "homepage": "https://ichef.github.io/gypcrete",
   "repository": "https://github.com/iCHEF/gypcrete/tree/master/packages/form",
@@ -34,7 +34,7 @@
     "react": "^16.6.0"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^2.0.0",
+    "@ichef/gypcrete": "^2.0.1",
     "classnames": "^2.2.5",
     "immutable": "^3.8.2",
     "keycode": "^2.1.9"

--- a/packages/imageeditor/package.json
+++ b/packages/imageeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-imageeditor",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Image cropper built with Gypcrete",
   "homepage": "https://ichef.github.io/gypcrete",
   "repository": "https://github.com/iCHEF/gypcrete/tree/master/packages/imageeditor",
@@ -34,7 +34,7 @@
     "react": "^16.6.0"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^2.0.0",
+    "@ichef/gypcrete": "^2.0.1",
     "classnames": "^2.2.5",
     "react-avatar-editor": "^11.0.2"
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ichef/gypcrete-storybook",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React Storybook for Gypcrete",
   "private": true,
   "repository": "iCHEF/gypcrete",
@@ -20,9 +20,9 @@
     "ghpages": "npm run clean && npm run build:storybook"
   },
   "dependencies": {
-    "@ichef/gypcrete": "^2.0.0",
-    "@ichef/gypcrete-form": "^2.0.0",
-    "@ichef/gypcrete-imageeditor": "^2.0.0",
+    "@ichef/gypcrete": "^2.0.1",
+    "@ichef/gypcrete-form": "^2.0.1",
+    "@ichef/gypcrete-imageeditor": "^2.0.1",
     "@storybook/addon-actions": "^4.0.0",
     "@storybook/addon-info": "^4.0.0",
     "@storybook/addon-options": "^4.0.0",


### PR DESCRIPTION
# Changes in this release 
- #193 Fix 'closable()' not blocking 'onClose()' callback on inside-clicks

# Changelog
### Changed
- [Core] Fix `closable()` mixin to or not to call `onClose()` correctly on inside-clicks. (#193)