### PR TITLE
[Bugfix] Fix passing invalid props to dom element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - [Core] Reduce icon font to only WOFF and WOFF2 formats. (#266)
 
+### Added
+- [Core] Allow passing remaining props to wrapper DOM element. (#267, #269)
+
 ### Changed
 - [Core] Add sort icon. (#268)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "create-react-context": "^0.2.3",
     "document-offset": "^1.0.4",
     "keycode": "^2.1.9",
+    "lodash.omit": "^4.5.0",
     "memoize-one": "^4.0.3",
     "react-textarea-autosize": "^7.1.0",
     "warning": "^4.0.3"

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
@@ -139,12 +140,14 @@ class SearchInput extends Component {
     }
 
     render() {
-        const { inputProps, value, placeholder, className, ...wrapperProps } = this.props;
+        const { inputProps, value, placeholder, className } = this.props;
         const { innerValue } = this.state;
 
         const inputValue = this.isControlled() ? value : innerValue;
         const isLoading = this.context.status === STATUS_CODE.LOADING;
         const rootClassName = classNames(className, `${BEM.root}`);
+
+        const wrapperProps = omit(this.props, Object.keys(SearchInput.propTypes));
 
         return (
             <div className={rootClassName} {...wrapperProps}>

--- a/packages/core/src/SearchInput.js
+++ b/packages/core/src/SearchInput.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
+import getRemainingProps from './utils/getRemainingProps';
 import rowComp from './mixins/rowComp';
 import './styles/SearchInput.scss';
 
@@ -147,7 +147,7 @@ class SearchInput extends Component {
         const isLoading = this.context.status === STATUS_CODE.LOADING;
         const rootClassName = classNames(className, `${BEM.root}`);
 
-        const wrapperProps = omit(this.props, Object.keys(SearchInput.propTypes));
+        const wrapperProps = getRemainingProps(this.props, SearchInput.propTypes);
 
         return (
             <div className={rootClassName} {...wrapperProps}>

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
@@ -100,7 +101,7 @@ class StatusIcon extends PureComponent {
     }
 
     render() {
-        const { status, position, ...wrapperProps } = this.props;
+        const { status, position } = this.props;
         const rootClassName = ROOT_BEM.modifier(position);
         let icon = null;
 
@@ -119,6 +120,8 @@ class StatusIcon extends PureComponent {
             default:
                 break;
         }
+
+        const wrapperProps = omit(this.props, Object.keys(StatusIcon.propTypes));
 
         return (icon && (
             <span className={rootClassName} {...wrapperProps}>

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -121,7 +121,7 @@ class StatusIcon extends PureComponent {
                 break;
         }
 
-        const wrapperProps = getRemainingProps(this.props, StatusIcon);
+        const wrapperProps = getRemainingProps(this.props, StatusIcon.propTypes);
 
         return (icon && (
             <span className={rootClassName} {...wrapperProps}>

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
+import getRemainingProps from './utils/getRemainingProps';
 import './styles/StatusIcon.scss';
 
 import Icon from './Icon';
@@ -121,7 +121,7 @@ class StatusIcon extends PureComponent {
                 break;
         }
 
-        const wrapperProps = omit(this.props, Object.keys(StatusIcon.propTypes));
+        const wrapperProps = getRemainingProps(this.props, StatusIcon);
 
         return (icon && (
             <span className={rootClassName} {...wrapperProps}>

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -18,6 +18,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
@@ -125,8 +126,8 @@ class Text extends PureComponent {
             noGrow,
             bold,
             className,
-            ...wrapperProps
         } = this.props;
+        const wrapperProps = omit(this.props, Object.keys(Text.propTypes));
 
         const bemClass = BEM.root
             .modifier(align)

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -18,10 +18,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import omit from 'lodash.omit';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
+import getRemainingProps from './utils/getRemainingProps';
 import withStatus, { withStatusPropTypes } from './mixins/withStatus';
 import './styles/Text.scss';
 
@@ -127,7 +127,7 @@ class Text extends PureComponent {
             bold,
             className,
         } = this.props;
-        const wrapperProps = omit(this.props, Object.keys(Text.propTypes));
+        const wrapperProps = getRemainingProps(this.props, Text);
 
         const bemClass = BEM.root
             .modifier(align)

--- a/packages/core/src/Text.js
+++ b/packages/core/src/Text.js
@@ -127,7 +127,7 @@ class Text extends PureComponent {
             bold,
             className,
         } = this.props;
-        const wrapperProps = getRemainingProps(this.props, Text);
+        const wrapperProps = getRemainingProps(this.props, Text.propTypes);
 
         const bemClass = BEM.root
             .modifier(align)

--- a/packages/core/src/utils/getRemainingProps.js
+++ b/packages/core/src/utils/getRemainingProps.js
@@ -1,5 +1,5 @@
 import omit from 'lodash.omit';
 
-export default function getRemainingProps(props, Component) {
-    return omit(props, Object.keys(Component.propTypes));
+export default function getRemainingProps(props, propTypes) {
+    return omit(props, Object.keys(propTypes));
 }

--- a/packages/core/src/utils/getRemainingProps.js
+++ b/packages/core/src/utils/getRemainingProps.js
@@ -1,0 +1,5 @@
+import omit from 'lodash.omit';
+
+export default function getRemainingProps(props, Component) {
+    return omit(props, Object.keys(Component.propTypes));
+}

--- a/packages/storybook/examples/core/Text.stories.js
+++ b/packages/storybook/examples/core/Text.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StatusIcon } from '@ichef/gypcrete/src/StatusIcon';
+import StatusIcon from '@ichef/gypcrete/src/StatusIcon';
 import Text, { PureText } from '@ichef/gypcrete/src/Text';
 import TextEllipsis from '@ichef/gypcrete/src/TextEllipsis';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9739,6 +9739,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"


### PR DESCRIPTION
# Purpose

- 修正在 #267 中誤把不合法的 props 往下傳給 DOM element 的問題；為此添加了 `lodash.omit` 的 dependency。抽出了 `getRemainingProps` 的 utility。
- 也順手修掉 `<Text>` story 中噴出來的 error message，起因於錯誤的 import `<StatusIcon>`


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
