### PR TITLE
Pass message as messageTitle when type is string in Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - [Core] Remove deprecated behavior in Popup, which will treat element of `buttons` as props to `<PopupButton>`, if `element.type` is not `<PopupButton>`. (#276)
 
+### Changed
+
+- [Core] when message prop of `<Popup>` is a string, pass it to `<PopupMessage>` as `title` prop. (#279)
+
 ### Added
 - [Core] Add `muted` prop on following component: (#278)
     - `<Button>`
@@ -30,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Add sort icon. (#268)
 - [Core] Add announce icon. (#272)
 - [Core] Add `large` prop to `<Popup>`. (#273)
+- [Core] Add `messageTitle` and `messageDesc` prop to `<Popup>`.
 
 ## [4.2.1]
 

--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -45,7 +45,9 @@ export function PopupMessage({ title, desc, bottomArea }) {
             {title && (
                 <span className={BEM.messageTitle}>{title}</span>
             )}
-            <span className={BEM.messageDesc}>{desc}</span>
+            {desc && (
+                <span className={BEM.messageDesc}>{desc}</span>
+            )}
             {bottomArea}
         </div>
     );

--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -121,9 +121,9 @@ function Popup({
 
             return (
                 <PopupMessage
-                    title={messageTitle}
                     // support for legacy string type `message` prop
-                    desc={messageDesc || message}
+                    title={messageTitle || message}
+                    desc={messageDesc}
                     bottomArea={messageBottomArea}
                 />
             );

--- a/packages/core/src/__tests__/Popup.test.js
+++ b/packages/core/src/__tests__/Popup.test.js
@@ -59,7 +59,7 @@ describe('Pure <Popup>', () => {
         const wrapper = shallow(<PurePopup message="foo" />);
 
         expect(wrapper.find(PopupMessage).exists()).toBeTruthy();
-        expect(wrapper.find(PopupMessage).prop('desc')).toBe('foo');
+        expect(wrapper.find(PopupMessage).prop('title')).toBe('foo');
     });
 
     it('renders popup with large class name', () => {

--- a/packages/core/src/styles/Popup.scss
+++ b/packages/core/src/styles/Popup.scss
@@ -62,7 +62,6 @@ $component: #{$prefix}-popup;
         font-size: rem(16px);
         line-height: rem(22px);
         font-weight: bold;
-        margin-bottom: rem(8px);
     }
 
     // Message desc
@@ -70,6 +69,7 @@ $component: #{$prefix}-popup;
         font-size: rem(14px);
         line-height: rem(20px);
         color: rgba(0, 0, 0, .7);
+        margin-top: rem(8px);
     }
 
     // Nested components


### PR DESCRIPTION
# Purpose

- when `message` prop of `<Popup>` is a string, pass it to `<PopupMessage>` as `title` prop.




# Changes

- a list of what have been done
- maybe some code change

