### PR TITLE
[Feature] Allow passing remaining props to wrapper element to add attribute (e.g. test id)

### DIFF
--- a/packages/core/src/Modal.js
+++ b/packages/core/src/Modal.js
@@ -65,6 +65,7 @@ function Modal({
     // React props
     className,
     children,
+    ...wrapperProps
 }) {
     const rootBem = BEM.root
         .modifier('centered', centered)
@@ -80,7 +81,7 @@ function Modal({
     const handleOverlayClick = createHandleOverlayClick(onClose);
 
     return (
-        <div className={rootClassName}>
+        <div className={rootClassName} {...wrapperProps}>
             <Overlay onClick={handleOverlayClick} />
 
             <ColumnView

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -139,7 +139,7 @@ class SearchInput extends Component {
     }
 
     render() {
-        const { inputProps, value, placeholder, className } = this.props;
+        const { inputProps, value, placeholder, className, ...wrapperProps } = this.props;
         const { innerValue } = this.state;
 
         const inputValue = this.isControlled() ? value : innerValue;
@@ -147,7 +147,7 @@ class SearchInput extends Component {
         const rootClassName = classNames(className, `${BEM.root}`);
 
         return (
-            <div className={rootClassName}>
+            <div className={rootClassName} {...wrapperProps}>
                 <div className={BEM.inputWrapper}>
                     <Icon type="search" />
 

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -24,6 +24,7 @@ function Section({
     // React props
     className,
     children,
+    ...wrapperProps
 }) {
     // Class names
     const rootClassName = classNames(
@@ -53,7 +54,7 @@ function Section({
     );
 
     return (
-        <div className={rootClassName}>
+        <div className={rootClassName} {...wrapperProps}>
             {titleArea}
             <div className={bodyClassName}>
                 {children}

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -100,10 +100,11 @@ class StatusIcon extends PureComponent {
     }
 
     render() {
-        const rootClassName = ROOT_BEM.modifier(this.props.position);
+        const { status, position, ...wrapperProps } = this.props;
+        const rootClassName = ROOT_BEM.modifier(position);
         let icon = null;
 
-        switch (this.props.status) {
+        switch (status) {
             case LOADING:
                 icon = <Icon type="inline-loading" color="gray" spinning />;
                 break;
@@ -119,7 +120,11 @@ class StatusIcon extends PureComponent {
                 break;
         }
 
-        return (icon && <span className={rootClassName}>{icon}</span>);
+        return (icon && (
+            <span className={rootClassName} {...wrapperProps}>
+                {icon}
+            </span>
+        ));
     }
 }
 

--- a/packages/core/src/Tag.js
+++ b/packages/core/src/Tag.js
@@ -8,11 +8,11 @@ import prefixClass from './utils/prefixClass';
 const COMPONENT_NAME = prefixClass('tag');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 
-function Tag({ className, children }) {
+function Tag({ className, children, ...wrapperProps }) {
     const rootClass = classNames(`${ROOT_BEM.toString()}`, className);
 
     return (
-        <span className={rootClass}>
+        <span className={rootClass} {...wrapperProps}>
             <span>{children}</span>
         </span>
     );

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -119,7 +119,14 @@ class Text extends PureComponent {
     }
 
     render() {
-        const { align, verticalOrder, noGrow, bold, className } = this.props;
+        const {
+            align,
+            verticalOrder,
+            noGrow,
+            bold,
+            className,
+            ...wrapperProps
+        } = this.props;
 
         const bemClass = BEM.root
             .modifier(align)
@@ -130,7 +137,7 @@ class Text extends PureComponent {
         const rootClassName = classNames(bemClass.toString(), className);
 
         return (
-            <div className={rootClassName}>
+            <div className={rootClassName} {...wrapperProps}>
                 {this.renderBasicRow()}
                 {this.renderAsideRow()}
             </div>

--- a/packages/core/src/TextEllipsis.js
+++ b/packages/core/src/TextEllipsis.js
@@ -6,9 +6,9 @@ import './styles/TextEllipsis.scss';
 const COMPONENT_NAME = prefixClass('text-ellipsis');
 const ROOT_BEM = icBEM(COMPONENT_NAME);
 
-function TextEllipsis({ children }) {
+function TextEllipsis({ children, ...wrapperProps }) {
     return (
-        <div className={ROOT_BEM} title={children}>
+        <div className={ROOT_BEM} title={children} {...wrapperProps}>
             {children}
         </div>
     );

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -225,10 +225,11 @@ class SelectList extends PureComponent {
             showCheckAll,
             title,
             desc,
+            ...wrapperProps
         } = this.props;
 
         return (
-            <List title={title} desc={desc}>
+            <List title={title} desc={desc} {...wrapperProps}>
                 {multiple && showCheckAll && this.renderCheckAllOption()}
                 {this.renderOptions()}
             </List>


### PR DESCRIPTION
# Purpose

修改了下列的 component，讓所有的 gypcrete component 都可以帶 props 到最外層的元素上，用於加 test id。例如 `<List data-test-id="menu-item-list" />`。
- `<Modal>`
- `<Section>`
- `<SearchInput>`
- `<StatusIcon>`
- `<Tag>`
- `<Text>`
- `<TextEllipsis>`
- `<SelectList>`

# Changes


# Review Tips

有一些已經把 remaining props 放在內層元素上，所以沒有修改：
- `<TextInput>`
props 會傳到裡面的 `<input>`
- `<SelectOption>`
props 會傳到裡面的 `<Checkbox>`，外層的 `<ListRow>` 吃不到。
- `<ImageEditor>`
props 會傳到 `react-avatar-editor` 上面

一些 component 裡面的元素也許想要加 props 進去：
- `<Section>`(即 `<List>`)
裡面有 title 和 desc
- `<SearchInput>`
裡面有 search button 和 input
- `<StatusIcon>`
裡面有 `<Icon>`
- `<Switch>`
裡面有 checkbox input
- `<Text>`
裡面有 basic 和 aside
- `<SelectList>`
全選的 option 沒辦法傳 props 進去
- `<SelectRow>`
裡面的 `<Text>` 和 `<Popover>` 沒辦法傳 props 進去，`<ListRow>` 和 `<SelectList>` 已經有了
- `<SwitchRow>`
裡面的 `<TextLabel>` 沒辦法傳 props 進去
- `<ImageEditor>`
裡面的 control 沒辦法傳 props 進去。

想問問大家要不要再加；或是就先做到這邊，等和 QE 協作再看有沒有需求。個人覺得可以先額外開洞允許傳 props 到 button/input 上。

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
