### PR TITLE
Change exported module types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules/
 coverage/
 lib/
 dist/
-es5/
+es/
 build/
 deploy/
 public/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - [Core] [Form] [ImageEditor] Peer dependency changes:
   * Change from `@babel/runtime-corejs2` to `@babel/runtime-corejs3`.
+- [Core] [Form] [ImageEditor] now exports CommonJS modules via "main" and ES modules via "module" field in `package.json`.
 - [Core] `<ColumnView>`:
   * The `bottomPadding` prop is removed. Please use `bodyPadding` prop and pass an object instead.
 - [Core] `<Modal>`:

--- a/babel.config.js
+++ b/babel.config.js
@@ -20,14 +20,14 @@ module.exports = {
             // Environment for Webpack. Empty for now.
             // Module: CommonJS
         },
-        es5: {
+        lib: {
             // Module: CommonJS
             plugins: [
                 'babel-plugin-strip-css-imports',
             ],
             ignore: ['**/__tests__/*'],
         },
-        lib: {
+        es: {
             // Module: ES Module
             presets: [
                 ['@babel/preset-env', { modules: false }],

--- a/configs/.eslintignore
+++ b/configs/.eslintignore
@@ -1,7 +1,7 @@
 node_modules/
 coverage/
 dist/
-es5/
+es/
 lib/
 public/
 !.storybook/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,20 +13,21 @@
     "npm": ">= 3.10.10"
   },
   "main": "lib/index.js",
+  "module": "es/index.js",
   "files": [
     "dist/",
     "lib/",
-    "es5/",
+    "es/",
     "README.md",
     "package.json"
   ],
   "scripts": {
     "prepublish": "npm run clean && npm run build",
-    "build": "npm run build:dist && npm run build:lib && npm run build:es5",
+    "build": "npm run build:dist && npm run build:lib && npm run build:es",
     "build:dist": "webpack --config ./configs/webpack.dist.js --color",
     "build:lib": "BABEL_ENV=lib babel src --root-mode=upward --out-dir lib",
-    "build:es5": "BABEL_ENV=es5 babel src --root-mode=upward --out-dir es5",
-    "clean": "rm -rf ./dist ./lib ./es5 ./deploy"
+    "build:es": "BABEL_ENV=es babel src --root-mode=upward --out-dir es",
+    "clean": "rm -rf ./dist ./lib ./es ./deploy"
   },
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.4.4",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -13,20 +13,21 @@
     "npm": ">= 3.10.10"
   },
   "main": "lib/index.js",
+  "module": "es/index.js",
   "files": [
     "dist/",
     "lib/",
-    "es5/",
+    "es/",
     "README.md",
     "package.json"
   ],
   "scripts": {
     "prepublish": "npm run clean && npm run build",
-    "build": "npm run build:dist && npm run build:lib && npm run build:es5",
+    "build": "npm run build:dist && npm run build:lib && npm run build:es",
     "build:dist": "webpack --config ../../configs/webpack.dist.js --color",
     "build:lib": "BABEL_ENV=lib babel src --root-mode=upward --out-dir=lib",
-    "build:es5": "BABEL_ENV=es5 babel src --root-mode=upward --out-dir es5",
-    "clean": "rm -rf ./dist ./lib ./es5 ./deploy"
+    "build:es": "BABEL_ENV=es babel src --root-mode=upward --out-dir es",
+    "clean": "rm -rf ./dist ./lib ./es ./deploy"
   },
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.4.4",

--- a/packages/imageeditor/package.json
+++ b/packages/imageeditor/package.json
@@ -13,20 +13,21 @@
     "npm": ">= 3.10.10"
   },
   "main": "lib/index.js",
+  "module": "es/index.js",
   "files": [
     "dist/",
     "lib/",
-    "es5/",
+    "es/",
     "README.md",
     "package.json"
   ],
   "scripts": {
     "prepublish": "npm run clean && npm run build",
-    "build": "npm run build:dist && npm run build:lib && npm run build:es5",
+    "build": "npm run build:dist && npm run build:lib && npm run build:es",
     "build:dist": "webpack --config ../../configs/webpack.dist.js --color",
     "build:lib": "BABEL_ENV=lib babel src --root-mode=upward --out-dir lib",
-    "build:es5": "BABEL_ENV=es5 babel src --root-mode=upward --out-dir es5",
-    "clean": "rm -rf ./dist ./lib ./es5"
+    "build:es": "BABEL_ENV=es babel src --root-mode=upward --out-dir es",
+    "clean": "rm -rf ./dist ./lib ./es"
   },
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.4.4",


### PR DESCRIPTION
# Purpose

All packages now instead exports CommonJS modules via `"main"` field in `package.json`, while still providing ES modules via `"module"` field.

This follows the convention of bundling tools like Webpack, which tends to look for ES modules via `"module"` field before obtaining from `"main`".

# Reference
- https://webpack.js.org/configuration/resolve/#resolvemainfields