### PR TITLE
[Chore] Add WebStorm generated .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ deploy/
 public/
 tmp/
 .cache/
+.idea/
 .DS_Store
 *-debug.log
 *-error.log


### PR DESCRIPTION
# Purpose
WebStorm automatically generates config files under `.idea/` directory which shouldn't be in version control

# Changes
- Added .idea to gitignore

# Risk
N/A

# TODOs
N/A