### PR TITLE
Update <ImageEditor> to give canvas in the same size of editor by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
     - Rename prop `asideAll` to `asideAllLabel`.
     - Rename prop `asideNone` to `asideNoneLabel`.
+- [ImageEditor] The instance method `getImageCanvas()` of `<ImageEditor>` now returns a `<canvas>` in the same dimension as the editor itself by default.
+
 
 ### Added
 - [Core] [Form] [ImageEditor] setup `warning@4.0.3`.

--- a/packages/imageeditor/src/index.js
+++ b/packages/imageeditor/src/index.js
@@ -119,7 +119,12 @@ class ImageEditor extends PureComponent {
      *
      * Setting ref with instance method doesn't break. It's just MAGIC.
      */
-    getImageCanvas = () => this.editorRef.current.getImage();
+    getImageCanvas = ({ originalSize = false } = {}) => {
+        if (originalSize) {
+            return this.editorRef.current.getImage();
+        }
+        return this.editorRef.current.getImageScaledToCanvas();
+    }
 
     handleSliderChange = (event) => {
         const newScale = Number(event.target.value);

--- a/packages/imageeditor/src/index.js
+++ b/packages/imageeditor/src/index.js
@@ -112,13 +112,6 @@ class ImageEditor extends PureComponent {
         }
     }
 
-    /**
-     * When maintaining ref with inline arrow function, it sometimes receives
-     * mystery `null` during canvas drag. This blocks accessing cropping rect
-     * via `onImageChange()` callback.
-     *
-     * Setting ref with instance method doesn't break. It's just MAGIC.
-     */
     getImageCanvas = ({ originalSize = false } = {}) => {
         if (originalSize) {
             return this.editorRef.current.getImage();


### PR DESCRIPTION
# Purpose
The `getImage()` method of `react-avatar-editor` returns a canvas with “the same resolution as the original image”. If you need the canvas to be in the dimension of editor, you'll have to call `getImageScaledToCanvas()` instead. However it's not intuitive in our own usage.

https://www.npmjs.com/package/react-avatar-editor#accessing-the-resulting-image

In this PR I'm changing the `getImageCanvas()` method in our own `<ImageEditor>` to expose the resized canvas by default. If you need its original behavior, which returns the canvas at the input image's original dimension, pass in `getImageCanvas({ originalSize: true })` instead.
