### PR TITLE
Add padding left for section title right area

### DIFF
--- a/packages/core/src/styles/Section.scss
+++ b/packages/core/src/styles/Section.scss
@@ -42,6 +42,7 @@ $component-name: #{$prefix}-section;
 
     &__title-right-area {
         margin-left: auto;
+        padding-left: rem(5px);
         flex-grow: 0;
         flex-shrink: 0;
     }


### PR DESCRIPTION
# Purpose

#297 實作 `<Section>` / `<List>` 的 title right area 後，設計要求區塊的左邊要有 5px 間隔。

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
