### PR TITLE
Fix formRow did not merge rowProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Changed
 - [Core] Update `<ListRow>` & `<List>` styles for supporting nested list better. (#257)
+- [Core] Fix `rowProps` used to be replaced in mixin `formRow`.(#258)
 
 ## [4.1.0]
 

--- a/packages/form/src/mixins/__tests__/formRow.test.js
+++ b/packages/form/src/mixins/__tests__/formRow.test.js
@@ -71,6 +71,31 @@ it('passes a collected rowProps prop to wrapped component', () => {
     });
 });
 
+
+it('passes a custom rowProps prop to wrapped component', () => {
+    const wrapper = shallow(
+        <FormRowFoo
+            desc="foo"
+            rowProps={{
+                status: 'success'
+            }}
+            status="error"
+            errorMsg="bar" />
+    );
+    const fooProps = wrapper.find(Foo).props();
+
+    expect(fooProps).not.toHaveProperty('desc');
+    expect(fooProps).not.toHaveProperty('status');
+    expect(fooProps).not.toHaveProperty('errorMsg');
+
+    expect(fooProps.rowProps).toMatchObject({
+        desc: 'foo',
+        status: 'success',
+        errorMsg: 'bar',
+    });
+});
+
+
 it('can optionally keep a ref to wrapped component', () => {
     const wrapper = mount(<FormRowBarWithRef />);
 

--- a/packages/form/src/mixins/formRow.js
+++ b/packages/form/src/mixins/formRow.js
@@ -47,16 +47,11 @@ const formRow = ({
                 status,
                 statusOptions,
                 errorMsg,
+                rowProps,
                 ...otherProps
             } = this.props;
 
             const ineditable = disabled || readOnly;
-            const rowProps = {
-                desc,
-                status,
-                statusOptions,
-                errorMsg,
-            };
 
             return (
                 <WrappedComponent
@@ -64,7 +59,13 @@ const formRow = ({
                     ineditable={ineditable}
                     disabled={disabled}
                     readOnly={readOnly}
-                    rowProps={rowProps}
+                    rowProps={{
+                        desc,
+                        status,
+                        statusOptions,
+                        errorMsg,
+                        ...rowProps,
+                    }}
                     {...otherProps} />
             );
         }


### PR DESCRIPTION
# Purpose
- Asana: https://app.asana.com/0/347798529122928/1163674165898705
- 在使用 SelectRow 傳入 rowProps 時，由於 prop 名稱相同，會直接把 mixin 原本計算的 rowProps 覆蓋掉，應該修正這個行為，改成 merge props

# Changes
- 在 mixin 中 將 rowProps 做 merge，並且讓傳入 mixin 中的 rowProps 優先權高於 mixin 計算的 rowProps。(這部分直接看測試情境應該會比較清楚)
