### PR TITLE
Fix deploy script to push tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- [Build] Fix deploy script to push back converted tags; bump minor for canary builds. (#261)
+
 ## [4.2.0]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bumpversion": "lerna version --no-git-tag-version --no-push",
     "release": "lerna publish from-package",
     "release:pre": "lerna publish --dist-tag=prerelease",
-    "release:canary": "lerna publish --canary --force-publish --exact",
+    "release:canary": "lerna publish --canary minor --force-publish --exact",
     "ghpages": "lerna run ghpages",
     "lint": "npm run lint:eslint && npm run lint:stylelint",
     "lint:eslint": "eslint ./packages --ignore-path=configs/.eslintignore ./",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,11 @@ echo "Publishing ${TRAVIS_TAG}"
 
 # convert lightweight tag to annotated tag so Lerna can use it
 git tag -a -f -m "${TRAVIS_TAG}" "${TRAVIS_TAG}" "${TRAVIS_TAG}"
-git push --force origin "${TRAVIS_TAG}"
+
+# push back tags
+git remote add tags-origin "https://ichefbot:${GH_TOKEN}@${GH_REPO}"
+git push --force tags-origin "${TRAVIS_TAG}"
+git remote remove tags-origin
 
 # publish to npm
 yarn release --yes --ignore-prepublish


### PR DESCRIPTION
# Changes

- Fix deploy script to correctly push back converted tags, which will be used by `lerna` for determining version.
- Always bump `minor` when releasing canary builds.
