### PR TITLE
Better supporting for nested list styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+- [Core] Update `<ListRow>` & `<List>` styles for supporting nested list better. (#257)
 
 ## [4.1.0]
 

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -34,25 +34,30 @@ function List({
     children,
     ...otherProps
 }) {
-    const bemClass = BEM.root.modifier(variant);
-    const rootClassName = classNames(bemClass.toString(), className);
-
     return (
         <ListSpacingContext.Consumer>
-            {spacing => (
-                <Section
-                    className={rootClassName}
-                    title={title}
-                    titleSize={titleSize}
-                    desc={desc}
-                    bodySpacing={false}
-                    verticalSpacing={spacing}
-                    {...otherProps}>
-                    <ul className={BEM.body.toString()}>
-                        {children}
-                    </ul>
-                </Section>
-            )}
+            {(spacing) => {
+                const bemClass = BEM.root
+                    .modifier(variant)
+                    .modifier('sm-margin-bottom', !spacing && !!title)
+                    .modifier('nested-indent', !spacing);
+
+                const rootClassName = classNames(bemClass.toString(), className);
+                return (
+                    <Section
+                        className={rootClassName}
+                        title={title}
+                        titleSize={titleSize}
+                        desc={desc}
+                        bodySpacing={false}
+                        verticalSpacing={spacing || !!title}
+                        {...otherProps}>
+                        <ul className={BEM.body.toString()}>
+                            {children}
+                        </ul>
+                    </Section>
+                );
+            }}
         </ListSpacingContext.Consumer>
     );
 }

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -40,7 +40,6 @@ function List({
                 const bemClass = BEM.root
                     .modifier(variant)
                     .modifier('sm-margin-bottom', !spacing && !!title)
-                    .modifier('nested-indent', !spacing);
 
                 const rootClassName = classNames(bemClass.toString(), className);
                 return (

--- a/packages/core/src/List.js
+++ b/packages/core/src/List.js
@@ -39,7 +39,7 @@ function List({
             {(spacing) => {
                 const bemClass = BEM.root
                     .modifier(variant)
-                    .modifier('sm-margin-bottom', !spacing && !!title)
+                    .modifier('sm-margin-bottom', !spacing && !!title);
 
                 const rootClassName = classNames(bemClass.toString(), className);
                 return (

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -21,6 +21,7 @@ export const BEM = {
     root: ROOT_BEM,
     body: ROOT_BEM.element('body'),
     footer: ROOT_BEM.element('footer'),
+    nestedListWrapper: ROOT_BEM.element('nested-list-wrapper')
 };
 
 class ListRow extends PureComponent {
@@ -81,13 +82,20 @@ class ListRow extends PureComponent {
 
         return (
             <ListSpacingContext.Provider value={false}>
-                <li className={rootClassName} {...wrapperProps}>
-                    <div className={BEM.body.toString()}>
-                        {children}
+                <li>
+                    <div className={rootClassName} {...wrapperProps}>
+                        <div className={BEM.body.toString()}>
+                            {children}
+                        </div>
+                        {this.renderFooter()}
                     </div>
-                    {this.renderFooter()}
-                    {nestedList}
+                    {nestedList && (
+                        <div className={BEM.nestedListWrapper.toString()}>
+                            {nestedList}
+                        </div>
+                    )}
                 </li>
+
             </ListSpacingContext.Provider>
         );
     }

--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -95,7 +95,6 @@ class ListRow extends PureComponent {
                         </div>
                     )}
                 </li>
-
             </ListSpacingContext.Provider>
         );
     }

--- a/packages/core/src/__tests__/ListRow.test.js
+++ b/packages/core/src/__tests__/ListRow.test.js
@@ -53,7 +53,7 @@ it('handles highlight modifier', () => {
     const wrapper = shallow(<ListRow highlight>Foo</ListRow>);
     const expectedClassName = ROW_BEM.root.modifier('highlight').toString();
 
-    expect(wrapper.find('li').hasClass(expectedClassName)).toBeTruthy();
+    expect(wrapper.find('li').find('div').first().hasClass(expectedClassName)).toBeTruthy();
 });
 
 it('renders nested item inside <li> but outside of body wrapper', () => {

--- a/packages/core/src/styles/List.scss
+++ b/packages/core/src/styles/List.scss
@@ -34,4 +34,8 @@ $component: #{$prefix}-list;
     &--button {
         // #TODO: implement button list
     }
+
+    &--sm-margin-bottom {
+        margin-bottom: rem($section-top-margin);
+    }
 }

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -75,3 +75,7 @@ $component: #{$prefix}-list-row;
         }
     }
 }
+
+.#{$component} + .#{$component}__nested-list-wrapper {
+    margin-left: rem($list-nested-indent);
+}

--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -77,6 +77,7 @@ $section-bottom-margin: 48px;
 $section-horizontal-padding: 16px;
 
 $list-border-radius: 8px;
+$list-nested-indent: 16px;
 
 $list-row-padding-horizontal: 16px;
 $list-row-padding-vertical: 4px;

--- a/packages/storybook/examples/core/List.stories.js
+++ b/packages/storybook/examples/core/List.stories.js
@@ -136,3 +136,43 @@ export function NestedList() {
         </DebugBox>
     );
 }
+
+export function NestedListWithTitle() {
+    const nestedList2nd = (
+        <List title="List Title 2">
+            <ListRow>
+                <TextLabel icon="inventory-item" basic="Nested A" />
+            </ListRow>
+            <ListRow>
+                <TextLabel icon="inventory-item" basic="Nested B" />
+            </ListRow>
+            <ListRow>
+                <TextLabel icon="inventory-item" basic="Nested C" />
+            </ListRow>
+        </List>
+    );
+
+    const nestedList1st = (
+        <List title="List Title">
+            <ListRow>
+                <TextLabel icon="printer" basic="3rd nested I" />
+            </ListRow>
+            <ListRow nestedList={nestedList2nd}>
+                <TextLabel icon="printer" basic="3rd nested II" />
+            </ListRow>
+        </List>
+    );
+
+    return (
+        <DebugBox width="30rem">
+            <List variant="normal" title="List title">
+                <ListRow>
+                    <TextLabel icon="tickets" basic="Hello World" />
+                </ListRow>
+                <ListRow nestedList={nestedList1st}>
+                    <TextLabel icon="tickets" basic="Row 2" />
+                </ListRow>
+            </List>
+        </DebugBox>
+    );
+}


### PR DESCRIPTION
# Purpose
調整 `<List>` & `<ListRow>` 以更好的解決 nested list 時的樣式顯示
由於 nested list 搬出原本 list row body 之外了，所以 hover 樣式重疊的問題也一併被解決

## Nested 的 `<List>` 沒有 `title` prop 時：
縮排且上下 `margin` 自動消失
![image](https://user-images.githubusercontent.com/6021943/74917729-f4166e80-5402-11ea-806b-df8269f2b3bd.png)

## Nested 的 `<List>` 有 `title` prop 時：
縮排且上下 `margin` 自動都變成 1.5 rem (預設 `margin-bottom` 為 3rem)
![image](https://user-images.githubusercontent.com/6021943/74917746-fc6ea980-5402-11ea-87a7-72c39d205fe5.png)

# Changes
- [Core] Update `<ListRow>` & `<List>` styles for supporting nested list better.

# Risk
none.
