### PR TITLE
Add centered prop into Modal to make it on top of screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-N/A
+### Changed
+- [Core] Add centered prop into Modal to make it on top of screen by default (#196)
 
 ## [2.0.1]
 ### Changed

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -100,11 +100,12 @@ class Modal extends PureComponent {
             bodyClassName,
             bodyPadding,
             onClose,
+            centered,
             // React props
             className,
             children,
         } = this.props;
-        const bemClass = BEM.root.modifier(size);
+        const bemClass = BEM.root.modifier('center', centered).modifier(size);
         const rootClassName = classNames(bemClass.toString(), className);
 
         return (
@@ -128,6 +129,7 @@ Modal.propTypes = {
     header: ModalContent.propTypes.header,
     bodyClassName: ModalContent.propTypes.bodyClassName,
     bodyPadding: ModalContent.propTypes.bodyPadding,
+    centered: PropTypes.bool,
 };
 
 Modal.defaultProps = {
@@ -136,6 +138,7 @@ Modal.defaultProps = {
     header: ModalContent.defaultProps.header,
     bodyClassName: ModalContent.defaultProps.bodyClassName,
     bodyPadding: ModalContent.defaultProps.bodyPadding,
+    centered: false,
 };
 
 export { Modal as PureModal };

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -38,6 +38,11 @@ describe('Pure <PureModal>', () => {
         testSizeProp('full');
     });
 
+    it('renders class names in response to the centered prop', () => {
+        const wrapper = shallow(<PureModal centered />);
+        expect(wrapper.hasClass(BEM.root.modifier('center').toString({ stripBlock: true }))).toBeTruthy();
+    });
+
     it('renders class names in response to the bodyPadding prop', () => {
         const wrapper = mount(<PureModal bodyPadding />);
         const paddingClass = BEM.body

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -12,14 +12,15 @@ $component: #{$prefix}-modal;
 // -------------------------------------
 .#{$prefix}-modal {
     display: flex;
-    align-items: center;
     justify-content: center;
+    align-items: top;
     position: fixed;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
     padding: 10px;
+    padding-top: 0;
     text-align: center;
     z-index: z("modal");
 }
@@ -39,7 +40,7 @@ $component: #{$prefix}-modal;
         display: flex;
         flex-direction: column;
         position: relative;
-        border-radius: $modal-border-radius;
+        border-radius: 0 0 $modal-border-radius $modal-border-radius;
         box-shadow: $modal-box-shadow;
         overflow: hidden;
         text-align: left;
@@ -86,6 +87,20 @@ $component: #{$prefix}-modal;
     &--full {
         .#{$prefix}-modal__container {
             max-width: $modal-width-full;
+        }
+    }
+}
+
+// -------------------------------------
+//   Modal Position
+// -------------------------------------
+.#{$prefix}-modal {
+    &--center {
+        align-items: center;
+        padding-top: 10px;
+
+        .#{$prefix}-modal__container {
+            border-radius: $modal-border-radius;
         }
     }
 }

--- a/packages/storybook/examples/core/Modal/index.js
+++ b/packages/storybook/examples/core/Modal/index.js
@@ -52,5 +52,10 @@ storiesOf('@ichef/gypcrete|Modal', module)
             </ClosableModalExample>
         ))
     )
+    .add('centered modal', withInfo()(() => (
+        <BasicModalExample bodyPadding centered>
+            Modal Content
+        </BasicModalExample>
+    )))
     // Props table
     .add('props', getPropTables([PureModal, Modal]));


### PR DESCRIPTION
# Purpose

Make `Modal` on top of screen rather than centering by default.

# Changes

* Add `centered` prop (which is boolean) on `Modal`, default to false. When it's false, the `gyp-modal` will be positioned on the top of screen, else it would be centered, where is the previous behavior.
* Update storybook for centered modal.

## UI change screenshot

Default modal after this PR (top-right and top-left border-radius set to 0):

![2019-02-12 6 03 26](https://user-images.githubusercontent.com/7620906/52627585-b417d400-2ef0-11e9-8dae-be86708493f0.png)

Modal with `center=true` (which is as same as previous modal):

![2019-02-12 6 03 41](https://user-images.githubusercontent.com/7620906/52627627-cabe2b00-2ef0-11e9-8863-13063eb400dd.png)


# Risk

None.

# TODOs

None.
