### PR TITLE
Refactor <ColumnView> and <Modal>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - [Core] [Form] [ImageEditor] Peer dependency changes:
   * Change from `@babel/runtime-corejs2` to `@babel/runtime-corejs3`.
+- [Core] `<ColumnView>`:
+  * The `bottomPadding` prop is removed. Please use `bodyPadding` prop and pass an object instead.
+- [Core] `<Modal>`:
+  * `<Modal>` is refactored to render a `<ColumnView>` as its inner layout.
+  * `<Modal>` no longer takes `size`  and `bodyClassName` props.
+  * The `bodyPadding` prop now takes an object and is passed to `<ColumnView>`.
 - [Form] `<SelectList>`:
     - Rename prop `values` to `value`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
     - Rename prop `defaultValues` to `defaultValue`, and it receive a single value directly when is not `multiple`, and receive an array when `multiple` is true.
@@ -24,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [Core] [Form] [ImageEditor] setup `warning@4.0.3`.
 - [Core] Add the `inline-info` icon to the selections of `<Icon>`.
+- [Core] Add `flexBody` prop for `<ColumnView>` (and also `<Modal>`) to render its body as a Flexbox.
 
 ### Changed
 - [Build] Upgrade to Babel v7.4.4 + `core-js` v3 to provide better polyfilling.
@@ -31,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Update `<Section>` title style and increase bottom margin.
 - [Form] Update `<SelectRow>` and `<SwitchRow>` to adpat vertically-reversed appearance as `<TextInputRow>` in v3.0.
 - [Form] Add `desc` prop to `<SelectOption>`
+- [Storybook] Update examples for refactord `<ColumnView>` and `<Modal>`.
 
 ## [3.0.0]
 ### Breaking

--- a/packages/core/src/ColumnView.js
+++ b/packages/core/src/ColumnView.js
@@ -26,18 +26,20 @@ export function ColumnPart({ children, ...otherProps }) {
 function ColumnView({
     header,
     footer,
-    bottomPadding,
+    bodyPadding,
     // React props
     className,
     children,
     ...wrapperProps
 }) {
     const rootClassName = classNames(BEM.root.toString(), className);
-    const bodyStyle = {};
 
-    if (bottomPadding) {
-        bodyStyle.paddingBottom = bottomPadding;
-    }
+    const bodyStyle = {
+        paddingTop: bodyPadding.top,
+        paddingBottom: bodyPadding.bottom,
+        paddingLeft: bodyPadding.left,
+        paddingRight: bodyPadding.right,
+    };
 
     return (
         <div className={rootClassName} {...wrapperProps}>
@@ -59,13 +61,18 @@ function ColumnView({
 ColumnView.propTypes = {
     header: PropTypes.node,
     footer: PropTypes.node,
-    bottomPadding: PropTypes.string,
+    bodyPadding: PropTypes.shape({
+        top: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number,
+    }),
 };
 
 ColumnView.defaultProps = {
     header: undefined,
     footer: undefined,
-    bottomPadding: undefined,
+    bodyPadding: { bottom: 24 },
 };
 
 export default ColumnView;

--- a/packages/core/src/ColumnView.js
+++ b/packages/core/src/ColumnView.js
@@ -15,14 +15,6 @@ export const BEM = {
     footer: ROOT_BEM.element('footer'),
 };
 
-export function ColumnPart({ children, ...otherProps }) {
-    if (!children) {
-        return null;
-    }
-
-    return <div {...otherProps}>{children}</div>;
-}
-
 function ColumnView({
     header,
     footer,
@@ -45,17 +37,21 @@ function ColumnView({
 
     return (
         <div className={rootClassName} {...wrapperProps}>
-            <ColumnPart className={BEM.header.toString()}>
-                {header}
-            </ColumnPart>
+            {header && (
+                <div className={`${BEM.header}`}>
+                    {header}
+                </div>
+            )}
 
             <div className={`${bodyClassName}`} style={bodyStyle}>
                 {children}
             </div>
 
-            <ColumnPart className={BEM.footer.toString()}>
-                {footer}
-            </ColumnPart>
+            {footer && (
+                <div className={`${BEM.footer}`}>
+                    {footer}
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/core/src/ColumnView.js
+++ b/packages/core/src/ColumnView.js
@@ -26,13 +26,15 @@ export function ColumnPart({ children, ...otherProps }) {
 function ColumnView({
     header,
     footer,
+    flexBody,
     bodyPadding,
     // React props
     className,
     children,
     ...wrapperProps
 }) {
-    const rootClassName = classNames(BEM.root.toString(), className);
+    const rootClassName = classNames(`${BEM.root}`, className);
+    const bodyClassName = BEM.body.modifier('flex', flexBody);
 
     const bodyStyle = {
         paddingTop: bodyPadding.top,
@@ -47,7 +49,7 @@ function ColumnView({
                 {header}
             </ColumnPart>
 
-            <div className={BEM.body.toString()} style={bodyStyle}>
+            <div className={`${bodyClassName}`} style={bodyStyle}>
                 {children}
             </div>
 
@@ -61,6 +63,7 @@ function ColumnView({
 ColumnView.propTypes = {
     header: PropTypes.node,
     footer: PropTypes.node,
+    flexBody: PropTypes.bool,
     bodyPadding: PropTypes.shape({
         top: PropTypes.number,
         bottom: PropTypes.number,
@@ -72,6 +75,7 @@ ColumnView.propTypes = {
 ColumnView.defaultProps = {
     header: undefined,
     footer: undefined,
+    flexBody: false,
     bodyPadding: { bottom: 24 },
 };
 

--- a/packages/core/src/__tests__/ColumnView.test.js
+++ b/packages/core/src/__tests__/ColumnView.test.js
@@ -2,27 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 
-import ColumnView, { ColumnPart, BEM as COLUMN_BEM } from '../ColumnView';
-
-describe('<ColumnPart>', () => {
-    it('passes every prop to wrapper when children exists', () => {
-        const handleClick = jest.fn();
-        const wrapper = shallow(
-            <ColumnPart className="bar" onClick={handleClick}>
-                Foo Bar
-            </ColumnPart>
-        );
-
-        expect(wrapper.text()).toBe('Foo Bar');
-        expect(wrapper.find('div').prop('className')).toBe('bar');
-        expect(wrapper.find('div').prop('onClick')).toBe(handleClick);
-    });
-
-    it('renders null when children does not exist', () => {
-        const wrapper = shallow(<ColumnPart />);
-        expect(wrapper.type()).toBeNull();
-    });
-});
+import ColumnView, { BEM as COLUMN_BEM } from '../ColumnView';
 
 describe('<ColumnView>', () => {
     it('renders without crashing', () => {
@@ -39,23 +19,41 @@ describe('<ColumnView>', () => {
         expect(wrapper.find(`.${COLUMN_BEM.body}`).text()).toBe('Foo bar');
     });
 
-    it('can override bottom padding on body wrapper', () => {
+    it('can make body a Flexbox', () => {
+        const wrapper = shallow(<ColumnView flexBody>Foo bar</ColumnView>);
+
+        expect(
+            wrapper.find(`.${COLUMN_BEM.body}`).hasClass(
+                COLUMN_BEM.body.modifier('flex').toString({ stripBlock: true })
+            )
+        ).toBeTruthy();
+    });
+
+    it('can override padding on body wrapper', () => {
+        const padding = {
+            top: 1,
+            bottom: 2,
+            left: 3,
+            right: 4,
+        };
         const wrapper = shallow(
-            <ColumnView bottomPadding="0">
+            <ColumnView bodyPadding={padding}>
                 Foo bar
             </ColumnView>
         );
         expect(wrapper.find(`.${COLUMN_BEM.body}`).prop('style')).toEqual({
-            paddingBottom: '0',
+            paddingTop: 1,
+            paddingBottom: 2,
+            paddingLeft: 3,
+            paddingRight: 4,
         });
     });
 
-    it('renders header in a header <ColumnPart>', () => {
+    it('renders header area if "header" prop is given', () => {
         const wrapper = shallow(
             <ColumnView header={<span data-test="header" />} />
         );
         expect(wrapper.find(`.${COLUMN_BEM.header}`)).toHaveLength(1);
-        expect(wrapper.find(`.${COLUMN_BEM.header}`).type()).toBe(ColumnPart);
         expect(
             wrapper
                 .find(`.${COLUMN_BEM.header}`)
@@ -63,12 +61,11 @@ describe('<ColumnView>', () => {
         ).toBeTruthy();
     });
 
-    it('renders footer in a footer <ColumnPart>', () => {
+    it('renders footer area if "footer" prop is given', () => {
         const wrapper = shallow(
             <ColumnView footer={<span data-test="footer" />} />
         );
         expect(wrapper.find(`.${COLUMN_BEM.footer}`)).toHaveLength(1);
-        expect(wrapper.find(`.${COLUMN_BEM.footer}`).type()).toBe(ColumnPart);
         expect(
             wrapper
                 .find(`.${COLUMN_BEM.footer}`)

--- a/packages/core/src/__tests__/Modal.test.js
+++ b/packages/core/src/__tests__/Modal.test.js
@@ -1,118 +1,91 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
-import { BEM, PureModal, ModalContent } from '../Modal';
+import { BEM, PureModal, DefaultHeader } from '../Modal';
+import ColumnView from '../ColumnView';
 import HeaderRow from '../HeaderRow';
 import Overlay from '../Overlay';
+import TextLabel from '../TextLabel';
 
-describe('<PureModal> with mixins', () => {
-    it('should render without crashing', () => {
-        const div = document.createElement('div');
-        const element = <PureModal />;
+describe('<DefaultHeader>', () => {
+    it('renders a center-aligned <TextLabel> inside a <HeaderRow>', () => {
+        const wrapper = shallow(<DefaultHeader title="Foo" />);
 
-        ReactDOM.render(element, div);
+        expect(wrapper.is(HeaderRow)).toBeTruthy();
+        expect(wrapper.prop('center')).toMatchObject(
+            <TextLabel align="center" basic="Foo" />
+        );
     });
 });
 
-describe('Pure <PureModal>', () => {
+describe('Overlay', () => {
     it('contains an <Overlay>', () => {
         const wrapper = shallow(<PureModal />);
 
         expect(wrapper.find(Overlay).exists()).toBeTruthy();
     });
 
-    it('renders class names in response to the size prop', () => {
-        const wrapper = shallow(<PureModal size="small" />);
-        const testSizeProp = (size) => {
-            wrapper.setProps({ size });
-            expect(wrapper.hasClass(
-                BEM.root
-                    .modifier(size)
-                    .toString({ stripBlock: true })
-            )).toBeTruthy();
-        };
+    it("calls 'onClose' on <Overlay> click, and blocks event bubble", () => {
+        const mockedHandleClose = jest.fn();
+        const wrapper = shallow(<PureModal onClose={mockedHandleClose} />);
 
-        testSizeProp('small');
-        testSizeProp('large');
-        testSizeProp('full');
+        const mockedStopPropagation = jest.fn();
+        wrapper.find(Overlay).simulate('click', {
+            stopPropagation: mockedStopPropagation,
+        });
+
+        expect(mockedStopPropagation).toHaveBeenCalled();
+        expect(mockedHandleClose).toHaveBeenCalled();
     });
+});
 
+describe('Rendering', () => {
     it('renders class names in response to the centered prop', () => {
         const wrapper = shallow(<PureModal centered />);
-        expect(wrapper.hasClass(BEM.root.modifier('center').toString({ stripBlock: true }))).toBeTruthy();
+        const expectedClassName = BEM.root.modifier('centered').toString({ stripBlock: true });
+
+        expect(wrapper.hasClass(expectedClassName)).toBeTruthy();
     });
 
-    it('renders class names in response to the bodyPadding prop', () => {
-        const wrapper = mount(<PureModal bodyPadding />);
-        const paddingClass = BEM.body
-            .modifier('padding', true)
-            .toString({ stripBlock: true });
-        expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
-    });
-
-    it('renders content of the modal', () => {
-        const content = <div>TestContent</div>;
-        const wrapper = shallow(<PureModal>{content}</PureModal>);
-        expect(wrapper.contains([content])).toBeTruthy();
-    });
-
-    it('calls handleOverlayClick on Overlay click', () => {
-        const wrapper = mount(<PureModal />);
-        const spy = jest.spyOn(wrapper.instance(), 'handleOverlayClick');
-        wrapper.instance().forceUpdate();
-        wrapper.find(Overlay).simulate('click');
-        expect(spy).toHaveBeenCalled();
-    });
-
-    it('calls onClick on Overlay click if the onClose prop is not null', () => {
-        const mockOnClick = jest.fn();
-        const wrapper = mount(<PureModal onClose={mockOnClick} />);
-        wrapper.instance().forceUpdate();
-        wrapper.find(Overlay).simulate('click');
-        expect(mockOnClick).toHaveBeenCalled();
-    });
-});
-
-describe('<PureModal> with a header row', () => {
-    it('renders a header in response to the header element', () => {
+    it('renders header and children inside a <ColumnView>', () => {
         const header = <HeaderRow />;
-        const wrapper = mount(<PureModal />);
-        const headerClass = `${BEM.header}`;
-        wrapper.setProps({ header });
-        expect(wrapper.find(`.${headerClass}`).exists()).toBeTruthy();
+        const children = <div data-target />;
+
+        const wrapper = shallow(
+            <PureModal header={header}>
+                {children}
+            </PureModal>
+        );
+        const columnViewWrapper = wrapper.find(ColumnView);
+
+        expect(columnViewWrapper.exists()).toBeTruthy();
+        expect(columnViewWrapper.props()).toMatchObject({
+            header,
+            children,
+            className: `${BEM.container}`,
+        });
     });
 
-    it('renders a header with label if the type of header is string', () => {
-        const header = 'foo';
-        const wrapper = mount(<PureModal />);
-        const headerClass = `${BEM.header}`;
-        wrapper.setProps({ header });
-        expect(wrapper.find(`.${headerClass}`).exists()).toBeTruthy();
-    });
-});
+    it('renders a basic <DefaultHeader> if only given String', () => {
+        const wrapper = shallow(
+            <PureModal header="Foo">Bar</PureModal>
+        );
 
-describe('Pure <ModalContent>', () => {
-    it('renders the modal container class name', () => {
-        const wrapper = shallow(<ModalContent />);
-        const containerClass = `${BEM.container}`;
-
-        expect(wrapper.hasClass(containerClass)).toBeTruthy();
+        expect(wrapper.find(ColumnView).prop('header')).toMatchObject(
+            <DefaultHeader title="Foo" />
+        );
     });
 
-    it('should render a padding if the prop bodyPadding is true', () => {
-        const wrapper = shallow(<ModalContent bodyPadding />);
-        const paddingClass = BEM.body
-            .modifier('padding', true)
-            .toString({ stripBlock: true });
-        expect(wrapper.find(`.${paddingClass}`).exists()).toBeTruthy();
-    });
+    it("passes 'flexBody' and 'bodyPadding' props to <ColumnView>", () => {
+        const wrapper = shallow(
+            <PureModal flexBody bodyPadding={{ bottom: 0 }}>
+                <div>Foo</div>
+            </PureModal>
+        );
 
-    it('should not render a padding if the prop bodyPadding is null', () => {
-        const wrapper = shallow(<ModalContent />);
-        const paddingClass = BEM.body
-            .modifier('padding', true)
-            .toString({ stripBlock: true });
-        expect(wrapper.find(`.${paddingClass}`).exists()).toBeFalsy();
+        expect(wrapper.find(ColumnView).props()).toMatchObject({
+            flexBody: true,
+            bodyPadding: { bottom: 0 },
+        });
     });
 });

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -13,6 +13,7 @@ $component: #{$prefix}-column-view;
     // --------------------
     //  Elements
     // --------------------
+
     &__header,
     &__footer {
         flex: 0 0 auto;
@@ -26,6 +27,11 @@ $component: #{$prefix}-column-view;
         flex: 1 1 100%;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
+
+        &--flex {
+            display: flex;
+            flex-direction: column;
+        }
     }
 
     &__footer {

--- a/packages/core/src/styles/ColumnView.scss
+++ b/packages/core/src/styles/ColumnView.scss
@@ -7,7 +7,7 @@ $component: #{$prefix}-column-view;
     background-color: $c-column-bg;
     display: flex;
     flex-direction: column;
-    // when nested under another column view
+    // when placed in another Flexbox
     flex: 1 1 100%;
 
     // --------------------
@@ -20,13 +20,14 @@ $component: #{$prefix}-column-view;
     }
 
     &__header {
-        z-index: 1;
+        z-index: 2;
     }
 
     &__body {
-        flex: 1 1 100%;
+        flex: 1 1 auto;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
+        z-index: 1;
 
         &--flex {
             display: flex;

--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -10,10 +10,8 @@ $component: #{$prefix}-modal;
 // -------------------------------------
 //   Modal Block
 // -------------------------------------
+
 .#{$prefix}-modal {
-    display: flex;
-    justify-content: center;
-    align-items: top;
     position: fixed;
     top: 0;
     bottom: 0;
@@ -21,74 +19,24 @@ $component: #{$prefix}-modal;
     right: 0;
     padding: 10px;
     padding-top: 0;
-    text-align: center;
-    z-index: z("modal");
 }
 
 // -------------------------------------
 //   Modal Elements
 // -------------------------------------
 .#{$prefix}-modal {
-    // Container
     &__container {
-        width: $modal-width-full;
-        height: $modal-height;
-        max-width: $modal-width-base;
+        width: $modal-width;
+        max-width: $modal-max-width;
+        height: auto;
+        min-height: $modal-height;
         max-height: $modal-max-height;
-        margin: 0 auto;
         background-color: $c-bg-light;
-        display: flex;
-        flex-direction: column;
-        position: relative;
         border-radius: 0 0 $modal-border-radius $modal-border-radius;
-        box-shadow: $modal-box-shadow;
-        overflow: hidden;
-        text-align: left;
-        z-index: z("front");
-        transition: width .15s;
-    } // Body
-    &__body {
-        flex: 1 1 auto;
+        margin: 0 auto;
         position: relative;
-        overflow: auto;
-        display: flex;
-        flex-direction: column;
-        padding-bottom: 24px;
-
-        &--padding {
-            padding: 24px;
-        }
-    } // Header
-    &__header {
-        flex: 0 0 auto;
-    } // Footer
-    &__footer {
-        flex: 0 0 auto;
-        padding: 0 24px;
-        text-align: right;
-        border-top: 1px solid $c-modal-border;
-    }
-}
-
-// -------------------------------------
-//   Modal Sizes
-// -------------------------------------
-.#{$prefix}-modal {
-    // Small
-    &--small {
-        .#{$prefix}-modal__container {
-            max-width: $modal-width-small;
-        }
-    } // Large
-    &--large {
-        .#{$prefix}-modal__container {
-            max-width: $modal-width-large;
-        }
-    } // Full
-    &--full {
-        .#{$prefix}-modal__container {
-            max-width: $modal-width-full;
-        }
+        overflow: hidden;
+        animation: anim-slide-down .4s forwards;
     }
 }
 
@@ -96,30 +44,12 @@ $component: #{$prefix}-modal;
 //   Modal Position
 // -------------------------------------
 .#{$prefix}-modal {
-    &--center {
+    &--centered {
+        display: flex;
         align-items: center;
-        padding-top: 10px;
 
         .#{$prefix}-modal__container {
             border-radius: $modal-border-radius;
-        }
-    }
-}
-
-// -------------------------------------
-//   Modal Modifies
-// -------------------------------------
-.#{$prefix}-modal {
-    // Active State
-    &--active {
-        // Backdrop
-        .#{$prefix}-modal__backdrop {
-            opacity: 0;
-            animation: anim-fade-in .3s forwards;
-        } // Container
-        .#{$prefix}-modal__container {
-            opacity: 0;
-            animation: anim-slide-down .4s forwards;
         }
     }
 }
@@ -139,21 +69,8 @@ $component: #{$prefix}-modal;
     #{repeat-str('.#{$prefix}-base-layer ~', $i)} .#{$prefix}-base-layer {
         .#{$prefix}-modal {
             &__container {
-                width: calc(#{$modal-width-full} - #{$i * 16}px);
-                max-width: $modal-width-base - $i * 16px;
-                height: $modal-height - $i * 8px;
-            }
-
-            &--large {
-                > .#{$prefix}-modal__container {
-                    max-width: $modal-width-large - $i * 16px;
-                }
-            }
-
-            &--small {
-                > .#{$prefix}-modal__container {
-                    max-width: $modal-width-small - $i * 16px;
-                }
+                width: $modal-width - $i * 64px;
+                height: $modal-height - $i * 32px;
             }
         }
     }

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -101,12 +101,10 @@ $popover-bottom-padding: 16px;
 $popover-border-radius: 8px;
 $popover-drop-shadow: 0 2px 3px hsba(0, 0, 0, 40);
 
-$modal-width-small:      320px;
-$modal-width-base:       640px;
-$modal-width-large:      960px;
-$modal-width-full:       90%;
-$modal-height:           480px;
-$modal-max-height:       80vh;
+$modal-width:      720px;
+$modal-max-width:  90%;
+$modal-height:     480px;
+$modal-max-height: 90%;
 $modal-border-radius:    $popover-border-radius;
 $modal-box-shadow:       $poup-box-shadow;
 $modal-indent-layer-max: 7;

--- a/packages/core/src/utils/wrapIfNotElement.js
+++ b/packages/core/src/utils/wrapIfNotElement.js
@@ -3,12 +3,6 @@ import React from 'react';
 /**
  * Wrap the passed-in `content` with a component if it's not a React element,
  * to make sure the result will always be a HTML tag.
- *
- * @param {ReactChildren} content
- * @param {Component} Wrapper
- * @param {String} prop - pass `content` into specified `prop`. Default via 'children'.
- *
- * @return {Element}
  */
 function wrapIfNotElement(content, {
     with: Wrapper,

--- a/packages/storybook/examples/core/Modal/ClosableModalExample.js
+++ b/packages/storybook/examples/core/Modal/ClosableModalExample.js
@@ -1,20 +1,12 @@
 import React, { PureComponent } from 'react';
 import { action } from '@storybook/addon-actions';
+
+import Button from '@ichef/gypcrete/src/Button';
 import Modal from '@ichef/gypcrete/src/Modal';
+
 import ModalHeader from './ModalHeader';
 
-
-function BasicModalExample({ children, ...props }) {
-    return (
-        <Modal {...props}>
-            <div>
-                {children}
-            </div>
-        </Modal>
-    );
-}
-
-class ClosableModalExample extends PureComponent {
+export default class ClosableModalExample extends PureComponent {
     state ={
         modalOpen: true
     };
@@ -36,20 +28,32 @@ class ClosableModalExample extends PureComponent {
         );
 
         if (!modalOpen) {
-            return null;
+            return (
+                <div>
+                    <Button
+                        solid
+                        color="blue"
+                        onClick={this.handleModalOpen}
+                        style={{ display: 'inline-block' }}
+                    >
+                        Open Modal
+                    </Button>
+                </div>
+            );
         }
 
         return (
-            <BasicModalExample
+            <Modal
                 header={header}
                 onClose={this.handleModalClose}
-                bodyPadding
-                {...this.props} />
+            >
+                Modal content
+            </Modal>
         );
     }
 }
 
-const MulitpleClosableModalExample = (props) => {
+export const MulitpleClosableModalExample = (props) => {
     const { depth, modalProp } = props;
     if (depth === 0) {
         return false;
@@ -61,6 +65,3 @@ const MulitpleClosableModalExample = (props) => {
         </ClosableModalExample>
     );
 };
-
-export { ClosableModalExample, MulitpleClosableModalExample };
-export default BasicModalExample;

--- a/packages/storybook/examples/core/Modal/index.js
+++ b/packages/storybook/examples/core/Modal/index.js
@@ -3,65 +3,51 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import Modal, { PureModal } from '@ichef/gypcrete/src/Modal';
-import getPropTables from 'utils/getPropTables';
+import { getAddonOptions } from 'utils/getPropTables';
 
-import BasicModalExample, { ClosableModalExample, MulitpleClosableModalExample } from './BasicModal';
+import ContainsColumnView from '../SplitView/ContainsColumnView';
+import ClosableModalExample, { MulitpleClosableModalExample } from './ClosableModalExample';
 
 storiesOf('@ichef/gypcrete|Modal', module)
+    .addDecorator(withInfo)
     .add(
-        'basic usage',
-        withInfo()(() => (
-            <BasicModalExample bodyPadding>
-                Modal Content
-            </BasicModalExample>
-        ))
+        'basic modal',
+        () => (
+            <Modal header="Basic modal">
+                Hello World!
+            </Modal>
+        )
     )
     .add(
-        'small modal',
-        withInfo()(() => (
-            <BasicModalExample bodyPadding size="small" header="Small Modal">
-                Modal Content
-            </BasicModalExample>
-        ))
+        'closable modal',
+        () => <ClosableModalExample />
     )
     .add(
-        'large modal',
-        withInfo()(() => (
-            <BasicModalExample bodyPadding size="large" header="Large Modal">
-                Modal Content
-            </BasicModalExample>
-        ))
+        'with <SplitView>',
+        () => (
+            <Modal header="With <SplitView>" flexBody bodyPadding={{ bottom: 0 }}>
+                <ContainsColumnView />
+            </Modal>
+        )
     )
     .add(
-        'full modal',
-        withInfo()(() => (
-            <BasicModalExample bodyPadding size="full" header="Full Modal">
-                Modal Content
-            </BasicModalExample>
-        ))
+        'centered modal',
+        () => (
+            <Modal header="Vertically-centered modal">
+                Hello World!
+            </Modal>
+        )
     )
-    .add('closable modal', withInfo()(() => <ClosableModalExample />))
-    .add(
-        'closable overlaying modals',
-        withInfo()(() => (
-            <ClosableModalExample size="large">
-                <div>Outer Modal</div>
-                <ClosableModalExample size="small">
-                    <div>Inner Modal</div>
-                </ClosableModalExample>
-            </ClosableModalExample>
-        ))
-    )
-    .add('centered modal', withInfo()(() => (
-        <BasicModalExample bodyPadding centered>
-            Modal Content
-        </BasicModalExample>
-    )))
     .add(
         'multiple layer modals',
-        withInfo('Indented with 8px from each side for each layer. When number of layer > 7 we won\'t indent it')(() => (
-            <MulitpleClosableModalExample depth={8} />
-        ))
+        () => <MulitpleClosableModalExample depth={10} />,
+        {
+            info: 'Indented with 32px from each side for each layer. When number of layer > 7 we won\'t indent it',
+        }
     )
     // Props table
-    .add('props', getPropTables([PureModal, Modal]));
+    .add(
+        'props',
+        () => <div />,
+        { info: getAddonOptions([PureModal, Modal]) }
+    );

--- a/packages/storybook/examples/core/SplitView/BasicUsage.js
+++ b/packages/storybook/examples/core/SplitView/BasicUsage.js
@@ -3,32 +3,29 @@ import React from 'react';
 import SplitView from '@ichef/gypcrete/src/SplitView';
 import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
 
-import DebugBox from 'utils/DebugBox';
 import ColoredBox from 'utils/ColoredBox';
 
 function BasicUsage() {
     return (
-        <DebugBox width="40rem" height="24rem">
-            <SplitView>
-                <SplitViewColumn>
-                    <ColoredBox
-                        width="100%"
-                        height="30rem"
-                        color="rgb(255, 235, 235)">
-                        Narrow Column
-                    </ColoredBox>
-                </SplitViewColumn>
+        <SplitView>
+            <SplitViewColumn>
+                <ColoredBox
+                    width="100%"
+                    height="30rem"
+                    color="rgb(255, 235, 235)">
+                    Narrow Column
+                </ColoredBox>
+            </SplitViewColumn>
 
-                <SplitViewColumn wide>
-                    <ColoredBox
-                        width="100%"
-                        height="30rem"
-                        color="rgb(235, 245, 255)">
-                        Narrow Column
-                    </ColoredBox>
-                </SplitViewColumn>
-            </SplitView>
-        </DebugBox>
+            <SplitViewColumn wide>
+                <ColoredBox
+                    width="100%"
+                    height="30rem"
+                    color="rgb(235, 245, 255)">
+                    Narrow Column
+                </ColoredBox>
+            </SplitViewColumn>
+        </SplitView>
     );
 }
 

--- a/packages/storybook/examples/core/SplitView/ContainsColumnView.js
+++ b/packages/storybook/examples/core/SplitView/ContainsColumnView.js
@@ -3,38 +3,35 @@ import React from 'react';
 import SplitView from '@ichef/gypcrete/src/SplitView';
 import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
 
-import DebugBox from 'utils/DebugBox';
 import ColoredBox from 'utils/ColoredBox';
 
 import DemoColumnView from './DemoColumnView';
 
 function ContainsColumnView() {
     return (
-        <DebugBox width="40rem" height="24rem">
-            <SplitView>
-                <SplitViewColumn>
-                    <DemoColumnView>
-                        <ColoredBox
-                            width="100%"
-                            height="30rem"
-                            color="rgb(255, 235, 235)">
-                            Narrow Column
-                        </ColoredBox>
-                    </DemoColumnView>
-                </SplitViewColumn>
+        <SplitView>
+            <SplitViewColumn>
+                <DemoColumnView>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(255, 235, 235)">
+                        Narrow Column
+                    </ColoredBox>
+                </DemoColumnView>
+            </SplitViewColumn>
 
-                <SplitViewColumn wide>
-                    <DemoColumnView>
-                        <ColoredBox
-                            width="100%"
-                            height="30rem"
-                            color="rgb(235, 245, 255)">
-                            Narrow Column
-                        </ColoredBox>
-                    </DemoColumnView>
-                </SplitViewColumn>
-            </SplitView>
-        </DebugBox>
+            <SplitViewColumn wide>
+                <DemoColumnView>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(235, 245, 255)">
+                        Narrow Column
+                    </ColoredBox>
+                </DemoColumnView>
+            </SplitViewColumn>
+        </SplitView>
     );
 }
 

--- a/packages/storybook/examples/core/SplitView/InsideColumnView.js
+++ b/packages/storybook/examples/core/SplitView/InsideColumnView.js
@@ -11,7 +11,7 @@ import DemoColumnView from './DemoColumnView';
 function InsideColumnView() {
     return (
         <DebugBox width="40rem" height="24rem">
-            <DemoColumnView bottomPadding="0">
+            <DemoColumnView bodyPadding={{ bottom: 0 }}>
                 <SplitView>
                     <SplitViewColumn>
                         <ColoredBox

--- a/packages/storybook/examples/core/SplitView/InsideColumnView.js
+++ b/packages/storybook/examples/core/SplitView/InsideColumnView.js
@@ -3,36 +3,33 @@ import React from 'react';
 import SplitView from '@ichef/gypcrete/src/SplitView';
 import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
 
-import DebugBox from 'utils/DebugBox';
 import ColoredBox from 'utils/ColoredBox';
 
 import DemoColumnView from './DemoColumnView';
 
 function InsideColumnView() {
     return (
-        <DebugBox width="40rem" height="24rem">
-            <DemoColumnView bodyPadding={{ bottom: 0 }}>
-                <SplitView>
-                    <SplitViewColumn>
-                        <ColoredBox
-                            width="100%"
-                            height="30rem"
-                            color="rgb(255, 235, 235)">
-                            Narrow Column
-                        </ColoredBox>
-                    </SplitViewColumn>
+        <DemoColumnView bodyPadding={{ bottom: 0 }}>
+            <SplitView>
+                <SplitViewColumn>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(255, 235, 235)">
+                        Narrow Column
+                    </ColoredBox>
+                </SplitViewColumn>
 
-                    <SplitViewColumn wide>
-                        <ColoredBox
-                            width="100%"
-                            height="30rem"
-                            color="rgb(235, 245, 255)">
-                            Narrow Column
-                        </ColoredBox>
-                    </SplitViewColumn>
-                </SplitView>
-            </DemoColumnView>
-        </DebugBox>
+                <SplitViewColumn wide>
+                    <ColoredBox
+                        width="100%"
+                        height="30rem"
+                        color="rgb(235, 245, 255)">
+                        Narrow Column
+                    </ColoredBox>
+                </SplitViewColumn>
+            </SplitView>
+        </DemoColumnView>
     );
 }
 

--- a/packages/storybook/examples/core/SplitView/index.js
+++ b/packages/storybook/examples/core/SplitView/index.js
@@ -1,8 +1,11 @@
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import SplitView from '@ichef/gypcrete/src/SplitView';
 import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
+
+import DebugBox from 'utils/DebugBox';
 import getPropTables from 'utils/getPropTables';
 
 import BasicUsage from './BasicUsage';
@@ -10,7 +13,14 @@ import ContainsColumnView from './ContainsColumnView';
 import InsideColumnView from './InsideColumnView';
 
 storiesOf('@ichef/gypcrete|SplitView', module)
-    .add('basic usage', withInfo()(BasicUsage))
-    .add('contains <ColumnView>', withInfo()(ContainsColumnView))
-    .add('inside <ColumnView>', withInfo()(InsideColumnView))
+    .addDecorator(storyFn => (
+        <DebugBox width="40rem" height="24rem">
+            {storyFn()}
+        </DebugBox>
+    ))
+    .addDecorator(withInfo)
+
+    .add('basic usage', BasicUsage)
+    .add('contains <ColumnView>', ContainsColumnView)
+    .add('inside <ColumnView>', InsideColumnView)
     .add('props', getPropTables([SplitView, SplitViewColumn]));

--- a/packages/storybook/examples/core/SplitView/index.js
+++ b/packages/storybook/examples/core/SplitView/index.js
@@ -6,21 +6,33 @@ import SplitView from '@ichef/gypcrete/src/SplitView';
 import SplitViewColumn from '@ichef/gypcrete/src/SplitViewColumn';
 
 import DebugBox from 'utils/DebugBox';
-import getPropTables from 'utils/getPropTables';
+import { getAddonOptions } from 'utils/getPropTables';
 
 import BasicUsage from './BasicUsage';
 import ContainsColumnView from './ContainsColumnView';
 import InsideColumnView from './InsideColumnView';
 
 storiesOf('@ichef/gypcrete|SplitView', module)
-    .addDecorator(storyFn => (
-        <DebugBox width="40rem" height="24rem">
-            {storyFn()}
-        </DebugBox>
-    ))
+    .addDecorator((storyFn, { parameters = {} }) => {
+        if (parameters.debugBox === false) {
+            return storyFn();
+        }
+        return (
+            <DebugBox width="40rem" height="24rem">
+                {storyFn()}
+            </DebugBox>
+        );
+    })
     .addDecorator(withInfo)
 
     .add('basic usage', BasicUsage)
     .add('contains <ColumnView>', ContainsColumnView)
     .add('inside <ColumnView>', InsideColumnView)
-    .add('props', getPropTables([SplitView, SplitViewColumn]));
+    .add(
+        'props',
+        () => <div />,
+        {
+            info: getAddonOptions([SplitView, SplitViewColumn]),
+            debugBox: false,
+        }
+    );

--- a/packages/storybook/utils/getPropTables.js
+++ b/packages/storybook/utils/getPropTables.js
@@ -6,11 +6,17 @@ const DEFAULT_OPTIONS = {
 };
 const EMPTY_COMPONENT = () => <div />;
 
-function getPropTables(components = [], options = {}) {
-    return withInfo({
+export function getAddonOptions(components = []) {
+    return {
         ...DEFAULT_OPTIONS,
-        ...options,
         propTables: components,
+    };
+}
+
+function getPropTables(components, options = {}) {
+    return withInfo({
+        ...getAddonOptions(components),
+        ...options,
     })(EMPTY_COMPONENT);
 }
 


### PR DESCRIPTION
# Purpose

The primary goal is to replace the inner layout of `<Modal>` with `<ColumnView>`.
It should turn on momentum scrolling on iPads, as well as a default bottom padding.

# Changes

### Breaking

- [Core] The `bottomPadding` prop is removed. Please use `bodyPadding` prop and pass an object instead.
- [Core] `<Modal>` is refactored to render a `<ColumnView>` as its inner layout.
- [Core] `<Modal>` no longer takes `size`  and `bodyClassName` props.
- [Core] `<Modal bodyPadding>` prop now takes the same object and is passed to `<ColumnView>`.

### Other changes
- [Storybook] Examples for `<SplitView>` is refactored so they can be reused.

<img width="774" alt="螢幕快照 2019-09-02 上午11 49 26" src="https://user-images.githubusercontent.com/365035/64089246-bd2a9e80-cd77-11e9-9cfe-45cf50494044.png">
