### PR TITLE
Allow passing children to <TextInputRow> #trivial

### DIFF
--- a/packages/form/src/TextInputRow.js
+++ b/packages/form/src/TextInputRow.js
@@ -12,6 +12,7 @@ function TextInputRow({
     readOnly,
     disabled,
     rowProps,
+    children,
     ...inputProps
 }) {
     return (
@@ -21,6 +22,7 @@ function TextInputRow({
                 disabled={disabled}
                 {...inputProps}
             />
+            {children}
         </ListRow>
     );
 }

--- a/packages/form/src/__tests__/TextInputRow.test.js
+++ b/packages/form/src/__tests__/TextInputRow.test.js
@@ -54,6 +54,24 @@ describe('Pure <TextInputRow>', () => {
         )).toBeTruthy();
     });
 
+    it('allows additional children', () => {
+        const wrapper = shallow(
+            <PureTextInputRow
+                readOnly={false}
+                disabled
+                rowProps={{}}
+            >
+                <div data-target />
+            </PureTextInputRow>
+        );
+
+        expect(
+            wrapper.children().containsMatchingElement(
+                <div data-target />
+            )
+        ).toBeTruthy();
+    });
+
     it('forwards unknown props to <TextInput>', () => {
         const handleChange = jest.fn();
         const wrapper = shallow(


### PR DESCRIPTION
# Purpose
This PR allows passing uncertain `children` to form `<TextInputRow>` as before.
