### PR TITLE
[Feature] Add title right area on Section / List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Change `<Icon>` implementaion from icon-font to inline-svg. (#280)
 - [Core] Upgrade `eslint-config-ichef` packages to `v8.0.0`. (#290)
 - [Core] Use node 12 in travis CI. (#290)
+- [Core] Add `titleRightArea` on `<Section>` / `<List>`. (#297)
 
 ### Added
 - [Core] Add `muted` prop on following component: (#278)

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -13,7 +13,7 @@ export const BEM = {
   title: ROOT_BEM.element('title'),
   body: ROOT_BEM.element('body'),
   desc: ROOT_BEM.element('desc'),
-  titleRightArea: ROOT_BEM.element('titleRightArea'),
+  titleRightArea: ROOT_BEM.element('title-right-area'),
 };
 
 function Section({

--- a/packages/core/src/Section.js
+++ b/packages/core/src/Section.js
@@ -13,11 +13,13 @@ export const BEM = {
   title: ROOT_BEM.element('title'),
   body: ROOT_BEM.element('body'),
   desc: ROOT_BEM.element('desc'),
+  titleRightArea: ROOT_BEM.element('titleRightArea'),
 };
 
 function Section({
   title,
   titleSize,
+  titleRightArea,
   desc,
   verticalSpacing, // add margin to above and below <Section>
   bodySpacing, // add padding to body for components that are not row-based
@@ -46,6 +48,9 @@ function Section({
     }
     >
       {title}
+      {titleRightArea && (
+        <div className={BEM.titleRightArea.toString()}>{titleRightArea}</div>
+      )}
     </div>
   );
   const descArea = desc && (
@@ -71,6 +76,7 @@ Section.propTypes = {
   verticalSpacing: PropTypes.bool,
   bodySpacing: PropTypes.bool,
   titleSize: PropTypes.oneOf(['base', 'small']),
+  titleRightArea: PropTypes.node,
 };
 
 Section.defaultProps = {
@@ -79,6 +85,7 @@ Section.defaultProps = {
   verticalSpacing: true,
   bodySpacing: true,
   titleSize: 'base',
+  titleRightArea: undefined,
 };
 
 export default Section;

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -40,7 +40,7 @@ $component-name: #{$prefix}-section;
         }
     }
 
-    &__titleRightArea {
+    &__title-right-area {
         margin-left: auto;
         flex-grow: 0;
         flex-shrink: 0;

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -17,6 +17,8 @@ $component-name: #{$prefix}-section;
     }
 
     &__title {
+        display: flex;
+        align-items: flex-end;
         line-height: rem($section-title-line-height);
         font-weight: $font-weight-bold;
         padding-bottom: rem(1px);
@@ -36,6 +38,13 @@ $component-name: #{$prefix}-section;
             display: inline-block;
             margin-right: .25em;
         }
+    }
+
+    &__titleRightArea {
+        margin-left: auto;
+        margin-bottom: 5px;
+        flex-grow: 0;
+        flex-shrink: 0;
     }
 
     &__desc {

--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -21,7 +21,7 @@ $component-name: #{$prefix}-section;
         align-items: flex-end;
         line-height: rem($section-title-line-height);
         font-weight: $font-weight-bold;
-        padding-bottom: rem(1px);
+        padding-bottom: rem(5px);
         border-bottom: 2px solid $c-section-divider;
 
         // title font-size
@@ -42,7 +42,6 @@ $component-name: #{$prefix}-section;
 
     &__titleRightArea {
         margin-left: auto;
-        margin-bottom: 5px;
         flex-grow: 0;
         flex-shrink: 0;
     }

--- a/packages/storybook/examples/core/List.stories.js
+++ b/packages/storybook/examples/core/List.stories.js
@@ -181,3 +181,32 @@ export function NestedListWithTitle() {
     </DebugBox>
   );
 }
+
+export function ListWithTitleRightButton() {
+  const button = (
+    <Button solid color="red" basic="I am a button" />
+  );
+  return (
+    <List title="List title" desc="Help text here" titleRightArea={button}>
+      <ListRow>
+        <Avatar alt="iCHEF" src="https://api.adorable.io/avatars/285/hello@ichef.tw" />
+        <TextLabel basic="Hello World" />
+      </ListRow>
+    </List>
+  );
+}
+
+export function ListWithLongTextAndTitleRightButton() {
+  const button = (
+    <Button solid color="red" basic="I am a button" />
+  );
+  const longText = '臣亮言：先帝創業未半，而中道崩殂。今天下三分，益州疲敝，此誠危急存亡之秋也！然侍衞之臣，不懈於內；忠志之士，忘身於外者，蓋追先帝之殊遇，欲報之於陛下也。誠宜開張聖聽，以光先帝遺德，恢弘志士之氣；不宜妄自菲薄，引喻失義，以塞忠諫之路也。';
+  return (
+    <List title={longText} titleRightArea={button}>
+      <ListRow>
+        <Avatar alt="iCHEF" src="https://api.adorable.io/avatars/285/hello@ichef.tw" />
+        <TextLabel basic="Hello World" />
+      </ListRow>
+    </List>
+  );
+}


### PR DESCRIPTION
# Purpose

在 `<List>` / `<Section>` 中加入 title 右方的區域。整個 `gyp-section--title` 變為 flex 排版。

另外和設計確認過，也將 title 的 padding 從 1px 改為 5px。

# Screenshot

![截圖 2020-10-16 下午12 05 48](https://user-images.githubusercontent.com/7620906/96211844-f76cf480-0fa7-11eb-92f2-df0efbef0969.png)


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
