### PR TITLE
Add `removePaddingBottom` on `<Modal>` to remove padding bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [Core] Refactored `closable()` mixin to detect inside/outside clicks via React SyntheticEvent mechanism instead of listening native events from DOM.
+- [Core] Add `removePaddingBotom` on `<Modal>` to remove padding bottom.
 - [Storybook] Fix mangled component name in storybook build. (#203)
 - [Storybook] Update examples for core `<TextInput>` and form `<TextInputRow>`. (#203)
 

--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -55,12 +55,14 @@ export const ModalContent = ({
     header,
     bodyClassName,
     bodyPadding,
+    removePaddingBottom,
     // React props
     children,
 }) => {
     const cNames = classNames(
         bodyClassName,
-        `${BEM.body.modifier('padding', bodyPadding)}`
+        `${BEM.body.modifier('padding', bodyPadding)}`,
+        `${BEM.body.modifier('remove-padding-bottom', removePaddingBottom)}`,
     );
     return (
         <div className={BEM.container}>
@@ -77,12 +79,14 @@ ModalContent.propTypes = {
     header: PropTypes.node,
     bodyClassName: PropTypes.string,
     bodyPadding: PropTypes.bool,
+    removePaddingBottom: PropTypes.bool,
 };
 
 ModalContent.defaultProps = {
     header: undefined,
     bodyClassName: '',
     bodyPadding: false,
+    removePaddingBottom: false,
 };
 
 class Modal extends PureComponent {
@@ -99,6 +103,7 @@ class Modal extends PureComponent {
             header,
             bodyClassName,
             bodyPadding,
+            removePaddingBottom,
             onClose,
             centered,
             // React props
@@ -115,6 +120,7 @@ class Modal extends PureComponent {
                     header={header}
                     bodyClassName={bodyClassName}
                     bodyPadding={bodyPadding}
+                    removePaddingBottom={removePaddingBottom}
                     onClose={onClose}>
                     {children}
                 </ModalContent>
@@ -129,6 +135,7 @@ Modal.propTypes = {
     header: ModalContent.propTypes.header,
     bodyClassName: ModalContent.propTypes.bodyClassName,
     bodyPadding: ModalContent.propTypes.bodyPadding,
+    removePaddingBottom: ModalContent.propTypes.removePaddingBottom,
     centered: PropTypes.bool,
 };
 
@@ -138,6 +145,7 @@ Modal.defaultProps = {
     header: ModalContent.defaultProps.header,
     bodyClassName: ModalContent.defaultProps.bodyClassName,
     bodyPadding: ModalContent.defaultProps.bodyPadding,
+    removePaddingBottom: ModalContent.defaultProps.removePaddingBottom,
     centered: false,
 };
 

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -51,6 +51,14 @@ describe('Pure <PureModal>', () => {
         expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
     });
 
+    it('renders class names in response to the removePaddingBottom prop', () => {
+        const wrapper = mount(<PureModal removePaddingBottom />);
+        const paddingClass = BEM.body
+            .modifier('remove-padding-bottom', true)
+            .toString({ stripBlock: true });
+        expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
+    });
+
     it('renders content of the modal', () => {
         const content = <div>TestContent</div>;
         const wrapper = shallow(<PureModal>{content}</PureModal>);
@@ -112,6 +120,22 @@ describe('Pure <ModalContent>', () => {
         const wrapper = shallow(<ModalContent />);
         const paddingClass = BEM.body
             .modifier('padding', true)
+            .toString({ stripBlock: true });
+        expect(wrapper.find(`.${paddingClass}`).exists()).toBeFalsy();
+    });
+
+    it('should render remove-padding-bottom class if the prop removePaddingBottom is true', () => {
+        const wrapper = shallow(<ModalContent removePaddingBottom />);
+        const paddingClass = BEM.body
+            .modifier('remove-padding-bottom', true)
+            .toString({ stripBlock: true });
+        expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
+    });
+
+    it('should not render remove-padding-bottom class if the prop removePaddingBottom is null', () => {
+        const wrapper = shallow(<ModalContent />);
+        const paddingClass = BEM.body
+            .modifier('remove-padding-bottom', true)
             .toString({ stripBlock: true });
         expect(wrapper.find(`.${paddingClass}`).exists()).toBeFalsy();
     });

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -58,6 +58,10 @@ $component: #{$prefix}-modal;
         &--padding {
             padding: 24px;
         }
+
+        &--remove-padding-bottom {
+            padding-bottom: 0 !important;
+        }
     } // Header
     &__header {
         flex: 0 0 auto;

--- a/packages/storybook/examples/core/Modal/index.js
+++ b/packages/storybook/examples/core/Modal/index.js
@@ -7,6 +7,18 @@ import getPropTables from 'utils/getPropTables';
 
 import BasicModalExample, { ClosableModalExample, MulitpleClosableModalExample } from './BasicModal';
 
+function BigContentBlock() {
+    return (
+        <div
+            style={{
+                height: 500,
+                border: '3px solid red',
+            }}>
+            Big Content Block
+        </div>
+    );
+}
+
 storiesOf('@ichef/gypcrete|Modal', module)
     .add(
         'basic usage',
@@ -37,6 +49,30 @@ storiesOf('@ichef/gypcrete|Modal', module)
         withInfo()(() => (
             <BasicModalExample bodyPadding size="full" header="Full Modal">
                 Modal Content
+            </BasicModalExample>
+        ))
+    )
+    .add(
+        'modal with default padding',
+        withInfo()(() => (
+            <BasicModalExample header="Modal">
+                <BigContentBlock />
+            </BasicModalExample>
+        ))
+    )
+    .add(
+        'modal without padding bottom',
+        withInfo()(() => (
+            <BasicModalExample removePaddingBottom header="Modal">
+                <BigContentBlock />
+            </BasicModalExample>
+        ))
+    )
+    .add(
+        'modal with bodyPadding and removePaddingBottom',
+        withInfo()(() => (
+            <BasicModalExample bodyPadding removePaddingBottom header="Modal">
+                <BigContentBlock />
             </BasicModalExample>
         ))
     )


### PR DESCRIPTION
# Purpose

Add `removePaddingBottom` on `<Modal>` (in implementation, `<ModalContent>`) to remove padding-bottom of modal content block. Defaults to false. Also update examples in storybook.

# Changes

- Add `removePaddingBotom` on `<Modal>` to remove padding bottom.

# UI screenshot

- Modal with `removePaddingBottom=true`

Remove the default padding bottom.

![螢幕快照 2019-04-24 下午1 58 24](https://user-images.githubusercontent.com/7620906/56635711-1b909380-6699-11e9-9b76-1a83c88d95e7.png)

- Modal with both `removePaddingBottom` and `bodyPadding`

The top (not shown in screenshot), left, right of modal will filled with bottom, but bottom padding is still 0.

![螢幕快照 2019-04-24 下午1 58 35](https://user-images.githubusercontent.com/7620906/56635722-23503800-6699-11e9-99a4-3b6ab4ef49e3.png)


# Risk

None

# TODOs

None
