### PR TITLE
Fix anchored popover top position when document is scrollable

### DIFF
--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -85,7 +85,7 @@ it('intercepts event propagation if instructed', () => {
             <ClosableFoo closable={{ stopEventPropagation: true }} />
         </div>
     );
-    wrapper.find('div#foo').simulate('click');
+    wrapper.find('div.gyp-closable').simulate('click');
     expect(handleClick).not.toHaveBeenCalled();
 
     wrapper = mount(
@@ -94,7 +94,7 @@ it('intercepts event propagation if instructed', () => {
         </div>
     );
 
-    wrapper.find('div#foo').simulate('click');
+    wrapper.find('div.gyp-closable').simulate('click');
     expect(handleClick).toHaveBeenCalled();
 });
 

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -131,14 +131,17 @@ const closable = ({
             } = this.props;
 
             return (
-                <div
-                    role="presentation"
-                    className={ROOT_BEM.toString()}
-                    onClick={this.handleOuterLayerClick}>
+                <>
+                    <div
+                        role="presentation"
+                        className={ROOT_BEM.toString()}
+                        onClick={this.handleOuterLayerClick}
+                    />
                     <WrappedComponent
                         onInsideClick={this.handleInsideClick}
-                        {...otherProps} />
-                </div>
+                        {...otherProps}
+                    />
+                </>
             );
         }
     }


### PR DESCRIPTION
# Purpose

As title. In #249 I mentioned this bug.

Anchored popover is a <Popover> wrapped with two HOCs:
`closable()(anchored()(Popover)`

Before this commit it will form following DOM structure:

```html
<body>
  <div class="gyp-base-layer">
    <div class="gyp-closable>
      <div class="gyp-popover gyp-popover--top">
    </div>
  </div>
</body>
```

`gyp-popover` is absolutely positioned, with `top` value which
is relative to its document top left corner. `gyp-closable` is
`position: fixed` with `width: 100vw` and `height: 100vh`.

It works when document is too short to scroll, such as previous
storybook doc canvas. But when the element triggering popover is
over the screen(i.e. we have to scroll to click it), the position
of anchored popover will be wrong because the `position: absoulte`
of `gyp-popover` is relative to `gyp-closable`, which is
`position: fixed`, so the `top` value is wrong.

The position of `gyp-popover` should always be relative to the
document. So in this fix we change the `closable` HOC code to change
DOM structure as:

```html
<body>
  <div class="gyp-base-layer">
    <div class="gyp-closable" />
    <div class="gyp-popover" />
  </div>
</body>
```

Let the `gyp-popover` be relative to `gyp-base-layer`, which is absolute
to `document.body`.

Note that this bug won't happen on Cloud2 since on Cloud2 the
`document.body` height is always `100vh`, which is not scrollable. 
And, this fix only affect `<Popover>` component because currently
only `<Popover>` using the `closable` mixin.

# Changes

- change `/packages/core/src/mixins/closable/` DOM structure.
- change closable `intercepts event propagation if instructed` test to match the fix.

## UI screenshots

You can verify them in popover storybook doc on `feature/core-docs-pt4` and this branch respectively.

Before the fix:

![螢幕快照 2020-02-10 上午11 48 03](https://user-images.githubusercontent.com/7620906/74120236-8ba6e080-4bfd-11ea-8f89-b6d58618a792.png)

After the fix:

![螢幕快照 2020-02-10 上午11 44 10](https://user-images.githubusercontent.com/7620906/74120244-92355800-4bfd-11ea-8f87-f1bf02610ac1.png)


# Risk

Might influence cloud2 popover UI. Though I have manually tested this and it looks fine.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
