### PR TITLE
Refactor 'closable()' mixin to use React's own events mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Core] Refactored `closable()` mixin to detect inside/outside clicks via React SyntheticEvent mechanism instead of listening native events from DOM.
 
 ## [2.1.0]
 ### Changed

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -31,7 +31,7 @@ function Popover({
     arrowStyle,
     nodeRef,
     // from closable()
-    handleInsideClick,
+    onInsideClick,
     // React props
     className,
     children,
@@ -41,7 +41,7 @@ function Popover({
     const rootClassName = classNames(bemClass.toString(), className);
 
     const handleWrapperClick = (event) => {
-        handleInsideClick(event);
+        onInsideClick(event);
         onClick(event);
     };
 
@@ -67,7 +67,7 @@ Popover.propTypes = {
     placement: anchoredPropTypes.placement,
     arrowStyle: anchoredPropTypes.arrowStyle,
     nodeRef: anchoredPropTypes.nodeRef,
-    handleInsideClick: PropTypes.func.isRequired,
+    onInsideClick: PropTypes.func.isRequired,
 };
 
 Popover.defaultProps = {

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import ListSpacingContext from './contexts/listSpacing';
@@ -24,10 +25,13 @@ export const BEM = {
 };
 
 function Popover({
+    onClick,
     // from anchored()
     placement,
     arrowStyle,
     nodeRef,
+    // from closable()
+    handleInsideClick,
     // React props
     className,
     children,
@@ -36,9 +40,19 @@ function Popover({
     const bemClass = BEM.root.modifier(placement);
     const rootClassName = classNames(bemClass.toString(), className);
 
+    const handleWrapperClick = (event) => {
+        handleInsideClick(event);
+        onClick(event);
+    };
+
     return (
         <ListSpacingContext.Provider value={false}>
-            <div className={rootClassName} ref={nodeRef} {...otherProps}>
+            <div
+                role="presentation"
+                className={rootClassName}
+                ref={nodeRef}
+                onClick={handleWrapperClick}
+                {...otherProps}>
                 <span className={BEM.arrow} style={arrowStyle} />
                 <div className={BEM.container}>
                     {children}
@@ -49,12 +63,15 @@ function Popover({
 }
 
 Popover.propTypes = {
+    onClick: PropTypes.func,
     placement: anchoredPropTypes.placement,
     arrowStyle: anchoredPropTypes.arrowStyle,
     nodeRef: anchoredPropTypes.nodeRef,
+    handleInsideClick: PropTypes.func.isRequired,
 };
 
 Popover.defaultProps = {
+    onClick: () => {},
     placement: ANCHORED_PLACEMENT.BOTTOM,
     arrowStyle: {},
     nodeRef: undefined,

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -38,6 +38,7 @@ it('has default configs', () => {
         onEscape: true,
         onClickOutside: false,
         onClickInside: false,
+        stopEventPropagation: true,
     });
 });
 
@@ -48,6 +49,7 @@ it('takes runtime options', () => {
             closable={{
                 onEscape: false,
                 onClickOutside: true,
+                stopEventPropagation: false,
             }} />
     );
 
@@ -55,6 +57,7 @@ it('takes runtime options', () => {
         onEscape: false,
         onClickOutside: true,
         onClickInside: false,
+        stopEventPropagation: false,
     });
 });
 
@@ -71,6 +74,28 @@ it('tears down event listeners on unmount', () => {
     const event = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
     document.dispatchEvent(event);
     expect(handleClose).not.toHaveBeenCalled();
+});
+
+it('intercepts event propagation if instructed', () => {
+    const ClosableFoo = closable()(Foo);
+    const handleClick = jest.fn();
+
+    let wrapper = mount(
+        <div role="presentation" onClick={handleClick}>
+            <ClosableFoo closable={{ stopEventPropagation: true }} />
+        </div>
+    );
+    wrapper.find('div#foo').simulate('click');
+    expect(handleClick).not.toHaveBeenCalled();
+
+    wrapper = mount(
+        <div role="presentation" onClick={handleClick}>
+            <ClosableFoo closable={{ stopEventPropagation: false }} />
+        </div>
+    );
+
+    wrapper.find('div#foo').simulate('click');
+    expect(handleClick).toHaveBeenCalled();
 });
 
 describe.each`

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -9,16 +9,16 @@ import closable, {
     COMPONENT_NAME as OUTER_LAYER_NAME,
 } from '../closable';
 
-const Foo = ({ handleInsideClick }) => (
+const Foo = ({ onInsideClick }) => (
     <div
         id="foo"
         role="presentation"
-        onClick={handleInsideClick}>
+        onClick={onInsideClick}>
         Foo
     </div>
 );
 Foo.propTypes = {
-    handleInsideClick: PropTypes.func.isRequired,
+    onInsideClick: PropTypes.func.isRequired,
 };
 
 it('renders without crashing', () => {

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -119,7 +119,6 @@ const closable = ({
             const {
                 onClose,
                 closable: runtimeOptions,
-                className,
                 ...otherProps
             } = this.props;
 
@@ -128,12 +127,9 @@ const closable = ({
                     role="presentation"
                     className={ROOT_BEM.toString()}
                     onClick={this.handleOuterLayerClick}>
-                    <div
-                        className={className}
-                        role="presentation"
-                        onClick={this.handleInsideClick}>
-                        <WrappedComponent {...otherProps} />
-                    </div>
+                    <WrappedComponent
+                        handleInsideClick={this.handleInsideClick}
+                        {...otherProps} />
                 </div>
             );
         }

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -128,7 +128,7 @@ const closable = ({
                     className={ROOT_BEM.toString()}
                     onClick={this.handleOuterLayerClick}>
                     <WrappedComponent
-                        handleInsideClick={this.handleInsideClick}
+                        onInsideClick={this.handleInsideClick}
                         {...otherProps} />
                 </div>
             );

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -98,6 +98,12 @@ const closable = ({
         handleOuterLayerClick = (event) => {
             const options = this.getOptions();
 
+            if (this.clickedInside) {
+                // ignoring click events bubbling up from inside
+                this.clickedInside = false;
+                return;
+            }
+
             if (options.onClickOutside) {
                 this.props.onClose(event);
             }
@@ -108,7 +114,7 @@ const closable = ({
          */
         handleInsideClick = (event) => {
             const options = this.getOptions();
-            event.stopPropagation();
+            this.clickedInside = true;
 
             if (options.onClickInside) {
                 this.props.onClose(event);

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -2,17 +2,16 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import keycode from 'keycode';
 
+import icBEM from '../utils/icBEM';
+import prefixClass from '../utils/prefixClass';
 import getComponentName from '../utils/getComponentName';
 
-const ESCAPE = 'Escape';
+import '../styles/Closable.scss';
 
-const outerLayerStyle = {
-    position: 'fixed',
-    width: '100vw',
-    height: '100vh',
-    top: 0,
-    left: 0,
-};
+export const COMPONENT_NAME = prefixClass('closable');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+
+const ESCAPE = 'Escape';
 
 /**
  * `closable()` HOC mixin
@@ -127,8 +126,8 @@ const closable = ({
             return (
                 <div
                     role="presentation"
-                    onClick={this.handleOuterLayerClick}
-                    style={outerLayerStyle}>
+                    className={ROOT_BEM.toString()}
+                    onClick={this.handleOuterLayerClick}>
                     <div
                         className={className}
                         role="presentation"

--- a/packages/core/src/styles/Closable.scss
+++ b/packages/core/src/styles/Closable.scss
@@ -1,0 +1,9 @@
+@import "./mixins";
+
+.#{$prefix}-closable {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    top: 0;
+    left: 0;
+}


### PR DESCRIPTION
# Purpose
The `closable()` mixin used to bind event listeners directly to both its wrapper `<div>` and `document` to detect inside/outside clicks.

This PR achieve this by using React's own SyntheticEvent mechanism instead, so it's easier for user to choose to intercept default behaviors using simple event callbacks within React.

This PR also removed `touchend` listeners from `closable()` mixin as browsers on touch devices eventually simulates `click` events for you.

# Changes
- [Core] Refactored `closable()` mixin to listen to `click` events using React SyntheticEvent.
- [Core] `<Popover>` is updated to report inside clicks to `closable()` mixin.

# Risk
Both `closable()` and `<Popover>` are affected by this PR.
But their public props remain the same, so I believe it doesn't have to ring the breaking alarm.
