### PR TITLE
Shorten width for multiple layer modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - [Core] Add centered prop into Modal to make it on top of screen by default (#196)
+- [Core] Shorten width for multiple modal. (#197)
 
 ## [2.0.1]
 ### Changed

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -122,3 +122,38 @@ $component: #{$prefix}-modal;
         }
     }
 }
+
+// -------------------------------------
+//   width indent for multiple modal
+// -------------------------------------
+
+@for $i from 1 through $modal-indent-layer-max - 1 {
+    // ---------------------------------
+    // this will generate selector like `.#{$prefix}-base-layer ~ .#{$prefix}-base-layer .#{$prefix-modal}`
+    // which is long and ugly, but
+    // 1. it's more complicated and error prone to handle layer count in React side
+    // 2. it's rare to use multiple modal in our use cases.
+    // so we handle indent by css.
+    // ---------------------------------
+    #{repeat-str('.#{$prefix}-base-layer ~', $i)} .#{$prefix}-base-layer {
+        .#{$prefix}-modal {
+            &__container {
+                width: calc(#{$modal-width-full} - #{$i * 16}px);
+                max-width: $modal-width-base - $i * 16px;
+                height: $modal-height - $i * 8px;
+            }
+
+            &--large {
+                > .#{$prefix}-modal__container {
+                    max-width: $modal-width-large - $i * 16px;
+                }
+            }
+
+            &--small {
+                > .#{$prefix}-modal__container {
+                    max-width: $modal-width-small - $i * 16px;
+                }
+            }
+        }
+    }
+}

--- a/packages/core/src/styles/_mixins.scss
+++ b/packages/core/src/styles/_mixins.scss
@@ -1,6 +1,20 @@
 @import "./variables";
 
 // -------------------------------------
+//   String helpers
+// -------------------------------------
+
+@function repeat-str($str, $times) {
+    $ret: '';
+
+    @for $i from 1 through $times {
+        $ret: $ret + $str;
+    }
+
+    @return $ret;
+}
+
+// -------------------------------------
 //   Relative size calculator
 // -------------------------------------
 

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -108,6 +108,7 @@ $modal-height:           480px;
 $modal-max-height:       80vh;
 $modal-border-radius:    $popover-border-radius;
 $modal-box-shadow:       $poup-box-shadow;
+$modal-indent-layer-max: 7;
 
 $splitview-narrow-min-width: 240px;
 $splitview-narrow-max-width: 400px;

--- a/packages/storybook/examples/core/Modal/BasicModal.js
+++ b/packages/storybook/examples/core/Modal/BasicModal.js
@@ -49,5 +49,18 @@ class ClosableModalExample extends PureComponent {
     }
 }
 
-export { ClosableModalExample };
+const MulitpleClosableModalExample = (props) => {
+    const { depth, modalProp } = props;
+    if (depth === 0) {
+        return false;
+    }
+    return (
+        <ClosableModalExample {...modalProp}>
+            <div>{depth}</div>
+            <MulitpleClosableModalExample depth={depth - 1} />
+        </ClosableModalExample>
+    );
+};
+
+export { ClosableModalExample, MulitpleClosableModalExample };
 export default BasicModalExample;

--- a/packages/storybook/examples/core/Modal/index.js
+++ b/packages/storybook/examples/core/Modal/index.js
@@ -5,7 +5,7 @@ import { withInfo } from '@storybook/addon-info';
 import Modal, { PureModal } from '@ichef/gypcrete/src/Modal';
 import getPropTables from 'utils/getPropTables';
 
-import BasicModalExample, { ClosableModalExample } from './BasicModal';
+import BasicModalExample, { ClosableModalExample, MulitpleClosableModalExample } from './BasicModal';
 
 storiesOf('@ichef/gypcrete|Modal', module)
     .add(
@@ -57,5 +57,11 @@ storiesOf('@ichef/gypcrete|Modal', module)
             Modal Content
         </BasicModalExample>
     )))
+    .add(
+        'multiple layer modals',
+        withInfo('Indented with 8px from each side for each layer. When number of layer > 7 we won\'t indent it')(() => (
+            <MulitpleClosableModalExample depth={8} />
+        ))
+    )
     // Props table
     .add('props', getPropTables([PureModal, Modal]));


### PR DESCRIPTION
# Purpose

Add indent for multiple modal

# Changes

Change css width (and `max-width`) and height of modal that on top of others. Will reduce 8px for right, bottom and left side. When layer number > 7 we will not indent it.

UI Screenshot:

![2019-02-13 2 45 32](https://user-images.githubusercontent.com/7620906/52692438-e08a2980-2f9e-11e9-8798-e8d4cfd9f2eb.png)

You could see that the top of modal is also indented, which could be fixed by add margin-top. But after #196 is merged, there's no need to add the margin to adjust this. See following screenshot:

![2019-02-13 2 46 49](https://user-images.githubusercontent.com/7620906/52692581-3bbc1c00-2f9f-11e9-861b-c955652cc7b6.png)


# Risk

None.

# TODOs

- [ ] Merge #196 
