### PR TITLE
[Bugfix] Fix that we have to click twice to close gyp-closable after click in wrapped component

### DIFF
--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -54,11 +54,6 @@ const closable = ({
             closable: mixinConfigs,
         };
 
-        constructor(props) {
-            super(props);
-            this.clickedInside = false;
-        }
-
         componentDidMount() {
             document.addEventListener('keyup', this.handleDocumentKeyup);
         }
@@ -100,12 +95,6 @@ const closable = ({
                 event.stopPropagation();
             }
 
-            if (this.clickedInside) {
-                // ignoring click events bubbling up from inside
-                this.clickedInside = false;
-                return;
-            }
-
             if (options.onClickOutside) {
                 this.props.onClose(event);
             }
@@ -116,7 +105,6 @@ const closable = ({
          */
         handleInsideClick = (event) => {
             const options = this.getOptions();
-            this.clickedInside = true;
 
             if (options.onClickInside) {
                 this.props.onClose(event);


### PR DESCRIPTION
# Purpose

修正在 `<SelectRow>` 開啟選項的 popover 並在裡面點選後，在外面按一下不會關掉 popover 的問題，必須按兩下。

這是因為修正了 #250 後，改變了 DOM 的結構讓 gyp-closable 不再是 `WrappedComponent` 的父元素，卻忘了拿掉原本在 `<WrappedComponent>` 內部點擊、觸發 gyp-closable click event handler 時不要執行 onClose 的機制。現在在 `<WrappedComponent>` 內點擊本來就不會觸發 gyp-closable 的 click handler，所以也不用額外這樣做。

實作上就是拿掉 `closable` 的 `this.insideClick` 變數。

# Changes

- 拿掉 `closable` 裡面的 `this.insideClick`。

# Risk

所有使用 `<Popover>` 的 component(在 gypcrete 裡面只有 `<SelectRow>`)

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
