### PR TITLE
Enhance <ImageEditor> for get canvas and controllable scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Form] `<TextInputRow>` now renders the new `<TextInput>` and forwards almost every prop to it, **without** a ref to its inner input.
 
 ### Changed
+- [ImageEditor] Add new instance method `getImageCanvas()` to get current image canvas element.
+- [ImageEditor] Add new props `scale` & `onScaleChange` to make scale value of editor can be controlled.
 - [Core] Refactored `closable()` mixin to detect inside/outside clicks via React SyntheticEvent mechanism instead of listening native events from DOM.
 - [Storybook] Fix mangled component name in storybook build. (#203)
 - [Storybook] Update examples for core `<TextInput>` and form `<TextInputRow>`. (#203)

--- a/packages/imageeditor/src/__tests__/index.test.js
+++ b/packages/imageeditor/src/__tests__/index.test.js
@@ -109,7 +109,7 @@ it('notifies new cropping rect whenever <AvatarEditor> think it changes', () => 
     );
 
     // mock <AvatarEditor> instance API
-    wrapper.instance().setCanvasRef({ getCroppingRect });
+    wrapper.instance().editorRef.current = { getCroppingRect };
 
     wrapper.find(AvatarEditor).simulate('imageChange');
     expect(handleCropChange).toHaveBeenLastCalledWith(CROP_RECT_FOO);
@@ -147,7 +147,7 @@ it('notifies imgInfo and cropping rect when image successfully loaded', () => {
     );
 
     // mock <AvatarEditor> instance API
-    wrapper.instance().setCanvasRef({ getCroppingRect });
+    wrapper.instance().editorRef.current = { getCroppingRect };
 
     wrapper.find(AvatarEditor).simulate('loadSuccess', MOCKED_IMG_INFO);
     expect(handleLoadSuccess).toHaveBeenLastCalledWith(MOCKED_IMG_INFO, MOCKED_CROP_RECT);
@@ -199,11 +199,29 @@ it('resets cached scale and position when image changes', () => {
     expect(wrapper.find(AvatarEditor).prop('position')).toEqual(DEFAULT_POSITION);
 });
 
-it('offers accessor method to ref to inner <AvatarEditor>', () => {
-    const MOCKED_REF = { getCroppingRect: () => {} };
+it('can get current image canvas via "getImageCanvas" method', () => {
+    const MOCKED_REF = { getImage: () => 'foo' };
     const wrapper = shallow(<ImageEditor image={TRANSPARENT_IMAGE} />);
 
-    // mock reference first as it does not happend under shallow rendering
-    wrapper.instance().setCanvasRef(MOCKED_REF);
-    expect(wrapper.instance().getCanvasRef()).toBe(MOCKED_REF);
+    wrapper.instance().editorRef.current = MOCKED_REF;
+    expect(wrapper.instance().getImageCanvas()).toBe('foo');
+});
+
+it('can be controlled by "scale" & "onScaleChange" props', () => {
+    const mockedHandleScaleChange = jest.fn();
+    const wrapper = shallow(
+        <ImageEditor
+            control
+            image={TRANSPARENT_IMAGE}
+            scale={0.87}
+            onScaleChange={mockedHandleScaleChange}
+        />
+    );
+
+    expect(wrapper.find(AvatarEditor).prop('scale')).toBe(0.87);
+
+    wrapper.find('input[type="range"]').simulate('change', {
+        target: { value: 1.5 },
+    });
+    expect(mockedHandleScaleChange).toBeCalledWith(1.5);
 });

--- a/packages/imageeditor/src/index.js
+++ b/packages/imageeditor/src/index.js
@@ -202,6 +202,7 @@ class ImageEditor extends PureComponent {
             height,
             onImageChange,
             onPositionChange,
+            onScaleChange,
             // react props
             className,
             style,

--- a/packages/imageeditor/src/styles/index.scss
+++ b/packages/imageeditor/src/styles/index.scss
@@ -14,6 +14,9 @@ $placeholder-border-color: rgba(0, 0, 0, .1);
     // elements
     &__canvas {
         position: relative;
+        background-color: #fff;
+        border-radius: 8px;
+        overflow: hidden;
 
         & > canvas {
             border: 1px solid #707070;

--- a/packages/imageeditor/src/styles/index.scss
+++ b/packages/imageeditor/src/styles/index.scss
@@ -14,6 +14,13 @@ $placeholder-border-color: rgba(0, 0, 0, .1);
     // elements
     &__canvas {
         position: relative;
+
+        & > canvas {
+            border: 1px solid #707070;
+            border-radius: 8px;
+            overflow: hidden;
+            box-sizing: border-box;
+        }
     }
 
     &__control {


### PR DESCRIPTION
# Purpose
enhance <ImageEditor> for get canvas and controllable scale.

# Changes
- [ImageEditor] Add new instance method `getImageCanvas()` to get current image canvas element.
- [ImageEditor] Add new props `scale` & `onScaleChange` to make scale value of editor can be controlled.

# Risk
none.

# TODOs
none.