### PR TITLE
[Fix] Force publish all packages when releasing canary #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bumpversion": "lerna version --no-git-tag-version --no-push",
     "release": "lerna publish from-package",
     "release:pre": "lerna publish --dist-tag=prerelease",
-    "release:canary": "lerna publish --canary",
+    "release:canary": "lerna publish --canary --force-publish",
     "ghpages": "lerna run ghpages",
     "lint": "npm run lint:eslint && npm run lint:stylelint",
     "lint:eslint": "eslint ./packages --ignore-path=configs/.eslintignore ./",


### PR DESCRIPTION
# Summary
This restores the v2 behavior.

When we were auto-releasing a canary build for #220, we found it only published a new build for `@ichef/gypctete-imageeditor`. Unfortunately the version of `@ichef/gypcrete` listed in that build remains `^3.0.0` because the two packages were not published at the same time.

By force-publish packages all together, we can at least be sure their dependencies would be correct.
