### PR TITLE
Add muted prop on `rowComp()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - [Core] Remove deprecated behavior in Popup, which will treat element of `buttons` as props to `<PopupButton>`, if `element.type` is not `<PopupButton>`. (#276)
 
+### Added
+- [Core] Add `muted` prop on following component: (#278)
+    - `<Button>`
+    - `<Checkbox>`
+    - `<SearchInput>`
+    - `<Switch>`
+    - `<TextInput>`
+    - `<TextLabel>`
+    - `<ListRow>`
+
 ## [4.3.0]
 
 ### Added

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -142,6 +142,7 @@ const rowComp = ({
             active: PropTypes.bool,
             highlight: PropTypes.bool,
             disabled: PropTypes.bool,
+            muted: PropTypes.bool,
 
             // status props
             status: statusPropTypes.status,
@@ -164,6 +165,7 @@ const rowComp = ({
             active: false,
             highlight: false,
             disabled: false,
+            muted: false,
 
             status: undefined,
             statusOptions: undefined,
@@ -251,6 +253,7 @@ const rowComp = ({
                 active,
                 highlight,
                 disabled,
+                muted,
 
                 status,
                 statusOptions,
@@ -271,6 +274,7 @@ const rowComp = ({
                 active,
                 highlight,
                 disabled,
+                muted,
                 error: status === STATUS_CODE.ERROR,
                 untouchable: status === STATUS_CODE.LOADING,
             });

--- a/packages/core/src/styles/_states.scss
+++ b/packages/core/src/styles/_states.scss
@@ -20,6 +20,10 @@
     pointer-events: none !important;
 }
 
+.#{$prefix-state}-muted {
+    opacity: .3 !important;
+}
+
 [hidden],
 .#{$prefix-state}-hidden {
     display: none;

--- a/packages/core/src/utils/__tests__/getStateClassnames.test.js
+++ b/packages/core/src/utils/__tests__/getStateClassnames.test.js
@@ -6,11 +6,12 @@ it('can generates a single class name', () => {
     expect(getStateClassnames({ error: true })).toBe('gyp-state-error');
     expect(getStateClassnames({ disabled: true })).toBe('gyp-state-disabled');
     expect(getStateClassnames({ untouchable: true })).toBe('gyp-state-untouchable');
+    expect(getStateClassnames({ muted: true })).toBe('gyp-state-muted');
 });
 
 it('can generate a set of class names', () => {
-    expect(getStateClassnames({ active: true, highlight: true }))
-        .toBe('gyp-state-active gyp-state-highlight');
+    expect(getStateClassnames({ active: true, highlight: true, muted: true }))
+        .toBe('gyp-state-active gyp-state-highlight gyp-state-muted');
 
     expect(getStateClassnames({ error: true, disabled: true, untouchable: true }))
         .toBe('gyp-state-error gyp-state-disabled gyp-state-untouchable');

--- a/packages/core/src/utils/getStateClassnames.js
+++ b/packages/core/src/utils/getStateClassnames.js
@@ -8,6 +8,7 @@ const CLASS_HIGHLIGHT = prefixClass(`${PREFIX}-highlight`);
 const CLASS_ERROR = prefixClass(`${PREFIX}-error`);
 const CLASS_DISABLED = prefixClass(`${PREFIX}-disabled`);
 const CLASS_UNTOUCHABLE = prefixClass(`${PREFIX}-untouchable`);
+const CLASS_MUTED = prefixClass(`${PREFIX}-muted`);
 
 function getStateClassnames(stateProps) {
     const results = classNames({
@@ -16,6 +17,7 @@ function getStateClassnames(stateProps) {
         [CLASS_ERROR]: stateProps.error,
         [CLASS_DISABLED]: stateProps.disabled,
         [CLASS_UNTOUCHABLE]: stateProps.untouchable,
+        [CLASS_MUTED]: stateProps.muted,
     });
 
     return results;

--- a/packages/storybook/examples/core/Button.stories.js
+++ b/packages/storybook/examples/core/Button.stories.js
@@ -164,6 +164,21 @@ export function DisabledButton() {
     );
 }
 
+export function MutedButton() {
+    return (
+        <FlexRow>
+            <Button
+                muted
+                basic="Muted Button"
+                aside="Muted button has disabled style, but clickable"
+                // eslint-disable-next-line no-alert
+                onClick={() => alert('I am clickable!')}
+                solid
+            />
+        </FlexRow>
+    );
+}
+
 export function ExpandedButton() {
     return (
         <div>


### PR DESCRIPTION
# Purpose

Asana: https://app.asana.com/0/347798529122928/1179698171481649

下列的 component 會新增 `muted` prop，`muted` 為 `true` 時，會有 `disabled` 的樣式，但 click 時仍會觸發事件。
- `<Button>`
- `<Checkbox>`
- `<SearchInput>`
- `<Switch>`
- `<TextInput>`
- `<TextLabel>`
- `<ListRow>`

實作上就是讓 `rowComp()` mixin 可以吃 `muted`，新增 `.gyp-state-muted` 的樣式，參照 `.gyp-state-disabled` 但拿掉 `pointer-events: none` 的限制。

# Changes

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
