### PR TITLE
[Storybook] Fix yarn start not work due to adding minimizer in dev env #trivial

### DIFF
--- a/packages/storybook/.storybook/webpack.config.js
+++ b/packages/storybook/.storybook/webpack.config.js
@@ -18,14 +18,16 @@ module.exports = (baseConfig, env, defaultConfig) => {
     // Following config customize the TerserPlugin to remove the mangling.
     // Note that this will make the total bundle size increase a little (2.9MB => 3.2MB).
     // Consider storybook is for developer this should be fine.
-    // eslint-disable-next-line no-param-reassign
-    defaultConfig.optimization.minimizer = [new TerserPlugin({
-        cache: true,
-        parallel: true,
-        terserOptions: {
-            mangle: false,
-        }
-    })];
+    if (defaultConfig.optimization && env === 'PRODUCTION') {
+        // eslint-disable-next-line no-param-reassign
+        defaultConfig.optimization.minimizer = [new TerserPlugin({
+            cache: true,
+            parallel: true,
+            terserOptions: {
+                mangle: false,
+            }
+        })];
+    }
 
     // Ref: Storybook webpack dev config https://git.io/fpJ6h
     const babelLoaderRule = defaultConfig.module.rules[0];


### PR DESCRIPTION
# Purpose

Fix `yarn start` not work due to adding custom minimizer in #204 . Thank @zhusee2 for discovering this issue.

Before review it's recommended to run `yarn start` to see if it works in dev and also `yarn build:storybook` in `packages/storybook` to see if the build keeps component name in production.

# Changes

- Check `defaultConfig.optimization` exists and production env before adding custom minimizer in storybook webpack config.

# Risk

None.

# TODOs

None.
