### PR TITLE
Adjust modal and column view padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Core] Add centered prop into Modal to make it on top of screen by default (#196)
 - [Core] Shorten width for multiple modal. (#197)
+- [Core] Adjust padding-bottom of modal and column view. (#198)
 
 ## [2.0.1]
 ### Changed

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -26,7 +26,6 @@ $component: #{$prefix}-column-view;
         flex: 1 1 100%;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
-        padding-bottom: rem($column-body-bottom-padding);
     }
 
     &__footer {

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -53,6 +53,7 @@ $component: #{$prefix}-modal;
         overflow: auto;
         display: flex;
         flex-direction: column;
+        padding-bottom: 24px;
 
         &--padding {
             padding: 24px;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -69,8 +69,6 @@ $search-input-border-color: $c-gray;
 $search-input-border-radius: 6px;
 $search-input-padding: 8px;
 
-$column-body-bottom-padding: 24px;
-
 $section-vertical-margin: 24px;
 $section-horizontal-padding: 16px;
 


### PR DESCRIPTION
# Purpose

Adjust modal / column view padding.

# Changes

- Add padding-bottom on modal, no matter `bodyPadding` prop is true or not.
- Remove padding-bottom on column view.

## UI screenshot

### Modal padding bottom:

#### Before

![2019-02-20 10 30 57](https://user-images.githubusercontent.com/7620906/53062098-a4088180-34fa-11e9-9bec-aa848e2f4a27.png)


#### After

![2019-02-20 10 24 50](https://user-images.githubusercontent.com/7620906/53061894-057c2080-34fa-11e9-95a1-acbfc6db18b2.png)

### ColumnView padding bottom removal:

### Before

![2019-02-20 10 28 23](https://user-images.githubusercontent.com/7620906/53062020-6572c700-34fa-11e9-821c-a12f996af720.png)

### After

![2019-02-20 10 28 34](https://user-images.githubusercontent.com/7620906/53062022-686db780-34fa-11e9-878e-76cb70d299b1.png)



# Risk

None.

# TODOs

None.

