### PR TITLE
Update component styles 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Add the `inline-info` icon to the selections of `<Icon>`.
 
 ### Changed
-- Upgrade to Babel v7.4.4 + `core-js` v3 to provide better polyfilling.
-- Upgrade to Lerna v3; changes publish steps.
+- [Build] Upgrade to Babel v7.4.4 + `core-js` v3 to provide better polyfilling.
+- [Build] Upgrade to Lerna v3; changes publish steps.
+- [Core] Update `<Section>` title style and increase bottom margin.
+- [Form] Update `<SelectRow>` and `<SwitchRow>` to adpat vertically-reversed appearance as `<TextInputRow>` in v3.0.
 
 ## [3.0.0]
 ### Breaking

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -3,8 +3,8 @@
 $component-name: #{$prefix}-section;
 
 .#{$component-name} {
-    margin-top: rem($section-vertical-margin);
-    margin-bottom: rem($section-vertical-margin);
+    margin-top: rem($section-top-margin);
+    margin-bottom: rem($section-bottom-margin);
 
     // --------------------
     //  Elements

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -11,20 +11,27 @@ $component-name: #{$prefix}-section;
     // --------------------
     &__title,
     &__desc {
-        @include small-text;
-
         white-space: pre-wrap;
         margin-left: rem($section-horizontal-padding);
         margin-right: rem($section-horizontal-padding);
     }
 
     &__title {
+        font-size: rem($section-title-font-size);
+        line-height: rem($section-title-line-height);
         font-weight: $font-weight-bold;
         padding-bottom: rem(1px);
         border-bottom: 2px solid $c-section-divider;
+
+        &:before {
+            content: "\25a0";
+            display: inline-block;
+            margin-right: 0.25em;
+        }
     }
 
     &__desc {
+        @include small-text;
         // take padding from row layout as reference
         padding-top: rem(2px);
     }

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -26,7 +26,7 @@ $component-name: #{$prefix}-section;
         &:before {
             content: "\25a0";
             display: inline-block;
-            margin-right: 0.25em;
+            margin-right: .25em;
         }
     }
 

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -71,7 +71,8 @@ $search-input-padding: 8px;
 
 $section-title-font-size: 18px;
 $section-title-line-height: 20px;
-$section-vertical-margin: 24px;
+$section-top-margin: 24px;
+$section-bottom-margin: 48px;
 $section-horizontal-padding: 16px;
 
 $list-border-radius: 8px;

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -69,6 +69,8 @@ $search-input-border-color: $c-black-30;
 $search-input-border-radius: 20px;
 $search-input-padding: 8px;
 
+$section-title-font-size: 18px;
+$section-title-line-height: 20px;
 $section-vertical-margin: 24px;
 $section-horizontal-padding: 16px;
 

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -246,9 +246,11 @@ class SelectRow extends PureComponent {
                 {this.renderAvatar()}
                 <Content minified={false} disabled={disabled} {...contentProps}>
                     <Text
+                        verticalOrder="reverse"
                         bold={!ineditable}
-                        basic={label}
-                        aside={this.renderRowValuesAside()} />
+                        basic={this.renderRowValuesAside()}
+                        aside={label}
+                    />
 
                     <span ref={(ref) => { this.anchorNode = ref; }}>
                         <Icon type="dropdown" />

--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -91,8 +91,10 @@ class SwitchRow extends PureComponent {
             <ListRow className={className} {...rowProps}>
                 <TextLabel
                     bold={!ineditable}
-                    basic={label}
-                    aside={this.getSwitchAside()} />
+                    verticalOrder="reverse"
+                    basic={this.getSwitchAside()}
+                    aside={label}
+                />
 
                 <Switch
                     status={null}

--- a/packages/form/src/__tests__/SelectRow.test.js
+++ b/packages/form/src/__tests__/SelectRow.test.js
@@ -167,7 +167,7 @@ describe('Pure <SelectRow>: Data', () => {
         expect(wrapper.find(SelectList).prop('value')).toEqual([1, 2, 3]);
     });
 
-    it('renders current value on aside', () => {
+    it('renders current value on <Text basic="value">', () => {
         const wrapper = shallow(
             <PureSelectRow multiple label="Select" value={[]}>
                 <Option label="Foo" value="foo" />
@@ -175,14 +175,14 @@ describe('Pure <SelectRow>: Data', () => {
                 <Option label="Meh" value="meh" />
             </PureSelectRow>
         );
-        expect(wrapper.find(Text).prop('aside'))
+        expect(wrapper.find(Text).prop('basic'))
             .toEqual(<span className={BEM.placeholder.toString()}>(Unset)</span>);
 
         wrapper.setProps({ value: ['foo', 'bar'] });
-        expect(wrapper.find(Text).prop('aside')).toBe('Foo, Bar');
+        expect(wrapper.find(Text).prop('basic')).toBe('Foo, Bar');
 
         wrapper.setProps({ value: ['foo', 'bar', 'meh'] });
-        expect(wrapper.find(Text).prop('aside')).toBe('All');
+        expect(wrapper.find(Text).prop('basic')).toBe('All');
     });
 
     it('renders the avatar', () => {
@@ -202,7 +202,7 @@ describe('Pure <SelectRow>: Data', () => {
         expect(wrapper.find(Avatar).prop('src')).toEqual('BAR_SRC');
     });
 
-    it('can customize aside labels', () => {
+    it('can customize value labels', () => {
         const wrapper = shallow(
             <PureSelectRow multiple label="Select" value={[]} asideNoneLabel="None">
                 <Option label="Foo" value="foo" />
@@ -211,20 +211,20 @@ describe('Pure <SelectRow>: Data', () => {
             </PureSelectRow>
         );
 
-        expect(wrapper.find(Text).prop('aside'))
+        expect(wrapper.find(Text).prop('basic'))
             .toEqual(<span className={BEM.placeholder.toString()}>None</span>);
 
         wrapper.setProps({
             value: ['foo', 'bar'],
             asideSeparator: ' + '
         });
-        expect(wrapper.find(Text).prop('aside')).toBe('Foo + Bar');
+        expect(wrapper.find(Text).prop('basic')).toBe('Foo + Bar');
 
         wrapper.setProps({
             value: ['foo', 'bar', 'meh'],
             asideAllLabel: 'Everything'
         });
-        expect(wrapper.find(Text).prop('aside')).toBe('Everything');
+        expect(wrapper.find(Text).prop('basic')).toBe('Everything');
     });
 
     it('can disable "All" label by overriding with null', () => {
@@ -239,7 +239,7 @@ describe('Pure <SelectRow>: Data', () => {
                 <Option label="Meh" value="meh" />
             </PureSelectRow>
         );
-        expect(wrapper.find(Text).prop('aside')).toBe('Foo, Bar, Meh');
+        expect(wrapper.find(Text).prop('basic')).toBe('Foo, Bar, Meh');
     });
 
     it('does not display "All" on single <SelectRow> with only one option', () => {
@@ -248,6 +248,6 @@ describe('Pure <SelectRow>: Data', () => {
                 <Option label="Foo" value="foo" />
             </PureSelectRow>
         );
-        expect(wrapper.find(Text).prop('aside')).toBe('Foo');
+        expect(wrapper.find(Text).prop('basic')).toBe('Foo');
     });
 });

--- a/packages/form/src/__tests__/SwitchRow.test.js
+++ b/packages/form/src/__tests__/SwitchRow.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
-import { Switch } from '@ichef/gypcrete';
+import { Switch, TextLabel } from '@ichef/gypcrete';
 import SwitchRow, { PureSwitchRow } from '../SwitchRow';
 
 describe('formRow(SwitchRow)', () => {
@@ -59,18 +59,19 @@ describe('Pure <SwitchRow>', () => {
         expect(wrapper.state('checked')).toBeFalsy();
     });
 
-    it('shows different aside with checked state', () => {
-        const wrapper = mount(
+    it('shows different basic with checked state', () => {
+        const wrapper = shallow(
             <PureSwitchRow
                 checked
                 label="foo"
                 asideOn="TEST_ON"
                 asideOff="TEST_OFF" />
         );
-        expect(wrapper.text()).toBe('fooTEST_ON');
+
+        expect(wrapper.find(TextLabel).prop('basic')).toBe('TEST_ON');
 
         wrapper.setProps({ checked: false });
-        expect(wrapper.text()).toBe('fooTEST_OFF');
+        expect(wrapper.find(TextLabel).prop('basic')).toBe('TEST_OFF');
     });
 
     it('accepts additional children', () => {


### PR DESCRIPTION
# Changed
- Update title style for `<Section>`.
- Increase bottom margin for `<Section>`.
- Update form rows to use vertically-reversed layout.

# Todo:
- [ ] Rename props for `<SwitchRow>` and `<SelectRow>` regarding “aside labels”.

# Screenshot
<img width="782" alt="螢幕快照 2019-06-27 下午4 27 13" src="https://user-images.githubusercontent.com/365035/60250253-d5ee8200-98f8-11e9-8e89-b3e1990afc8e.png">
