### PR TITLE
Refactor <SearchInput>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Can be controlled now, via props `value`, `onChange` and `onReset`.
     - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchWhenInputBlur` be `true`
     - New prop `searchWhenInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
+    - New prop `blockDuplicateValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is same with last time searching.
+    - New prop `blockEmptyValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is empty.
     - Rename prop `input` to be `inputProps`.
 - [Core] update `<SearchInput>` styles.
 - [Core] Add centered prop into Modal to make it on top of screen by default (#196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Core] Change `<SearchInput>` behavior:
     - Can be controlled now, via props `value`, `onChange` and `onReset`.
-    - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchWhenInputBlur` be `true`
-    - New prop `searchWhenInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
+    - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchOnInputBlur` be `true`
+    - New prop `searchOnInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
     - New prop `blockDuplicateValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is same with last time searching.
     - New prop `blockEmptyValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is empty.
     - Rename prop `input` to be `inputProps`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Can be controlled now, via props `value`, `onChange` and `onReset`.
     - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchWhenInputBlur` be `true`
     - New prop `searchWhenInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
+    - Rename prop `input` to be `inputProps`.
 - [Core] update `<SearchInput>` styles.
 - [Core] Add centered prop into Modal to make it on top of screen by default (#196)
 - [Core] Shorten width for multiple modal. (#197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- [Core] Change `<SearchInput>` behavior:
+    - Can be controlled now, via props `value`, `onChange` and `onReset`.
+    - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchWhenInputBlur` be `true`
+    - New prop `searchWhenInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
+- [Core] update `<SearchInput>` styles.
 - [Core] Add centered prop into Modal to make it on top of screen by default (#196)
 - [Core] Shorten width for multiple modal. (#197)
 - [Core] Adjust padding-bottom of modal and column view. (#198)

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -18,25 +18,36 @@ export const BEM = {
     input: ROOT_BEM.element('input'),
     inputWrapper: ROOT_BEM.element('input-wrapper'),
     resetBtn: ROOT_BEM.element('reset-button'),
+    icon: ROOT_BEM.element('input-icon'),
 };
 
 // a React.Component ensures it can be re-rendered when context changes
 class SearchInput extends Component {
     static propTypes = {
         /**
-         * Use `input` to inject props to the underlying <input>
+         * Use `inputProps` to inject props to the underlying <input>
          */
-        input: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+        inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
         placeholder: PropTypes.string,
         defaultValue: PropTypes.string,
+        value: PropTypes.string,
+        onChange: PropTypes.func,
         onSearch: PropTypes.func,
+        onReset: PropTypes.func,
+        searchWhenInputChange: PropTypes.bool,
+        searchWhenInputBlur: PropTypes.bool,
     };
 
     static defaultProps = {
-        input: {},
+        inputProps: {},
         placeholder: 'Search',
+        value: undefined,
         defaultValue: '',
+        onChange: () => {},
         onSearch: () => {},
+        onReset: () => {},
+        searchWhenInputChange: false,
+        searchWhenInputBlur: false,
     };
 
     static contextTypes = {
@@ -44,63 +55,80 @@ class SearchInput extends Component {
     };
 
     state = {
-        inputValue: this.props.defaultValue,
-        lastNotifiedValue: null,
+        innerValue: this.props.defaultValue,
     };
 
-    notifySearch() {
-        const { inputValue, lastNotifiedValue } = this.state;
+    inputRef = React.createRef();
 
-        if (inputValue !== lastNotifiedValue) {
-            this.setState({ lastNotifiedValue: inputValue });
-            this.props.onSearch(inputValue);
+    isControlled = () => (typeof this.props.value) !== 'undefined';
+
+    handleInputChange = (event) => {
+        const { searchWhenInputChange, onChange, onSearch } = this.props;
+        if (this.isControlled()) {
+            onChange(event);
+        } else {
+            this.setState({ innerValue: event.target.value });
+        }
+
+        if (searchWhenInputChange) {
+            onSearch(event.target.value);
         }
     }
 
-    handleInputChange = (event) => {
-        this.setState({ inputValue: event.target.value });
+    handleResetButtonClick = () => {
+        this.inputRef.current.focus();
+
+        const { onReset, value } = this.props;
+        const { innerValue } = this.state;
+
+        if (this.isControlled()) {
+            onReset(value);
+        } else {
+            onReset(innerValue);
+            this.setState({ innerValue: '' });
+        }
     }
 
-    handleResetButtonClick = () => {
-        this.setState({ inputValue: '' }, () => this.notifySearch());
+    handleSearch = () => {
+        const { onSearch, value } = this.props;
+        const { innerValue } = this.state;
+
+        onSearch(this.isControlled() ? value : innerValue);
     }
 
     handleInputBlur = () => {
-        this.notifySearch();
+        const { searchWhenInputBlur } = this.props;
+        if (searchWhenInputBlur) {
+            // Prevent triggering `onSearch` when reset button clicked.
+            setTimeout(() => {
+                if (document.activeElement !== this.inputRef.current) {
+                    this.handleSearch();
+                }
+            }, 50);
+        }
     }
 
     handleInputKeyup = (event) => {
         if (event.key === 'Enter') {
-            this.notifySearch();
+            this.handleSearch();
         }
     }
 
-    renderResetButton() {
-        return (
-            <button
-                type="button"
-                className={`${BEM.resetBtn}`}
-                aria-label="Reset"
-                tabIndex="-1"
-                onClick={this.handleResetButtonClick}>
-                <Icon type="delete" color="gray" />
-            </button>
-        );
-    }
-
     render() {
-        const { input: inputProps, placeholder, className } = this.props;
-        const { inputValue } = this.state;
+        const { inputProps, value, placeholder, className } = this.props;
+        const { innerValue } = this.state;
 
-        const rootClassName = classNames(className, `${BEM.root}`);
+        const inputValue = this.isControlled() ? value : innerValue;
         const isLoading = this.context.status === STATUS_CODE.LOADING;
+        const rootClassName = classNames(className, `${BEM.root}`);
 
         return (
             <div className={rootClassName}>
                 <div className={BEM.inputWrapper}>
-                    <Icon type="search" />
+                    <Icon type="search" onClick={this.handleSearch} className={`${BEM.icon}`} />
 
                     <input
+                        {...inputProps}
                         type="text"
                         className={`${BEM.input}`}
                         placeholder={placeholder}
@@ -108,10 +136,22 @@ class SearchInput extends Component {
                         onChange={this.handleInputChange}
                         onBlur={this.handleInputBlur}
                         onKeyUp={this.handleInputKeyup}
-                        {...inputProps} />
+                        ref={this.inputRef}
+                    />
 
                     {isLoading && <Icon type="loading" spinning color="gray" />}
-                    {inputValue && !isLoading && this.renderResetButton()}
+
+                    {(inputValue && !isLoading) && (
+                        <button
+                            type="button"
+                            className={`${BEM.resetBtn}`}
+                            aria-label="Reset"
+                            tabIndex="-1"
+                            onClick={this.handleResetButtonClick}
+                        >
+                            <Icon type="delete" color="gray" className={`${BEM.icon}`} />
+                        </button>
+                    )}
                 </div>
             </div>
         );

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -36,6 +36,8 @@ class SearchInput extends Component {
         onReset: PropTypes.func,
         searchWhenInputChange: PropTypes.bool,
         searchWhenInputBlur: PropTypes.bool,
+        blockDuplicateValueSearch: PropTypes.bool,
+        blockEmptyValueSearch: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -48,6 +50,8 @@ class SearchInput extends Component {
         onReset: () => {},
         searchWhenInputChange: false,
         searchWhenInputBlur: false,
+        blockDuplicateValueSearch: false,
+        blockEmptyValueSearch: false,
     };
 
     static contextTypes = {
@@ -62,10 +66,12 @@ class SearchInput extends Component {
 
     isFoucs = false;
 
+    cachedValue = null;
+
     isControlled = () => (typeof this.props.value) !== 'undefined';
 
     handleInputChange = (event) => {
-        const { searchWhenInputChange, onChange, onSearch } = this.props;
+        const { searchWhenInputChange, blockEmptyValueSearch, onChange, onSearch } = this.props;
         if (this.isControlled()) {
             onChange(event);
         } else {
@@ -73,6 +79,9 @@ class SearchInput extends Component {
         }
 
         if (searchWhenInputChange) {
+            if (blockEmptyValueSearch && event.target.value === '') {
+                return;
+            }
             onSearch(event.target.value);
         }
     }
@@ -92,10 +101,22 @@ class SearchInput extends Component {
     }
 
     handleSearch = () => {
-        const { onSearch, value } = this.props;
+        const { onSearch, value, blockDuplicateValueSearch, blockEmptyValueSearch } = this.props;
         const { innerValue } = this.state;
+        const newValue = this.isControlled() ? value : innerValue;
 
-        onSearch(this.isControlled() ? value : innerValue);
+        if (blockDuplicateValueSearch && (newValue === this.cachedValue)) {
+            return;
+        }
+
+        this.cachedValue = newValue;
+
+
+        if (blockEmptyValueSearch && newValue === '') {
+            return;
+        }
+
+        onSearch(newValue);
     }
 
     handleInputFocus = () => {
@@ -132,7 +153,7 @@ class SearchInput extends Component {
         return (
             <div className={rootClassName}>
                 <div className={BEM.inputWrapper}>
-                    <Icon type="search" onClick={this.handleSearch} className={`${BEM.icon}`} />
+                    <Icon type="search" />
 
                     <input
                         {...inputProps}

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -34,8 +34,8 @@ class SearchInput extends Component {
         onChange: PropTypes.func,
         onSearch: PropTypes.func,
         onReset: PropTypes.func,
-        searchWhenInputChange: PropTypes.bool,
-        searchWhenInputBlur: PropTypes.bool,
+        searchOnInputChange: PropTypes.bool,
+        searchOnInputBlur: PropTypes.bool,
         blockDuplicateValueSearch: PropTypes.bool,
         blockEmptyValueSearch: PropTypes.bool,
     };
@@ -48,8 +48,8 @@ class SearchInput extends Component {
         onChange: () => {},
         onSearch: () => {},
         onReset: () => {},
-        searchWhenInputChange: false,
-        searchWhenInputBlur: false,
+        searchOnInputChange: false,
+        searchOnInputBlur: false,
         blockDuplicateValueSearch: false,
         blockEmptyValueSearch: false,
     };
@@ -64,25 +64,29 @@ class SearchInput extends Component {
 
     inputRef = React.createRef();
 
-    isFoucs = false;
+    isFoucsed = false;
 
     cachedValue = null;
 
     isControlled = () => (typeof this.props.value) !== 'undefined';
 
     handleInputChange = (event) => {
-        const { searchWhenInputChange, blockEmptyValueSearch, onChange, onSearch } = this.props;
+        const { searchOnInputChange, blockEmptyValueSearch, onChange, onSearch } = this.props;
+        const newValue = event.target.value;
+
         if (this.isControlled()) {
             onChange(event);
         } else {
-            this.setState({ innerValue: event.target.value });
+            this.setState({ innerValue: newValue });
         }
 
-        if (searchWhenInputChange) {
-            if (blockEmptyValueSearch && event.target.value === '') {
+        if (searchOnInputChange) {
+            if (blockEmptyValueSearch && newValue === '') {
                 return;
             }
-            onSearch(event.target.value);
+
+            this.cachedValue = newValue;
+            onSearch(newValue);
         }
     }
 
@@ -120,16 +124,16 @@ class SearchInput extends Component {
     }
 
     handleInputFocus = () => {
-        this.isFoucs = true;
+        this.isFoucsed = true;
     }
 
     handleInputBlur = () => {
-        this.isFoucs = false;
-        const { searchWhenInputBlur } = this.props;
-        if (searchWhenInputBlur) {
+        this.isFoucsed = false;
+        const { searchOnInputBlur } = this.props;
+        if (searchOnInputBlur) {
             // Prevent triggering `onSearch` when reset button clicked.
             setTimeout(() => {
-                if (!this.isFoucs) {
+                if (!this.isFoucsed) {
                     this.handleSearch();
                 }
             }, 30);

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -64,8 +64,6 @@ class SearchInput extends Component {
 
     inputRef = React.createRef();
 
-    isFoucsed = false;
-
     cachedValue = null;
 
     isControlled = () => (typeof this.props.value) !== 'undefined';
@@ -92,7 +90,6 @@ class SearchInput extends Component {
 
     handleResetButtonClick = () => {
         this.inputRef.current.focus();
-
         const { onReset, value } = this.props;
         const { innerValue } = this.state;
 
@@ -123,20 +120,15 @@ class SearchInput extends Component {
         onSearch(newValue);
     }
 
-    handleInputFocus = () => {
-        this.isFoucsed = true;
-    }
-
     handleInputBlur = () => {
-        this.isFoucsed = false;
         const { searchOnInputBlur } = this.props;
         if (searchOnInputBlur) {
             // Prevent triggering `onSearch` when reset button clicked.
             setTimeout(() => {
-                if (!this.isFoucsed) {
+                if (document.activeElement !== this.inputRef.current) {
                     this.handleSearch();
                 }
-            }, 30);
+            }, 100);
         }
     }
 
@@ -166,7 +158,6 @@ class SearchInput extends Component {
                         placeholder={placeholder}
                         value={inputValue}
                         onChange={this.handleInputChange}
-                        onFocus={this.handleInputFocus}
                         onBlur={this.handleInputBlur}
                         onKeyUp={this.handleInputKeyup}
                         ref={this.inputRef}

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -60,6 +60,8 @@ class SearchInput extends Component {
 
     inputRef = React.createRef();
 
+    isFoucs = false;
+
     isControlled = () => (typeof this.props.value) !== 'undefined';
 
     handleInputChange = (event) => {
@@ -96,15 +98,20 @@ class SearchInput extends Component {
         onSearch(this.isControlled() ? value : innerValue);
     }
 
+    handleInputFocus = () => {
+        this.isFoucs = true;
+    }
+
     handleInputBlur = () => {
+        this.isFoucs = false;
         const { searchWhenInputBlur } = this.props;
         if (searchWhenInputBlur) {
             // Prevent triggering `onSearch` when reset button clicked.
             setTimeout(() => {
-                if (document.activeElement !== this.inputRef.current) {
+                if (!this.isFoucs) {
                     this.handleSearch();
                 }
-            }, 50);
+            }, 30);
         }
     }
 
@@ -134,6 +141,7 @@ class SearchInput extends Component {
                         placeholder={placeholder}
                         value={inputValue}
                         onChange={this.handleInputChange}
+                        onFocus={this.handleInputFocus}
                         onBlur={this.handleInputBlur}
                         onKeyUp={this.handleInputKeyup}
                         ref={this.inputRef}

--- a/packages/core/src/__tests__/SearchInput.test.js
+++ b/packages/core/src/__tests__/SearchInput.test.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import SearchInput, { PureSearchInput, BEM } from '../SearchInput';
 
-const INPUT_VALUE = 'inputValue';
+const INNER_VALUE = 'innerValue';
+const ON_BLUR_SEARCH_DELAY = 30;
+
+const delay = ms => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+});
 
 describe('rowComp(SearchInput)', () => {
     it('renders without crashing', () => {
@@ -16,26 +21,14 @@ describe('rowComp(SearchInput)', () => {
 });
 
 describe('Pure <SearchInput>', () => {
+    // UI rendering
     it('renders with an <input type=text> inside', () => {
         const wrapper = shallow(<PureSearchInput />);
 
         expect(wrapper.find('input').matchesElement(<input type="text" />)).toBeTruthy();
     });
 
-    it('caches input value in internal state', () => {
-        const wrapper = shallow(<PureSearchInput />);
-        const inputWrapper = wrapper.find('input');
-
-        expect(wrapper.state(INPUT_VALUE)).toBe('');
-
-        inputWrapper.simulate('change', { target: { value: 'foo' } });
-        expect(wrapper.state(INPUT_VALUE)).toBe('foo');
-
-        inputWrapper.simulate('change', { target: { value: 'bar' } });
-        expect(wrapper.state(INPUT_VALUE)).toBe('bar');
-    });
-
-    it('renders reset button when input isnt empty', () => {
+    it('renders reset button when input is not empty', () => {
         const wrapper = shallow(<PureSearchInput />);
         const inputWrapper = wrapper.find('input');
 
@@ -43,73 +36,6 @@ describe('Pure <SearchInput>', () => {
 
         inputWrapper.simulate('change', { target: { value: 'foo' } });
         expect(wrapper.find(`.${BEM.resetBtn}`)).toHaveLength(1);
-    });
-
-    it('takes defaultValue for input', () => {
-        const wrapper = shallow(<PureSearchInput defaultValue="foo" />);
-
-        expect(wrapper.state(INPUT_VALUE)).toBe('foo');
-    });
-
-    it('clears input value and calls onSearch() on reset button click', () => {
-        const handleSearch = jest.fn(() => PureSearchInput.defaultProps.onSearch());
-        const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
-        const inputWrapper = wrapper.find('input');
-
-        inputWrapper.simulate('change', { target: { value: 'foo' } });
-        expect(wrapper.state(INPUT_VALUE)).toBe('foo');
-
-        wrapper.find(`.${BEM.resetBtn}`).simulate('click');
-        expect(wrapper.state(INPUT_VALUE)).toBe('');
-        expect(handleSearch).toHaveBeenLastCalledWith('');
-    });
-
-    it('calls onSearch() prop with input value on Enter', () => {
-        const handleSearch = jest.fn();
-        const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
-        const inputWrapper = wrapper.find('input');
-
-        inputWrapper.simulate('change', { target: { value: 'foo' } });
-
-        // Other keys should not trigger onSearch()
-        inputWrapper.simulate('keyup', { key: 'Escape' });
-        expect(handleSearch).not.toHaveBeenCalled();
-
-        // Only Enter key should trigger
-        inputWrapper.simulate('keyup', { key: 'Enter' });
-        expect(handleSearch).toHaveBeenLastCalledWith('foo');
-
-        wrapper.find(`.${BEM.resetBtn}`).simulate('click');
-        inputWrapper.simulate('keyup', { key: 'Enter' });
-        expect(handleSearch).toHaveBeenLastCalledWith('');
-    });
-
-    it('calls onSearch() prop with input value on Blur', () => {
-        const handleSearch = jest.fn();
-        const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
-        const inputWrapper = wrapper.find('input');
-
-        inputWrapper.simulate('change', { target: { value: 'foo' } });
-        inputWrapper.simulate('blur');
-        expect(handleSearch).toHaveBeenLastCalledWith('foo');
-
-        wrapper.find(`.${BEM.resetBtn}`).simulate('click');
-        inputWrapper.simulate('blur');
-        expect(handleSearch).toHaveBeenLastCalledWith('');
-    });
-
-    it('only calls onSearch() if input value different from cached value', () => {
-        const handleSearch = jest.fn();
-        const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
-        const inputWrapper = wrapper.find('input');
-
-        inputWrapper.simulate('change', { target: { value: 'foo' } });
-        inputWrapper.simulate('keyup', { key: 'Enter' });
-        expect(handleSearch).toHaveBeenCalledWith('foo');
-        expect(handleSearch).toHaveBeenCalledTimes(1);
-
-        inputWrapper.simulate('blur');
-        expect(handleSearch).toHaveBeenCalledTimes(1);
     });
 
     it('renders loading icon when status is loading', () => {
@@ -133,4 +59,173 @@ describe('Pure <SearchInput>', () => {
         expect(wrapper.find(`.${BEM.resetBtn}`)).toHaveLength(0);
         expect(wrapper.find('Icon').find({ type: 'loading' })).toHaveLength(1);
     });
+
+    // states & behaviors
+    it('[uncontrolled] caches input value in internal state', () => {
+        const wrapper = shallow(<PureSearchInput />);
+        const inputWrapper = wrapper.find('input');
+
+        expect(wrapper.state(INNER_VALUE)).toBe('');
+
+        inputWrapper.simulate('change', { target: { value: 'foo' } });
+        expect(wrapper.state(INNER_VALUE)).toBe('foo');
+
+        inputWrapper.simulate('change', { target: { value: 'bar' } });
+        expect(wrapper.state(INNER_VALUE)).toBe('bar');
+    });
+
+    it('[uncontrolled] takes defaultValue for input', () => {
+        const wrapper = shallow(<PureSearchInput defaultValue="foo" />);
+
+        expect(wrapper.state(INNER_VALUE)).toBe('foo');
+    });
+
+    it('[uncontrolled] clears input value and calls "onReset" on reset button click', () => {
+        const handleReset = jest.fn();
+        const wrapper = mount(<PureSearchInput onReset={handleReset} />);
+        const inputWrapper = wrapper.find('input');
+
+        inputWrapper.simulate('change', { target: { value: 'foo' } });
+        expect(wrapper.state(INNER_VALUE)).toBe('foo');
+
+        wrapper.find(`.${BEM.resetBtn}`).simulate('click');
+        expect(handleReset).toHaveBeenLastCalledWith('foo');
+        expect(wrapper.state(INNER_VALUE)).toBe('');
+    });
+
+    it('[controlled] test input value will be controlled by "value" prop', () => {
+        const wrapper = shallow(<PureSearchInput value="foo" />);
+        const inputWrapper = wrapper.find('input');
+        expect(inputWrapper.prop('value')).toEqual('foo');
+    });
+
+    it('[controlled] calls "onChange" with new value on input change', () => {
+        const handleChange = jest.fn();
+        const wrapper = shallow(<PureSearchInput value="foo" onChange={handleChange} />);
+        const inputWrapper = wrapper.find('input');
+
+        inputWrapper.simulate('change', { target: { value: 'bar' } });
+        expect(handleChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                target: { value: 'bar' },
+            }),
+        );
+    });
+
+    it('[controlled] calls "onReset" with last value on reset button click', () => {
+        const handleReset = jest.fn();
+        const wrapper = mount(<PureSearchInput value="foo" onReset={handleReset} />);
+        wrapper.find(`.${BEM.resetBtn}`).simulate('click');
+        expect(handleReset).toHaveBeenLastCalledWith('foo');
+    });
+
+    it('calls "onSearch" prop with input value on "Enter" keyup', () => {
+        const handleSearch = jest.fn();
+        const wrapper = shallow(<PureSearchInput onSearch={handleSearch} />);
+        const inputWrapper = wrapper.find('input');
+
+        inputWrapper.simulate('change', { target: { value: 'foo' } });
+
+        // Other keys should not trigger onSearch()
+        inputWrapper.simulate('keyup', { key: 'Escape' });
+        expect(handleSearch).not.toHaveBeenCalled();
+
+        // Only Enter key should trigger
+        inputWrapper.simulate('keyup', { key: 'Enter' });
+        expect(handleSearch).toHaveBeenLastCalledWith('foo');
+    });
+
+    it.each([[true, 1], [false, 0]])(
+        'when "searchOnInputBlur" prop to be "%s", call "onSearch" prop on input blur or not',
+        async (searchOnInputBlur, handleSerachCalledTimes) => {
+            const handleSearch = jest.fn();
+            const wrapper = shallow(
+                <PureSearchInput
+                    onSearch={handleSearch}
+                    searchOnInputBlur={searchOnInputBlur}
+                />
+            );
+
+            const inputWrapper = wrapper.find('input');
+            inputWrapper.simulate('change', { target: { value: 'foo' } });
+            inputWrapper.simulate('blur');
+            await delay(ON_BLUR_SEARCH_DELAY);
+
+            expect(handleSearch).toHaveBeenCalledTimes(handleSerachCalledTimes);
+            if (searchOnInputBlur) {
+                expect(handleSearch).toHaveBeenLastCalledWith('foo');
+            }
+        }
+    );
+
+    it.each([[true, 1], [false, 0]])(
+        'when "searchOnInputChange" prop to be "%s", call "onSearch" prop on input change or not',
+        (searchOnInputChange, handleSerachCalledTimes) => {
+            const handleSearch = jest.fn();
+            const wrapper = shallow(
+                <PureSearchInput
+                    onSearch={handleSearch}
+                    searchOnInputChange={searchOnInputChange}
+                />
+            );
+
+            const inputWrapper = wrapper.find('input');
+            inputWrapper.simulate('change', { target: { value: 'foo' } });
+
+            expect(handleSearch).toHaveBeenCalledTimes(handleSerachCalledTimes);
+            if (searchOnInputChange) {
+                expect(handleSearch).toHaveBeenLastCalledWith('foo');
+            }
+        }
+    );
+
+    it.each([[true, 1], [false, 2]])(
+        'when "blockDuplicateValueSearch" prop to be "%s", block duplicate value searching or not',
+        (blockDuplicateValueSearch, handleSerachCalledTimes) => {
+            const handleSearch = jest.fn();
+            const wrapper = shallow(
+                <PureSearchInput
+                    onSearch={handleSearch}
+                    blockDuplicateValueSearch={blockDuplicateValueSearch}
+                />
+            );
+
+            const inputWrapper = wrapper.find('input');
+            inputWrapper.simulate('change', { target: { value: 'foo' } });
+            inputWrapper.simulate('keyup', { key: 'Enter' });
+
+            expect(handleSearch).toHaveBeenCalledWith('foo');
+            expect(handleSearch).toHaveBeenCalledTimes(1);
+
+            // try to trigger onSearch again without value changing
+            inputWrapper.simulate('keyup', { key: 'Enter' });
+            expect(handleSearch).toHaveBeenCalledTimes(handleSerachCalledTimes);
+            if (!blockDuplicateValueSearch) {
+                expect(handleSearch).toHaveBeenLastCalledWith('foo');
+            }
+        }
+    );
+
+    it.each([[true, 0], [false, 1]])(
+        'when "blockEmptyValueSearch" prop to be "%s", block empty value searching or not',
+        (blockEmptyValueSearch, handleSerachCalledTimes) => {
+            const handleSearch = jest.fn();
+            const wrapper = shallow(
+                <PureSearchInput
+                    defaultValue="foo"
+                    onSearch={handleSearch}
+                    blockEmptyValueSearch={blockEmptyValueSearch}
+                />
+            );
+
+            const inputWrapper = wrapper.find('input');
+            inputWrapper.simulate('change', { target: { value: '' } });
+            inputWrapper.simulate('keyup', { key: 'Enter' });
+
+            expect(handleSearch).toHaveBeenCalledTimes(handleSerachCalledTimes);
+            if (!blockEmptyValueSearch) {
+                expect(handleSearch).toHaveBeenLastCalledWith('');
+            }
+        }
+    );
 });

--- a/packages/core/src/styles/SearchInput.scss
+++ b/packages/core/src/styles/SearchInput.scss
@@ -1,8 +1,6 @@
 @import "./mixins";
 
 .#{$prefix}-search-input {
-    padding: rem($search-input-padding - 1px);
-
     // ----------------------
     //  SearchInput Elements
     // ----------------------

--- a/packages/core/src/styles/SearchInput.scss
+++ b/packages/core/src/styles/SearchInput.scss
@@ -32,4 +32,8 @@
         display: flex;
         align-content: flex-start;
     }
+
+    &__input-icon {
+        cursor: pointer;
+    }
 }

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -65,8 +65,8 @@ $status-icon-corner-size: 16px;
 $button-border-radius: 4px;
 
 $search-input-background-color: $c-white;
-$search-input-border-color: $c-gray;
-$search-input-border-radius: 6px;
+$search-input-border-color: $c-black-30;
+$search-input-border-radius: 20px;
 $search-input-padding: 8px;
 
 $section-vertical-margin: 24px;

--- a/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
+++ b/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
@@ -34,7 +34,7 @@ export default class BasicSearchInputExample extends React.Component {
                         onChange={this.handleControlledInputChange}
                         onSearch={action('onSearch')}
                         onReset={this.handleControlledInputReset}
-                        searchOnInputChange
+                        // searchOnInputChange
                         searchOnInputBlur
                         blockDuplicateValueSearch
                         blockEmptyValueSearch

--- a/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
+++ b/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
@@ -3,22 +3,50 @@ import React from 'react';
 import SearchInput from '@ichef/gypcrete/src/SearchInput';
 import DebugBox from 'utils/DebugBox';
 
-function BasicSearchInputExample() {
-    return (
-        <div>
-            <DebugBox>
-                <SearchInput />
-            </DebugBox>
+export default class BasicSearchInputExample extends React.Component {
+    state = {
+        controlledInputValue: '',
+    }
 
-            <DebugBox>
-                <SearchInput defaultValue="Monkey King" />
-            </DebugBox>
+    handleSearch = (keyword) => {
+        console.log('handleSearch', keyword);
+    }
 
-            <DebugBox>
-                <SearchInput defaultValue="Monkey King" status="loading" />
-            </DebugBox>
-        </div>
-    );
+    handleControlledInputChange = (e) => {
+        this.setState({
+            controlledInputValue: e.target.value,
+        });
+    }
+
+    handleControlledInputReset = () => {
+        this.setState({
+            controlledInputValue: '',
+        });
+    }
+
+    render() {
+        const { controlledInputValue } = this.state;
+        return (
+            <div>
+                <DebugBox>
+                    <SearchInput
+                        value={controlledInputValue}
+                        onChange={this.handleControlledInputChange}
+                        onSearch={this.handleSearch}
+                        onReset={this.handleControlledInputReset}
+                        searchWhenInputChange
+                        searchWhenInputBlur
+                    />
+                </DebugBox>
+
+                <DebugBox>
+                    <SearchInput defaultValue="Monkey King" />
+                </DebugBox>
+
+                <DebugBox>
+                    <SearchInput defaultValue="Monkey King" status="loading" />
+                </DebugBox>
+            </div>
+        );
+    }
 }
-
-export default BasicSearchInputExample;

--- a/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
+++ b/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
@@ -1,24 +1,24 @@
 import React from 'react';
 
 import SearchInput from '@ichef/gypcrete/src/SearchInput';
+import { action } from '@storybook/addon-actions';
 import DebugBox from 'utils/DebugBox';
+
 
 export default class BasicSearchInputExample extends React.Component {
     state = {
         controlledInputValue: '',
     }
 
-    handleSearch = (keyword) => {
-        console.log('handleSearch', keyword);
-    }
-
     handleControlledInputChange = (e) => {
+        action('onChange')(e.target.value);
         this.setState({
             controlledInputValue: e.target.value,
         });
     }
 
     handleControlledInputReset = () => {
+        action('onReset')();
         this.setState({
             controlledInputValue: '',
         });
@@ -32,10 +32,10 @@ export default class BasicSearchInputExample extends React.Component {
                     <SearchInput
                         value={controlledInputValue}
                         onChange={this.handleControlledInputChange}
-                        onSearch={this.handleSearch}
+                        onSearch={action('onSearch')}
                         onReset={this.handleControlledInputReset}
-                        searchWhenInputChange
-                        searchWhenInputBlur
+                        searchOnInputChange
+                        searchOnInputBlur
                         blockDuplicateValueSearch
                         blockEmptyValueSearch
                     />

--- a/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
+++ b/packages/storybook/examples/core/SearchInput/BasicSearchInput.js
@@ -36,6 +36,8 @@ export default class BasicSearchInputExample extends React.Component {
                         onReset={this.handleControlledInputReset}
                         searchWhenInputChange
                         searchWhenInputBlur
+                        blockDuplicateValueSearch
+                        blockEmptyValueSearch
                     />
                 </DebugBox>
 

--- a/packages/storybook/examples/core/SearchInput/index.js
+++ b/packages/storybook/examples/core/SearchInput/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
@@ -7,6 +8,6 @@ import getPropTables from 'utils/getPropTables';
 import BasicSearchInputExample from './BasicSearchInput';
 
 storiesOf('@ichef/gypcrete|SearchInput', module)
-    .add('basic usage', withInfo()(BasicSearchInputExample))
+    .add('basic usage', withInfo()(() => <BasicSearchInputExample />))
     // Props table
     .add('props', getPropTables([PureSearchInput, SearchInput]));


### PR DESCRIPTION
# Purpose
Refactor `<SearchInput>` and make it can be controlled.

# Changes
- [Core] Change `<SearchInput>` behavior:
    - Can be controlled now, via props `value`, `onChange` and `onReset`.
    - No longer trigger `onSearch` when input blur by default. You can enable this behavior by setting prop `searchOnInputBlur` be `true`
    - New prop `searchOnInputChange`, when it is `true`, `onSearch` will be triggered every time after input changed. The default value is `false`.
    - New prop `blockDuplicateValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is same with last time searching.
    - New prop `blockEmptyValueSearch`, when it is `true`, `onSearch` will not be triggerd if input value is empty.
    - Rename prop `input` to be `inputProps`.
- [Core] update `<SearchInput>` styles.
![image](https://user-images.githubusercontent.com/6021943/53159756-75c19980-3601-11e9-9644-d5c3f778a837.png)

# Risk
- Breaking changes: 
    - No longer trigger `onSearch` when input blur by default, It's a breaking change.
    - Rename prop `input` to be `inputProps`.
# TODOs
None.
