### PR TITLE
Remove deprected PopupButton type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking
+- [Core] Remove deprecated behavior in Popup, which will treat element of `buttons` as props to `<PopupButton>`, if `element.type` is not `<PopupButton>`. (#276)
 
 ## [4.3.0]
 

--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -8,8 +8,6 @@ import wrapIfNotElement from './utils/wrapIfNotElement';
 
 import renderToLayer from './mixins/renderToLayer';
 
-import PopupButton from './PopupButton';
-
 import Icon from './Icon';
 import Overlay from './Overlay';
 
@@ -74,32 +72,13 @@ function renderPopupButtons(buttons, direction) {
         return null;
     }
 
-    /**
-     * `<Popup>` expects an array of pre-configured `<PopupButton>`s.
-     * This transforms `<Button>` into `<PopupButton>` for compatibility.
-     *
-     * Should remove in v2 release.
-     * @deprecated
-     */
-    const popupButtons = buttons.map((button) => {
-        if (button.type === PopupButton) {
-            return button;
-        }
-        return (
-            <PopupButton
-                key={button.key}
-                {...button.props}
-            />
-        );
-    });
-
     const wrapperClass = BEM.buttonsGroup
         .modifier(direction)
         .toString();
 
     return (
         <div className={wrapperClass}>
-            {popupButtons}
+            {buttons}
         </div>
     );
 }

--- a/packages/core/src/__tests__/Popup.test.js
+++ b/packages/core/src/__tests__/Popup.test.js
@@ -10,7 +10,6 @@ import Popup, {
 } from '../Popup';
 import PopupButton from '../PopupButton';
 
-import Button from '../Button';
 import Icon from '../Icon';
 import Overlay from '../Overlay';
 import TextLabel from '../TextLabel';
@@ -110,20 +109,6 @@ describe('Pure <Popup>', () => {
         wrapper.setProps({ buttons });
         expect(wrapper.find(`.${POPUP_BEM.buttonsGroup}`).exists()).toBeTruthy();
 
-        expect(wrapper.find(`.${POPUP_BEM.buttonsGroup}`).children()).toHaveLength(2);
-        expect(wrapper.find(`.${POPUP_BEM.buttonsGroup}`).containsAllMatchingElements([
-            <PopupButton basic="Label A" />,
-            <PopupButton basic="Label B" />,
-        ])).toBeTruthy();
-    });
-
-    it('transforms <Button> into <PopupButton> for compatibility', () => {
-        // #DEPRECATE: remove in v2 release
-        const buttons = [
-            <Button key="a" basic="Label A" />,
-            <Button key="b" basic="Label B" />,
-        ];
-        const wrapper = shallow(<PurePopup message="foo" buttons={buttons} />);
         expect(wrapper.find(`.${POPUP_BEM.buttonsGroup}`).children()).toHaveLength(2);
         expect(wrapper.find(`.${POPUP_BEM.buttonsGroup}`).containsAllMatchingElements([
             <PopupButton basic="Label A" />,


### PR DESCRIPTION
# Purpose

Asana: https://app.asana.com/0/347798529122928/1180565159757507

去掉 `<Popup>` 裡面對 buttons 額外確認 element type、如果不是 `<PopupButton>` 就當作 props 丟進 `<PopupButton>` 的行為。

這個舊行為會使得我們傳包住 `<PopupButton>` 的 element 到 `buttons` 時噴錯，因為只要包了 component，type 就不再是 `PopupButton`。

確認過我們目前沒用到這個行為了。

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
