### PR TITLE
Fix centered modal width

### DIFF
--- a/packages/core/src/styles/Modal.scss
+++ b/packages/core/src/styles/Modal.scss
@@ -50,6 +50,8 @@ $component: #{$prefix}-modal;
 
         .#{$prefix}-modal__container {
             border-radius: $modal-border-radius;
+            flex-basis: $modal-width;
+            flex-grow: 0;
         }
     }
 }


### PR DESCRIPTION
# Purpose

Asana: https://app.asana.com/0/347798529122928/1161341114084393

This fix that when centering modal (`<Modal centered />`) the modal width is too wide. Also see https://github.com/iCHEF/gypcrete/pull/248#discussion_r375179006

# Changes

- `Modal.scss`. Define centered modal flex-basis and flex-grow.

# Risk

None. Since on cloud2 there's no centered modal

# UI screenshots

## Before

![螢幕快照 2020-02-11 下午4 28 27](https://user-images.githubusercontent.com/7620906/74221155-6775fd00-4cec-11ea-8897-42b5dc13e7d6.png)

## After

![螢幕快照 2020-02-11 下午4 27 48](https://user-images.githubusercontent.com/7620906/74221175-7066ce80-4cec-11ea-8f87-e7f718e1eed5.png)


# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
