### PR TITLE
Refactor <SelectList> & <SelectRow>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Form] `<SelectList>` now passes sorted values via `onChange()`
 - [Form] `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
-- [Form] Customize display labels for `<SelectRow>` with `asideAllLabel`, `asideNoneLabel` and `asideSeparator`.
+- [Form] Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
 - [Form] Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
 - [Core] `<ListRow>` stops forwarding status props to children via context. This is changed against `v1.2.0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.0.0]
 ### Breaking
+- [Form] `<SelectList>`:
+    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
+    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
+    - Rename prop `allOptionLabel` to `checkAllLabel`.
+- [Form] `<SelectRow>`:
+    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
+    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
+    - Rename prop `asideAll` to `asideAllLabel`.
+    - Rename prop `asideNone` to `asideNoneLabel`.
 - [Core] Add `verticalOrder` prop to `<Text>` so you can swap the position of `basic` and `aside`. Also applied to `rowComp()` mixin.
 - [Core] Rewrite `<TextInput>` to match latest design, offering single-line `<input>`, multi-line `<textarea>` and supports custom rendering via render prop.
 - [Form] `<TextInputRow>` now renders the new `<TextInput>` and forwards almost every prop to it, **without** a ref to its inner input.
@@ -241,7 +250,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Form] `<SelectList>` now passes sorted values via `onChange()`
 - [Form] `<SelectRow>` now caches values internally, and use that to control `<SelectList>`
-- [Form] Customize display labels for `<SelectRow>` with `asideAll`, `asideNone` and `asideSeparator`.
+- [Form] Customize display labels for `<SelectRow>` with `asideAllLabel`, `asideNoneLabel` and `asideSeparator`.
 - [Form] Extract `parseSelectOptions()` helper to read from children of `<SelectOption>`s.
 - [Core] `<ListRow>` stops forwarding status props to children via context. This is changed against `v1.2.0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Breaking
-- [Core] [Form] [ImageEditor] Peer dependency changes:
-  * Change from `@babel/runtime-corejs2` to `@babel/runtime-corejs3`.
-
 ### Changed
 - Upgrade to Babel v7.4.4 + `core-js` v3 to provide better polyfilling.
 
+### Added
+- [Core] [Form] [ImageEditor] setup `warning@4.0.3`.
+
+### Breaking
+- [Core] [Form] [ImageEditor] Peer dependency changes:
+  * Change from `@babel/runtime-corejs2` to `@babel/runtime-corejs3`.
+- [Form] `<SelectList>`:
+    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
+    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
+    - Rename prop `allOptionLabel` to `checkAllLabel`.
+- [Form] `<SelectRow>`:
+    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
+    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
+    - Rename prop `asideAll` to `asideAllLabel`.
+    - Rename prop `asideNone` to `asideNoneLabel`.
 
 ## [3.0.0]
 ### Breaking
-- [Form] `<SelectList>`:
-    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
-    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
-    - Rename prop `allOptionLabel` to `checkAllLabel`.
-- [Form] `<SelectRow>`:
-    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
-    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive and array when `multiple` is true.
-    - Rename prop `asideAll` to `asideAllLabel`.
-    - Rename prop `asideNone` to `asideNoneLabel`.
 - [Core] Add `verticalOrder` prop to `<Text>` so you can swap the position of `basic` and `aside`. Also applied to `rowComp()` mixin.
 - [Core] Rewrite `<TextInput>` to match latest design, offering single-line `<input>`, multi-line `<textarea>` and supports custom rendering via render prop.
 - [Form] `<TextInputRow>` now renders the new `<TextInput>` and forwards almost every prop to it, **without** a ref to its inner input.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
     "document-offset": "^1.0.4",
     "keycode": "^2.1.9",
     "memoize-one": "^4.0.3",
-    "react-textarea-autosize": "^7.1.0"
+    "react-textarea-autosize": "^7.1.0",
+    "warning": "^4.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -38,7 +38,8 @@
     "classnames": "^2.2.5",
     "immutable": "^3.8.2",
     "keycode": "^2.1.9",
-    "react-textarea-autosize": "^7.1.0"
+    "react-textarea-autosize": "^7.1.0",
+    "warning": "^4.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -76,7 +76,7 @@ class SelectList extends PureComponent {
         minCheck: 0,
         checkAllLabel: 'All',
         value: undefined,
-        defaultValue: [],
+        defaultValue: undefined,
         onChange: () => {},
         title: undefined,
         desc: undefined,
@@ -84,7 +84,7 @@ class SelectList extends PureComponent {
 
     state = {
         checkedState: getInitialCheckedState(
-            this.props.value || this.props.defaultValue,
+            this.getInitialValue(),
             this.props.multiple
         ),
     };
@@ -105,6 +105,13 @@ class SelectList extends PureComponent {
                 checkedState: getInitialCheckedState([])
             });
         }
+    }
+
+    getInitialValue() {
+        const { value, defaultValue, multiple } = this.props;
+        const newDefaultValue = (defaultValue === undefined && multiple) ? [] : defaultValue;
+
+        return (value !== undefined) ? value : newDefaultValue;
     }
 
     getIsControlled(fromProps = this.props) {

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -92,7 +92,7 @@ class SelectList extends PureComponent {
     componentWillReceiveProps(nextProps) {
         warning(
             this.getIsControlled(this.props) === this.getIsControlled(nextProps),
-            '<SelectList>: do not change between controlled and uncontrolld, it may cause some dataflow problem.'
+            '<SelectList> should not switch from controlled to uncontrolled (or vice versa).'
         );
 
         if (this.getIsControlled(nextProps)) {
@@ -100,7 +100,7 @@ class SelectList extends PureComponent {
                 checkedState: getInitialCheckedState(nextProps.value, nextProps.multiple),
             });
         } else if (this.props.multiple !== nextProps.multiple) {
-            warning(false, '<SelectList>: do not change `multiple` prop when uncontrolld, it will auto reset value to prevent dataflow problem.');
+            warning(false, '<SelectList>: you should not change `multiple` prop while it is uncontrolled. Its value will be reset now.');
             this.setState({
                 checkedState: getInitialCheckedState([])
             });

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -109,9 +109,16 @@ class SelectList extends PureComponent {
 
     getInitialValue() {
         const { value, defaultValue, multiple } = this.props;
-        const newDefaultValue = (defaultValue === undefined && multiple) ? [] : defaultValue;
 
-        return (value !== undefined) ? value : newDefaultValue;
+        if (value !== undefined) {
+            return value;
+        }
+
+        if (multiple && defaultValue === undefined) {
+            return [];
+        }
+
+        return defaultValue;
     }
 
     getIsControlled(fromProps = this.props) {

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import warning from 'warning';
+
 import { Map as ImmutableMap } from 'immutable';
 
 import {
@@ -14,7 +16,7 @@ import Option, {
 import parseSelectOptions from './utils/parseSelectOptions';
 import getElementTypeSymbol from './utils/getElementTypeSymbol';
 
-function getInitialCheckedState(selectedValue, multiple) {
+function getInitialCheckedState(selectedValue, multiple = true) {
     const checkedState = new ImmutableMap();
 
     return checkedState.withMutations((map) => {
@@ -88,9 +90,19 @@ class SelectList extends PureComponent {
     };
 
     componentWillReceiveProps(nextProps) {
+        warning(
+            this.getIsControlled(this.props) === this.getIsControlled(nextProps),
+            '<SelectList>: do not change between controlled and uncontrolld, it may cause some dataflow problem.'
+        );
+
         if (this.getIsControlled(nextProps)) {
             this.setState({
-                checkedState: getInitialCheckedState(nextProps.value),
+                checkedState: getInitialCheckedState(nextProps.value, nextProps.multiple),
+            });
+        } else if (this.props.multiple !== nextProps.multiple) {
+            warning(false, '<SelectList>: do not change `multiple` prop when uncontrolld, it will auto reset value to prevent dataflow problem.');
+            this.setState({
+                checkedState: getInitialCheckedState([])
             });
         }
     }

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -208,8 +208,7 @@ class SelectList extends PureComponent {
         this.handleChange(nextState);
     }
 
-    renderOptions() {
-        const { children } = this.props;
+    renderOptions(children = this.props.children) {
         const { checkedState } = this.state;
 
         return React.Children.map(children, (child) => {
@@ -219,6 +218,11 @@ class SelectList extends PureComponent {
                     onChange: this.handleOptionChange,
                 });
             }
+
+            if (child && child.type === React.Fragment) {
+                return this.renderOptions(child.props.children);
+            }
+
             return child;
         });
     }

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import warning from 'warning';
 
 import {
     ListRow,
@@ -102,8 +103,16 @@ class SelectRow extends PureComponent {
             valueLabelMap: getValueToLabelAvatarMap(nextProps.children),
         });
 
+        warning(
+            this.getIsControlled(this.props) === this.getIsControlled(nextProps),
+            '<SelectRow> warning: do not change between controlled and uncontrolld, it may cause some dataflow problem.'
+        );
+
         if (this.getIsControlled(nextProps)) {
             this.setState({ cachedValue: nextProps.value });
+        } else if (this.props.multiple !== nextProps.multiple) {
+            warning(false, '<SelectRow> Warning: do not change `multiple` prop when uncontrolld, it will auto reset value to prevent dataflow problem.');
+            this.setState({ cachedValue: (nextProps.multiple) ? [] : null });
         }
     }
 
@@ -149,7 +158,7 @@ class SelectRow extends PureComponent {
         const { multiple, asideAllLabel, asideNoneLabel, asideSeparator } = this.props;
         const { cachedValue, valueLabelMap } = this.state;
 
-        if (cachedValue.length === 0) {
+        if (multiple && cachedValue.length === 0) {
             return <span className={BEM.placeholder.toString()}>{asideNoneLabel}</span>;
         }
 
@@ -160,7 +169,7 @@ class SelectRow extends PureComponent {
             }
         }
 
-        const cachedValueArray = Array.isArray(cachedValue) ? cachedValue : [cachedValue];
+        const cachedValueArray = multiple ? cachedValue : [cachedValue];
         return cachedValueArray
             .map((value) => {
                 const valueMap = valueLabelMap.get(value) || {};
@@ -171,10 +180,6 @@ class SelectRow extends PureComponent {
 
     renderAvatar() {
         const { cachedValue, valueLabelMap } = this.state;
-
-        if (cachedValue.length === 0) {
-            return null;
-        }
 
         const cachedValueArray = Array.isArray(cachedValue) ? cachedValue : [cachedValue];
         return cachedValueArray

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -118,9 +118,16 @@ class SelectRow extends PureComponent {
 
     getInitialValue() {
         const { value, defaultValue, multiple } = this.props;
-        const newDefaultValue = (defaultValue === undefined && multiple) ? [] : defaultValue;
 
-        return (value !== undefined) ? value : newDefaultValue;
+        if (value !== undefined) {
+            return value;
+        }
+
+        if (multiple && defaultValue === undefined) {
+            return [];
+        }
+
+        return defaultValue;
     }
 
     getIsControlled(fromProps = this.props) {

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -19,7 +19,7 @@ it('renders without crashing', () => {
 
 it('reads options only from <SelectOptions>', () => {
     const wrapper = shallow(
-        <SelectList values={['foo']}>
+        <SelectList value="foo">
             <Option label="Foo" value="foo" />
             <Option label="Bar" value="bar" />
             <div />
@@ -45,10 +45,10 @@ describe('Single response mode', () => {
         expect(handleChange).not.toHaveBeenCalled();
 
         wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
-        expect(handleChange).toHaveBeenLastCalledWith(['foo']);
+        expect(handleChange).toHaveBeenLastCalledWith('foo');
 
         wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-        expect(handleChange).toHaveBeenLastCalledWith(['bar']);
+        expect(handleChange).toHaveBeenLastCalledWith('bar');
     });
 
     it('keeps one option checked when uncontrolled', () => {
@@ -75,7 +75,7 @@ describe('Single response mode', () => {
 
     it('does not update options checked state when controlled', () => {
         const wrapper = shallow(
-            <SelectList values={['foo']}>
+            <SelectList value="foo">
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
             </SelectList>
@@ -89,7 +89,7 @@ describe('Single response mode', () => {
 
     it('updates <Option checked> if is controlled and values changes', () => {
         const wrapper = shallow(
-            <SelectList values={['foo']}>
+            <SelectList value="foo">
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
             </SelectList>
@@ -97,14 +97,14 @@ describe('Single response mode', () => {
         expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
         expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
 
-        wrapper.setProps({ values: ['bar'] });
+        wrapper.setProps({ value: 'bar' });
         expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeFalsy();
         expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeTruthy();
     });
 
     it('does not update <Option checked> if is uncontrolled and other prop changes', () => {
         const wrapper = shallow(
-            <SelectList defaultValues={['foo']}>
+            <SelectList defaultValue="foo">
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
             </SelectList>
@@ -112,7 +112,7 @@ describe('Single response mode', () => {
         expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
         expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
 
-        wrapper.setProps({ defaultValues: ['bar'] });
+        wrapper.setProps({ defaultValue: ['bar'] });
         expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
         expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
     });
@@ -133,7 +133,7 @@ describe('Multiple response mode', () => {
             onChange: wrapper.instance().handleCheckAllOptionChange,
         });
 
-        wrapper.setProps({ allOptionLabel: 'Check All' });
+        wrapper.setProps({ checkAllLabel: 'Check All' });
         expect(wrapper.find(Option).at(0).prop('label')).toBe('Check All');
     });
 
@@ -195,7 +195,7 @@ describe('Multiple response mode', () => {
 describe('Read-only options', () => {
     it('toggles all options without affecting read-only options', () => {
         const wrapper = shallow(
-            <SelectList multiple defaultValues={['foo']}>
+            <SelectList multiple defaultValue={['foo']}>
                 <Option label="Foo" value="foo" readOnly />
                 <Option label="Bar" value="bar" />
             </SelectList>
@@ -213,7 +213,7 @@ describe('Read-only options', () => {
 describe('Minimum checks limit', () => {
     it('does not allow to uncheck if will unable to match minCheck', () => {
         const wrapper = shallow(
-            <SelectList multiple minCheck={1} defaultValues={['foo']}>
+            <SelectList multiple minCheck={1} defaultValue={['foo']}>
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
             </SelectList>
@@ -232,7 +232,7 @@ describe('Minimum checks limit', () => {
 
     it('keeps first n-options checked when unchecking all options', () => {
         const wrapper = shallow(
-            <SelectList multiple minCheck={2} defaultValues={['foo', 'option3']}>
+            <SelectList multiple minCheck={2} defaultValue={['foo', 'option3']}>
                 <Option label="Foo" value="foo" />
                 <Option label="Bar" value="bar" />
                 <Option label="Option3" value="option3" />

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -247,3 +247,19 @@ describe('Minimum checks limit', () => {
         expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);
     });
 });
+
+it('if change `multiple` prop when uncontrolled, it will auto reset cachedValue', () => {
+    const wrapper = shallow(
+        <SelectList defaultValue="foo">
+            <Option label="Option A" value="foo" />
+            <Option label="Option B" value="bar" />
+        </SelectList>
+    );
+    expect(wrapper.instance().getValues()).toEqual(['foo']);
+
+    wrapper.setProps({ multiple: true, defaultValue: ['foo', 'bar'] });
+    expect(wrapper.instance().getValues()).toEqual([]);
+
+    wrapper.setProps({ multiple: false, defaultValue: ['bar'] });
+    expect(wrapper.instance().getValues()).toEqual([]);
+});

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -141,14 +141,17 @@ describe('Pure <SelectRow>: Data', () => {
         expect(wrapper.state('cachedValue')).toEqual([1, 2]);
     });
 
-    it('does updates cached value from props when uncontrolled', () => {
+    it('if change `multiple` prop when uncontrolled, it will auto reset cachedValue', () => {
         const wrapper = shallow(
             <PureSelectRow label="Select" defaultValue={1} />
         );
         expect(wrapper.state('cachedValue')).toEqual(1);
 
         wrapper.setProps({ multiple: true, defaultValue: [1, 2] });
-        expect(wrapper.state('cachedValue')).toEqual(1);
+        expect(wrapper.state('cachedValue')).toEqual([]);
+
+        wrapper.setProps({ multiple: false, defaultValue: 87 });
+        expect(wrapper.state('cachedValue')).toEqual(null);
     });
 
     it('controls <SelectList> with cached value', () => {
@@ -187,7 +190,7 @@ describe('Pure <SelectRow>: Data', () => {
         const barAvatar = <Avatar alt="bar" src="BAR_SRC" />;
 
         const wrapper = shallow(
-            <PureSelectRow label="Select" value={['foo']}>
+            <PureSelectRow label="Select" value="foo">
                 <Option label="foo" value="foo" avatar={fooAvatar} />
                 <Option label="bar" value="bar" avatar={barAvatar} />
             </PureSelectRow>
@@ -195,7 +198,7 @@ describe('Pure <SelectRow>: Data', () => {
 
         expect(wrapper.find(Avatar).prop('src')).toEqual('FOO_SRC');
 
-        wrapper.setProps({ value: ['bar'] });
+        wrapper.setProps({ value: 'bar' });
         expect(wrapper.find(Avatar).prop('src')).toEqual('BAR_SRC');
     });
 
@@ -241,7 +244,7 @@ describe('Pure <SelectRow>: Data', () => {
 
     it('does not display "All" on single <SelectRow> with only one option', () => {
         const wrapper = shallow(
-            <PureSelectRow label="Select" value={['foo']}>
+            <PureSelectRow label="Select" value="foo">
                 <Option label="Foo" value="foo" />
             </PureSelectRow>
         );

--- a/packages/form/src/utils/parseSelectOptions.js
+++ b/packages/form/src/utils/parseSelectOptions.js
@@ -1,4 +1,4 @@
-import { Children } from 'react';
+import { Fragment } from 'react';
 import { TYPE_SYMBOL } from '../SelectOption';
 
 import getElementTypeSymbol from './getElementTypeSymbol';
@@ -9,16 +9,20 @@ import getElementTypeSymbol from './getElementTypeSymbol';
  * @param {ReactChildren} children - children of `<SelectOptions>`
  * @returns {array}
  */
-function parseSelectOptions(children) {
-    const results = [];
+export default function parseSelectOptions(children) {
+    const childArray = Array.isArray(children) ? children : [children].filter(item => item);
 
-    Children.forEach(children, (child) => {
+    const results = childArray.map((child) => {
         if (getElementTypeSymbol(child) === TYPE_SYMBOL) {
-            results.push(child.props);
+            return child.props;
         }
+
+        if (child && child.type === Fragment) {
+            return parseSelectOptions(child.props.children);
+        }
+
+        return null;
     });
 
-    return results;
+    return results.flat().filter(item => item);
 }
-
-export default parseSelectOptions;

--- a/packages/imageeditor/package.json
+++ b/packages/imageeditor/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@ichef/gypcrete": "^3.0.0",
     "classnames": "^2.2.5",
-    "react-avatar-editor": "^11.0.2"
+    "react-avatar-editor": "^11.0.2",
+    "warning": "^4.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/packages/storybook/examples/form/SelectList/MultipleControlled.js
+++ b/packages/storybook/examples/form/SelectList/MultipleControlled.js
@@ -8,7 +8,7 @@ function MultipleControlled() {
     return (
         <SelectList
             multiple
-            values={['1', '2']}
+            value={['1', '2']}
             onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />

--- a/packages/storybook/examples/form/SelectList/MultipleMinCheck.js
+++ b/packages/storybook/examples/form/SelectList/MultipleMinCheck.js
@@ -9,7 +9,7 @@ function MultipleMinCheck() {
         <SelectList
             multiple
             minCheck={1}
-            defaultValues={['1']}
+            defaultValue={['1']}
             onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />

--- a/packages/storybook/examples/form/SelectList/MultipleReadOnlyOption.js
+++ b/packages/storybook/examples/form/SelectList/MultipleReadOnlyOption.js
@@ -8,7 +8,7 @@ function MultipleReadOnlyOption() {
     return (
         <SelectList
             multiple
-            defaultValues={['1']}
+            defaultValue={['1']}
             onChange={action('change')}>
             <Option label="Option A" value="1" readOnly />
             <Option label="Option B" value="2" />

--- a/packages/storybook/examples/form/SelectList/MultipleUncontrolled.js
+++ b/packages/storybook/examples/form/SelectList/MultipleUncontrolled.js
@@ -8,7 +8,7 @@ function MultipleUncontrolled() {
     return (
         <SelectList
             multiple
-            defaultValues={['1']}
+            defaultValue={['1']}
             onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />

--- a/packages/storybook/examples/form/SelectList/MultipleWithoutCheckAll.js
+++ b/packages/storybook/examples/form/SelectList/MultipleWithoutCheckAll.js
@@ -9,7 +9,7 @@ function MultipleWithoutCheckAll() {
         <SelectList
             multiple
             showCheckAll={false}
-            defaultValues={['1']}
+            defaultValue={['1']}
             onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />

--- a/packages/storybook/examples/form/SelectList/SingleControlled.js
+++ b/packages/storybook/examples/form/SelectList/SingleControlled.js
@@ -6,7 +6,7 @@ import Option from '@ichef/gypcrete-form/src/SelectOption';
 
 function SingleControlled() {
     return (
-        <SelectList values={['1']} onChange={action('change')}>
+        <SelectList value="1" onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />
             <Option label="Option C" value="3" />

--- a/packages/storybook/examples/form/SelectList/SingleUncontrolled.js
+++ b/packages/storybook/examples/form/SelectList/SingleUncontrolled.js
@@ -6,7 +6,7 @@ import Option from '@ichef/gypcrete-form/src/SelectOption';
 
 function SingleUncontrolled() {
     return (
-        <SelectList defaultValues={['1']} onChange={action('change')}>
+        <SelectList defaultValue="1" onChange={action('change')}>
             <Option label="Option A" value="1" />
             <Option label="Option B" value="2" />
             <Option label="Option C" value="3" />

--- a/packages/storybook/examples/form/SelectRow/BasicUsage.js
+++ b/packages/storybook/examples/form/SelectRow/BasicUsage.js
@@ -11,7 +11,7 @@ function BasicUsage() {
             <SelectRow
                 label="Module default state on iPad"
                 desc="Default is off"
-                defaultValues={['no']}
+                defaultValue="no"
                 onChange={action('change')}>
                 <Option label="Yes" value="yes" />
                 <Option label="No" value="no" />
@@ -29,7 +29,7 @@ function BasicUsage() {
                 label="World peace"
                 status="error"
                 errorMsg="Cannot declare a war."
-                values={['peace']}>
+                value="peace">
                 <Option label="Peace" value="peace" />
                 <Option label="War" value="war" />
             </SelectRow>

--- a/packages/storybook/examples/form/SelectRow/Customize.js
+++ b/packages/storybook/examples/form/SelectRow/Customize.js
@@ -10,8 +10,8 @@ function MultipleValues() {
             <SelectRow
                 multiple
                 label="Custom 'All' label"
-                asideAll="EVERYHTING SELECTED"
-                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                asideAllLabel="EVERYHTING SELECTED"
+                defaultValue={['opt-a', 'opt-b', 'opt-c']}>
                 <Option label="Option A" value="opt-a" />
                 <Option label="Option B" value="opt-b" />
                 <Option label="Option C" value="opt-c" />
@@ -20,8 +20,8 @@ function MultipleValues() {
             <SelectRow
                 multiple
                 label="Turn off 'All' label"
-                asideAll={false}
-                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                asideAllLabel={false}
+                defaultValue={['opt-a', 'opt-b', 'opt-c']}>
                 <Option label="Option A" value="opt-a" />
                 <Option label="Option B" value="opt-b" />
                 <Option label="Option C" value="opt-c" />
@@ -30,7 +30,7 @@ function MultipleValues() {
             <SelectRow
                 multiple
                 label="Custom 'None' label"
-                asideNone="Nothing">
+                asideNoneLabel="Nothing">
                 <Option label="Option A" value="opt-a" />
                 <Option label="Option B" value="opt-b" />
                 <Option label="Option C" value="opt-c" />
@@ -39,9 +39,9 @@ function MultipleValues() {
             <SelectRow
                 multiple
                 label="Custom separator label"
-                asideAll={false}
+                asideAllLabel={false}
                 asideSeparator=" + "
-                defaultValues={['opt-a', 'opt-b', 'opt-c']}>
+                defaultValue={['opt-a', 'opt-b', 'opt-c']}>
                 <Option label="Option A" value="opt-a" />
                 <Option label="Option B" value="opt-b" />
                 <Option label="Option C" value="opt-c" />

--- a/packages/storybook/examples/form/SelectRow/MultipleValues.js
+++ b/packages/storybook/examples/form/SelectRow/MultipleValues.js
@@ -23,7 +23,7 @@ function MultipleValues() {
                 multiple
                 label="Minimal selection: 2"
                 minCheck={2}
-                defaultValues={['opt-c', 'opt-d']}>
+                defaultValue={['opt-c', 'opt-d']}>
                 <Option label="Option A" value="opt-a" />
                 <Option label="Option B" value="opt-b" />
                 <Option label="Option C" value="opt-c" />

--- a/packages/storybook/examples/form/SelectRow/WithAvatar.js
+++ b/packages/storybook/examples/form/SelectRow/WithAvatar.js
@@ -14,8 +14,9 @@ function WithAvatar() {
     return (
         <List title="Switch rows">
             <SelectRow
+                label="Avatar"
                 desc="Select One Avatar"
-                defaultValues={['Love']}
+                defaultValue="Love"
                 onChange={action('change')}>
                 <Option label="Love" value="Love" avatar={loveAvatar} />
                 <Option label="Trumps" value="Trumps" avatar={trumpsAvatar} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -13114,6 +13114,13 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"


### PR DESCRIPTION
# Purpose
Refactor <SelectList> & <SelectRow>.

# Changes
### Added
- [Core] setup `warning@4.0.3`.
- [Form] setup `warning@4.0.3`.
- [ImageEditor] setup `warning@4.0.3`.

### Breaking
- [Form] `<SelectList>`:
    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
    - Rename prop `allOptionLabel` to `checkAllLabel`.
- [Form] `<SelectRow>`:
    - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
    - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
    - Rename prop `asideAll` to `asideAllLabel`.
    - Rename prop `asideNone` to `asideNoneLabel`.


# Risk
May break something in cloud2, I will make another PR to resolve them.

# TODOs
none.