### PR TITLE
Add <Avatar> to display an image along with the text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Add `verticalOrder` prop to `<Text>` so you can swap the position of `basic` and `aside`. Also applied to `rowComp()` mixin.
 - [Core] Rewrite `<TextInput>` to match latest design, offering single-line `<input>`, multi-line `<textarea>` and supports custom rendering via render prop.
 - [Form] `<TextInputRow>` now renders the new `<TextInput>` and forwards almost every prop to it, **without** a ref to its inner input.
+- [Core] Add `<Avatar>` to display an image.
 
 ### Changed
 - [Core] Refactored `closable()` mixin to detect inside/outside clicks via React SyntheticEvent mechanism instead of listening native events from DOM.
 - [Storybook] Fix mangled component name in storybook build. (#203)
 - [Storybook] Update examples for core `<TextInput>` and form `<TextInputRow>`. (#203)
+- [Core] Change `rowComp()` to allow the appearance of `<Avatar>` alongside the text. (#208)
+- [Core] Change `<Checkbox>` to display `<Avatar>`. (#208)
+- [Form] Change `<SelectRow>` and `<Checkbox>` to display `<Avatar>`. (#208)
+- [Storybook] Add examples for `<Avatar>` and the list components with `<Avatar>`s. (#208)
 
 ## [2.1.0]
 ### Changed

--- a/packages/core/src/Avatar.js
+++ b/packages/core/src/Avatar.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './styles/Avatar.scss';
+
+import icBEM from './utils/icBEM';
+import prefixClass from './utils/prefixClass';
+
+const COMPONENT_NAME = prefixClass('avatar');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+
+function Avatar({ className, src, alt }) {
+    const rootClass = classNames(`${ROOT_BEM.toString()}`, className);
+
+    return (
+        <div className={rootClass}>
+            <img alt={alt} src={src} />
+        </div>
+    );
+}
+
+Avatar.propTypes = {
+    src: PropTypes.bool.isRequired,
+    alt: PropTypes.bool.isRequired,
+};
+
+export default Avatar;

--- a/packages/core/src/Avatar.js
+++ b/packages/core/src/Avatar.js
@@ -10,19 +10,37 @@ import prefixClass from './utils/prefixClass';
 const COMPONENT_NAME = prefixClass('avatar');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 
-function Avatar({ className, src, alt }) {
-    const rootClass = classNames(`${ROOT_BEM.toString()}`, className);
+const SQUARE = 'square';
+const ROUNDED = 'rounded';
+const CIRCLE = 'circle';
+export const AVATAR_TYPE = { SQUARE, ROUNDED, CIRCLE };
+
+function Avatar({
+    className,
+    src,
+    alt,
+    type,
+    ...otherProps
+}) {
+    const bemClass = ROOT_BEM.modifier(type);
+
+    const rootClassName = classNames(className, `${bemClass}`);
 
     return (
-        <div className={rootClass}>
+        <div className={rootClassName} {...otherProps}>
             <img alt={alt} src={src} />
         </div>
     );
 }
 
 Avatar.propTypes = {
-    src: PropTypes.bool.isRequired,
-    alt: PropTypes.bool.isRequired,
+    src: PropTypes.string.isRequired,
+    alt: PropTypes.string.isRequired,
+    type: PropTypes.oneOf(Object.values(AVATAR_TYPE)),
+};
+
+Avatar.defaultProps = {
+    type: SQUARE,
 };
 
 export default Avatar;

--- a/packages/core/src/__tests__/Avatar.test.js
+++ b/packages/core/src/__tests__/Avatar.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import Avatar from '../Avatar';
+
+describe('<Avatar>', () => {
+    it('renders without crashing', () => {
+        const div = document.createElement('div');
+        const element = <Avatar src="LINK" alt="ALT" />;
+
+        ReactDOM.render(element, div);
+    });
+
+    it('handles type modifiers', () => {
+        let wrapper = shallow(<Avatar src="LINK" alt="ALT" />);
+        expect(wrapper.hasClass('gyp-avatar--square')).toBeTruthy();
+
+        wrapper = shallow(<Avatar type="square" src="LINK" alt="ALT" />);
+        expect(wrapper.hasClass('gyp-avatar--square')).toBeTruthy();
+
+        wrapper = shallow(<Avatar type="rounded" src="LINK" alt="ALT" />);
+        expect(wrapper.hasClass('gyp-avatar--rounded')).toBeTruthy();
+
+        wrapper = shallow(<Avatar type="circle" src="LINK" alt="ALT" />);
+        expect(wrapper.hasClass('gyp-avatar--circle')).toBeTruthy();
+    });
+});

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,6 +6,7 @@ import EditableBasicRow from './EditableBasicRow';
 import Icon from './Icon';
 import StatusIcon from './StatusIcon';
 import Tag from './Tag';
+import Avatar from './Avatar';
 import Text from './Text';
 import EditableText from './EditableText';
 import Tooltip from './Tooltip';
@@ -49,6 +50,7 @@ export {
     StatusIcon,
     Tag,
     Text,
+    Avatar,
     EditableText,
     Tooltip,
     SwitchIcon,

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -133,6 +133,7 @@ const rowComp = ({
                 PropTypes.element
             ]),
             basic: PropTypes.node,
+            avatar: PropTypes.node,
             aside: PropTypes.node,
             tag: PropTypes.node,
             bold: PropTypes.bool,
@@ -155,6 +156,7 @@ const rowComp = ({
             verticalOrder: defaultVerticalOrder,
             icon: null,
             basic: null,
+            avatar: null,
             aside: null,
             tag: null,
             bold: false,
@@ -237,7 +239,7 @@ const rowComp = ({
         render() {
             const {
                 minified,
-
+                avatar,
                 align,
                 verticalOrder,
                 icon,
@@ -276,6 +278,7 @@ const rowComp = ({
 
             return (
                 <WrappedComponent className={wrapperClassName} {...otherProps}>
+                    {avatar}
                     {children || this.renderContent()}
                 </WrappedComponent>
             );

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -7,7 +7,7 @@
     width: 2.2rem;
     height: 2.2rem;
     overflow: hidden;
-    margin: .2rem .25rem;
+    margin: .2rem .45rem .2rem .25rem;
     background-color: $c-gray;
 
     // ----------------------

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -29,7 +29,7 @@
     // ----------------------
     //  Inner image
     // ----------------------
-    > img {
+    & > img {
         width: 100%;
         height: 100%;
         text-align: center;

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -9,6 +9,7 @@
     overflow: hidden;
     margin: .2rem .45rem .2rem .25rem;
     background-color: $c-gray;
+    flex-shrink: 0;
 
     // ----------------------
     //  <Avatar> variants

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -1,0 +1,25 @@
+@import "./mixins";
+
+// -------------------------------------
+//   Component Block
+// -------------------------------------
+.#{$prefix}-avatar {
+    width: 2.2rem;
+    height: 2.2rem;
+    overflow: hidden;
+    margin: .2rem .25rem;
+
+    > img {
+        width: 100%;
+        height: 100%;
+        text-align: center;
+        object-fit: cover;
+    }
+}
+
+// Override the default left margin on <ListRow>
+.#{$prefix}-list-row > .#{$prefix}-avatar {
+    &:first-child {
+        margin-left: 0;
+    }
+}

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -8,7 +8,26 @@
     height: 2.2rem;
     overflow: hidden;
     margin: .2rem .25rem;
+    background-color: $c-gray;
 
+    // ----------------------
+    //  <Avatar> variants
+    // ----------------------
+    &--square {
+        border-radius: 0;
+    }
+
+    &--rounded {
+        border-radius: 6px;
+    }
+
+    &--circle {
+        border-radius: 50%;
+    }
+
+    // ----------------------
+    //  Inner image
+    // ----------------------
     > img {
         width: 100%;
         height: 100%;

--- a/packages/core/src/styles/Avatar.scss
+++ b/packages/core/src/styles/Avatar.scss
@@ -42,3 +42,9 @@
         margin-left: 0;
     }
 }
+
+.#{$prefix}-list-row__body > .#{$prefix}-avatar {
+    &:first-child {
+        margin-left: 0;
+    }
+}

--- a/packages/form/src/SelectOption.js
+++ b/packages/form/src/SelectOption.js
@@ -17,6 +17,7 @@ export const TYPE_SYMBOL = Symbol('SelectOption');
 function SelectOption({
     label,
     value,
+    avatar,
     readOnly,
     checked,
     onChange,
@@ -32,6 +33,7 @@ function SelectOption({
                 checked={checked}
                 disabled={readOnly}
                 basic={label}
+                avatar={avatar}
                 onChange={handleCheckboxChange}
                 {...checkboxProps} />
         </ListRow>

--- a/packages/form/src/SelectOption.js
+++ b/packages/form/src/SelectOption.js
@@ -43,6 +43,7 @@ function SelectOption({
 SelectOption.propTypes = {
     label: PropTypes.node.isRequired,
     value: valueType,
+    avatar: PropTypes.node,
     readOnly: PropTypes.bool,
     // Set by <SelectList>
     checked: PropTypes.bool,
@@ -51,6 +52,7 @@ SelectOption.propTypes = {
 
 SelectOption.defaultProps = {
     value: null,
+    avatar: null,
     readOnly: false,
     checked: false,
     onChange: () => {},

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -50,6 +50,22 @@ function getValueLabelMap(fromChildren = []) {
     return resultMap;
 }
 
+/**
+ * Generate a value-avatar map from all `<SelectOption>`s.
+ *
+ * @param {array} fromOptions
+ * @return {Map}
+ */
+function getValueAvatarMap(fromChildren = []) {
+    const resultMap = new Map();
+    const options = parseSelectOptions(fromChildren);
+
+    options.forEach(
+        option => resultMap.set(option.value, option.avatar)
+    );
+    return resultMap;
+}
+
 class SelectRow extends PureComponent {
     static propTypes = {
         label: PropTypes.node.isRequired,
@@ -85,12 +101,14 @@ class SelectRow extends PureComponent {
     state = {
         popoverOpen: false,
         valueLabelMap: getValueLabelMap(this.props.children),
+        avatarLabelMap: getValueAvatarMap(this.props.children),
         cachedValues: this.props.values || this.props.defaultValues,
     };
 
     componentWillReceiveProps(nextProps) {
         this.setState({
             valueLabelMap: getValueLabelMap(nextProps.children),
+            avatarLabelMap: getValueAvatarMap(nextProps.children),
         });
 
         if (this.getIsControlled(nextProps)) {
@@ -156,6 +174,17 @@ class SelectRow extends PureComponent {
             .join(asideSeparator);
     }
 
+    renderAvatar() {
+        const { cachedValues, avatarLabelMap } = this.state;
+
+        if (cachedValues.length === 0) {
+            return null;
+        }
+
+        return cachedValues
+            .map(value => avatarLabelMap.get(value));
+    }
+
     render() {
         const {
             label,
@@ -189,6 +218,7 @@ class SelectRow extends PureComponent {
 
         return (
             <ListRow className={wrapperClassName} {...rowProps}>
+                {this.renderAvatar()}
                 <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
                         bold={!ineditable}

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -40,28 +40,18 @@ const CLOSABLE_CONFIG = {
  * @param {array} fromOptions
  * @return {Map}
  */
-function getValueLabelMap(fromChildren = []) {
+function getValueToLabelAvatarMap(fromChildren = []) {
     const resultMap = new Map();
     const options = parseSelectOptions(fromChildren);
 
     options.forEach(
-        option => resultMap.set(option.value, option.label)
-    );
-    return resultMap;
-}
-
-/**
- * Generate a value-avatar map from all `<SelectOption>`s.
- *
- * @param {array} fromOptions
- * @return {Map}
- */
-function getValueAvatarMap(fromChildren = []) {
-    const resultMap = new Map();
-    const options = parseSelectOptions(fromChildren);
-
-    options.forEach(
-        option => resultMap.set(option.value, option.avatar)
+        (option) => {
+            const { label, avatar } = option;
+            resultMap.set(option.value, {
+                label,
+                avatar,
+            });
+        }
     );
     return resultMap;
 }
@@ -100,15 +90,13 @@ class SelectRow extends PureComponent {
 
     state = {
         popoverOpen: false,
-        valueLabelMap: getValueLabelMap(this.props.children),
-        avatarLabelMap: getValueAvatarMap(this.props.children),
+        valueLabelMap: getValueToLabelAvatarMap(this.props.children),
         cachedValues: this.props.values || this.props.defaultValues,
     };
 
     componentWillReceiveProps(nextProps) {
         this.setState({
-            valueLabelMap: getValueLabelMap(nextProps.children),
-            avatarLabelMap: getValueAvatarMap(nextProps.children),
+            valueLabelMap: getValueToLabelAvatarMap(nextProps.children),
         });
 
         if (this.getIsControlled(nextProps)) {
@@ -170,19 +158,25 @@ class SelectRow extends PureComponent {
         }
 
         return cachedValues
-            .map(value => valueLabelMap.get(value))
+            .map((value) => {
+                const valueMap = valueLabelMap.get(value) || {};
+                return valueMap.label;
+            })
             .join(asideSeparator);
     }
 
     renderAvatar() {
-        const { cachedValues, avatarLabelMap } = this.state;
+        const { cachedValues, valueLabelMap } = this.state;
 
         if (cachedValues.length === 0) {
             return null;
         }
 
         return cachedValues
-            .map(value => avatarLabelMap.get(value));
+            .map((value) => {
+                const valueMap = valueLabelMap.get(value) || {};
+                return valueMap.avatar;
+            });
     }
 
     render() {

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
 import {
+    Avatar,
     Button,
     Popover,
     Text,
@@ -180,6 +181,23 @@ describe('Pure <SelectRow>: Data', () => {
 
         wrapper.setProps({ values: ['foo', 'bar', 'meh'] });
         expect(wrapper.find(Text).prop('aside')).toBe('All');
+    });
+
+    it('renders the avatar', () => {
+        const fooAvatar = <Avatar alt="foo" src="FOO_SRC" />;
+        const barAvatar = <Avatar alt="bar" src="BAR_SRC" />;
+
+        const wrapper = shallow(
+            <PureSelectRow label="Select" values={['foo']}>
+                <Option label="foo" value="foo" avatar={fooAvatar} />
+                <Option label="bar" value="bar" avatar={barAvatar} />
+            </PureSelectRow>
+        );
+
+        expect(wrapper.find(Avatar).prop('src')).toEqual('FOO_SRC');
+
+        wrapper.setProps({ values: ['bar'] });
+        expect(wrapper.find(Avatar).prop('src')).toEqual('BAR_SRC');
     });
 
     it('can customize aside labels', () => {

--- a/packages/storybook/examples/core/Avatar/BasicAvatar.js
+++ b/packages/storybook/examples/core/Avatar/BasicAvatar.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import Avatar from '@ichef/gypcrete/src/Avatar';
+
+function BasicAvatarExample() {
+    return (
+        <>
+            <Avatar src="https://api.adorable.io/avatars/285/design@ichef.tw" />
+            <Avatar src="https://api.adorable.io/avatars/285/rd@ichef.tw" />
+            <Avatar src="https://api.adorable.io/avatars/285/marketing@ichef.tw" />
+        </>
+    );
+}
+
+export default BasicAvatarExample;

--- a/packages/storybook/examples/core/Avatar/BasicAvatar.js
+++ b/packages/storybook/examples/core/Avatar/BasicAvatar.js
@@ -1,14 +1,16 @@
 import React from 'react';
 
 import Avatar from '@ichef/gypcrete/src/Avatar';
+import FlexRow from 'utils/FlexRow';
 
 function BasicAvatarExample() {
     return (
-        <>
-            <Avatar src="https://api.adorable.io/avatars/285/design@ichef.tw" />
-            <Avatar src="https://api.adorable.io/avatars/285/rd@ichef.tw" />
-            <Avatar src="https://api.adorable.io/avatars/285/marketing@ichef.tw" />
-        </>
+        <FlexRow>
+            <Avatar alt="Avatar of Design" src="https://api.adorable.io/avatars/285/design@ichef.tw" />
+            <Avatar type="square" alt="Avatar of RD" src="https://api.adorable.io/avatars/285/rd@ichef.tw" />
+            <Avatar type="rounded" alt="Avatar of Marketing" src="https://api.adorable.io/avatars/285/marketing@ichef.tw" />
+            <Avatar type="circle" alt="Avatar of Customer Service" src="https://api.adorable.io/avatars/285/customer_service@ichef.tw" />
+        </FlexRow>
     );
 }
 

--- a/packages/storybook/examples/core/Avatar/index.js
+++ b/packages/storybook/examples/core/Avatar/index.js
@@ -1,0 +1,12 @@
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Avatar from '@ichef/gypcrete/src/Avatar';
+import getPropTables from 'utils/getPropTables';
+
+import BasicAvatar from './BasicAvatar';
+
+storiesOf('@ichef/gypcrete|Avatar', module)
+    .add('basic usage', withInfo()(BasicAvatar))
+    // Props table
+    .add('props', getPropTables([Avatar]));

--- a/packages/storybook/examples/core/Checkbox/BasicCheckbox.js
+++ b/packages/storybook/examples/core/Checkbox/BasicCheckbox.js
@@ -1,9 +1,12 @@
 import React from 'react';
 
 import Checkbox from '@ichef/gypcrete/src/Checkbox';
+import Avatar from '@ichef/gypcrete/src/Avatar';
 import DebugBox from 'utils/DebugBox';
 
 function BasicCheckboxExample() {
+    const rdAvatar = <Avatar type="square" alt="Avatar of RD" src="https://api.adorable.io/avatars/285/rd@ichef.tw" />;
+
     return (
         <div>
             <DebugBox>
@@ -16,6 +19,13 @@ function BasicCheckboxExample() {
                     basic="Join pilot program"
                     aside="Secondary helps"
                     tag="New" />
+            </DebugBox>
+
+            <DebugBox>
+                <Checkbox
+                    defaultChecked
+                    basic="Join pilot program"
+                    avatar={rdAvatar} />
             </DebugBox>
 
             <DebugBox>

--- a/packages/storybook/examples/core/Checkbox/BasicCheckbox.js
+++ b/packages/storybook/examples/core/Checkbox/BasicCheckbox.js
@@ -5,7 +5,7 @@ import Avatar from '@ichef/gypcrete/src/Avatar';
 import DebugBox from 'utils/DebugBox';
 
 function BasicCheckboxExample() {
-    const rdAvatar = <Avatar type="square" alt="Avatar of RD" src="https://api.adorable.io/avatars/285/rd@ichef.tw" />;
+    const rdAvatar = <Avatar type="square" alt="John Doe" src="https://api.adorable.io/avatars/285/johndoe@example.com" />;
 
     return (
         <div>

--- a/packages/storybook/examples/core/List/NormalList.js
+++ b/packages/storybook/examples/core/List/NormalList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Avatar from '@ichef/gypcrete/src/Avatar';
 import List from '@ichef/gypcrete/src/List';
 import ListRow from '@ichef/gypcrete/src/ListRow';
 
@@ -13,6 +14,11 @@ function NormalList() {
     return (
         <DebugBox width="30rem">
             <List variant="normal" title="List title" desc="Help text here">
+                <ListRow>
+                    <Avatar alt="iCHEF" src="https://api.adorable.io/avatars/285/hello@ichef.tw" />
+                    <TextLabel basic="Hello World" />
+                </ListRow>
+
                 <ListRow>
                     <TextLabel icon="tickets" basic="Hello World" />
                 </ListRow>

--- a/packages/storybook/examples/form/SelectRow/WithAvatar.js
+++ b/packages/storybook/examples/form/SelectRow/WithAvatar.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import Avatar from '@ichef/gypcrete/src/Avatar';
+import List from '@ichef/gypcrete/src/List';
+import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
+import Option from '@ichef/gypcrete-form/src/SelectOption';
+
+function WithAvatar() {
+    const rdAvatar = <Avatar type="square" alt="Avatar of RD" src="https://api.adorable.io/avatars/285/rd@ichef.tw" />;
+    const designAvatar = <Avatar alt="Avatar of Design" src="https://api.adorable.io/avatars/285/design@ichef.tw" />;
+
+    return (
+        <List title="Switch rows">
+            <SelectRow
+                desc="Default is off"
+                defaultValues={['RD']}
+                onChange={action('change')}>
+                <Option label="RD" value="RD" avatar={rdAvatar} />
+                <Option label="Design" value="Design" avatar={designAvatar} />
+            </SelectRow>
+        </List>
+    );
+}
+
+export default WithAvatar;

--- a/packages/storybook/examples/form/SelectRow/WithAvatar.js
+++ b/packages/storybook/examples/form/SelectRow/WithAvatar.js
@@ -7,17 +7,19 @@ import SelectRow from '@ichef/gypcrete-form/src/SelectRow';
 import Option from '@ichef/gypcrete-form/src/SelectOption';
 
 function WithAvatar() {
-    const rdAvatar = <Avatar type="square" alt="Avatar of RD" src="https://api.adorable.io/avatars/285/rd@ichef.tw" />;
-    const designAvatar = <Avatar alt="Avatar of Design" src="https://api.adorable.io/avatars/285/design@ichef.tw" />;
+    const loveAvatar = <Avatar alt="Love" src="https://api.adorable.io/avatars/285/love@ichef.tw" />;
+    const trumpsAvatar = <Avatar alt="Trumps" src="https://api.adorable.io/avatars/285/trumps@ichef.tw" />;
+    const hateAvatar = <Avatar alt="Hate" src="https://api.adorable.io/avatars/285/hate@ichef.tw" />;
 
     return (
         <List title="Switch rows">
             <SelectRow
-                desc="Default is off"
-                defaultValues={['RD']}
+                desc="Select One Avatar"
+                defaultValues={['Love']}
                 onChange={action('change')}>
-                <Option label="RD" value="RD" avatar={rdAvatar} />
-                <Option label="Design" value="Design" avatar={designAvatar} />
+                <Option label="Love" value="Love" avatar={loveAvatar} />
+                <Option label="Trumps" value="Trumps" avatar={trumpsAvatar} />
+                <Option label="Hate" value="Hate" avatar={hateAvatar} />
             </SelectRow>
         </List>
     );

--- a/packages/storybook/examples/form/SelectRow/index.js
+++ b/packages/storybook/examples/form/SelectRow/index.js
@@ -6,11 +6,13 @@ import getPropTables from 'utils/getPropTables';
 
 import BasicUsage from './BasicUsage';
 import MultipleValues from './MultipleValues';
+import WithAvatar from './WithAvatar';
 import Customize from './Customize';
 
 storiesOf('@ichef/gypcrete-form|SelectRow', module)
     .add('basic usage', withInfo()(BasicUsage))
     .add('multiple selection', withInfo()(MultipleValues))
+    .add('with avatar', withInfo()(WithAvatar))
     .add('customize labels', withInfo()(Customize))
     // Props table
     .add('props', getPropTables([SelectRow]));


### PR DESCRIPTION
# Purpose

In our project in development, there is a need to add users' avatars alongside the text of `<ListRow>`, `<SelectRow>`, and `<SelectOption>`.

With this in mind, we add the following three types (square, rounded, and circle) of `<Avatar>`s to display an image along with the text, and change related components to accommodate the avatars.

![Screen Shot 2019-04-26 at 6 24 45 PM](https://user-images.githubusercontent.com/1139698/56801667-98b23900-6850-11e9-9bde-2b82b07e537a.png)


# Screenshots

#### `<Avatar>`
![Screen Shot 2019-04-26 at 6 27 39 PM](https://user-images.githubusercontent.com/1139698/56801805-ffcfed80-6850-11e9-841d-c27c79faf010.png)

#### `<ListRow>`
![Screen Shot 2019-04-26 at 6 29 26 PM](https://user-images.githubusercontent.com/1139698/56801932-4aea0080-6851-11e9-9e5d-a60e2d13abea.png)

### `<Checkbox>`
![Screen Shot 2019-04-26 at 6 30 27 PM](https://user-images.githubusercontent.com/1139698/56802000-75d45480-6851-11e9-8d6b-21106cbc513d.png)

### `<SelectRow>`
![Kapture 2019-04-26 at 18 32 54](https://user-images.githubusercontent.com/1139698/56802111-c5b31b80-6851-11e9-96b4-5f31b1e5df7c.gif)


# Changes

- Add `<Avatar>`
- Change `rowComp()` to allow the appearance of `<Avatar>` alongside the text 
- Change `<SelectRow>` and `<Checkbox>` to display `<Avatar>`


# Risks

The change of `rowComp()` allows any components wrapped with it to integrate `<Avatar>` on its left. However, since `<Avatar>` is an experimental feature in a project, components except`<ListRow>` and `<SelectRow>` have not been tested and documented.