### PR TITLE
Revise <Popup> rev.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 - [Core] Remove deprecated behavior in Popup, which will treat element of `buttons` as props to `<PopupButton>`, if `element.type` is not `<PopupButton>`. (#276)
-- [Core] `<Popup>` is revised to match latest design spec: (#292)
+- [Core] `<Popup>` is revised to match latest design spec: (#293)
   * no longer supports horizontal buttons.
   * ~takes a `{ title, desc }` object format for `message` prop.~
   * supports optional `title` prop. (from #300, dropping change from prev line.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Remove deprecated behavior in Popup, which will treat element of `buttons` as props to `<PopupButton>`, if `element.type` is not `<PopupButton>`. (#276)
 - [Core] `<Popup>` is revised to match latest design spec: (#292)
   * no longer supports horizontal buttons.
-  * takes a `{ title, desc }` object format for `message` prop.
+  * ~takes a `{ title, desc }` object format for `message` prop.~
+  * supports optional `title` prop. (from #300, dropping change from prev line.)
   * uses `size` prop instead of `large` boolean prop.
   * drops the following props: `customMessageNode`, `messageTitle`, `messageDesc`, `buttonsDirection`.
 

--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -57,13 +57,13 @@ PopupIcon.defaultProps = {
   color: undefined,
 };
 
-export function PopupMessage({ message }) {
+export function PopupMessage({ title, message }) {
   // variant: title + desc
-  if (message.title) {
+  if (title) {
     return (
       <>
-        <div className={BEM.messageTitle}>{message.title}</div>
-        <div className={BEM.messageDesc}>{message.desc}</div>
+        <div className={BEM.messageTitle}>{title}</div>
+        <div className={BEM.messageDesc}>{message}</div>
       </>
     );
   }
@@ -72,20 +72,18 @@ export function PopupMessage({ message }) {
   return message;
 }
 PopupMessage.propTypes = {
-  message: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      desc: PropTypes.string.isRequired,
-    }),
-  ]).isRequired,
+  title: PropTypes.node,
+  message: PropTypes.node.isRequired,
 };
-PopupMessage.defaultProps = {};
+PopupMessage.defaultProps = {
+  title: undefined,
+};
 
 function Popup({
   size,
   icon,
   iconColor,
+  title,
   message,
   messageBottomArea,
   buttons,
@@ -103,7 +101,7 @@ function Popup({
         <PopupIcon icon={icon} color={iconColor} />
 
         <div className={BEM.body}>
-          <PopupMessage message={message} />
+          <PopupMessage title={title} message={message} />
           {messageBottomArea}
         </div>
 
@@ -124,6 +122,7 @@ Popup.propTypes = {
   ]),
   icon: PopupIcon.propTypes.icon,
   iconColor: PopupIcon.propTypes.color,
+  title: PopupMessage.propTypes.title,
   message: PopupMessage.propTypes.message,
   messageBottomArea: PropTypes.node,
   buttons: PropTypes.node,
@@ -133,6 +132,7 @@ Popup.defaultProps = {
   size: POPUP_SIZE.SMALL,
   icon: PopupIcon.defaultProps.icon,
   iconColor: PopupIcon.defaultProps.color,
+  title: PopupMessage.defaultProps.title,
   message: PopupMessage.defaultProps.message,
   messageBottomArea: undefined,
   buttons: undefined,

--- a/packages/core/src/__tests__/Popup.test.js
+++ b/packages/core/src/__tests__/Popup.test.js
@@ -76,17 +76,9 @@ describe('<Popup> icon', () => {
 });
 
 describe('<Popup> message', () => {
-  it('passes "message" prop to <PopupMessage>', () => {
-    const wrapper = shallow(<PurePopup message="foo" />);
-
-    expect(
-      wrapper.containsMatchingElement(<PopupMessage message="foo" />)
-    ).toBeTruthy();
-  });
-
-  it('supports { title, desc } message format', () => {
+  it('supports message with optional title', () => {
     const wrapper = shallow(
-      <PurePopup message={{ title: 'foo', desc: 'bar' }} />
+      <PurePopup title="foo" message="bar" />
     );
     const messageWrapper = wrapper.find(PopupMessage).shallow();
 

--- a/packages/storybook/examples/core/Popup.stories.js
+++ b/packages/storybook/examples/core/Popup.stories.js
@@ -43,10 +43,8 @@ export function MessageWithTitle() {
     <Popup
       icon="error"
       iconColor="red"
-      message={{
-        title: 'Invalid inputs',
-        desc: 'Please check value of each fields.',
-      }}
+      title="Invalid inputs"
+      message="Please check value of each fields."
       buttons={(
         <PopupButton basic="Confirm" onClick={action('confirm')} />
       )}
@@ -60,10 +58,8 @@ export function LargePopup() {
       size="large"
       icon="error"
       iconColor="red"
-      message={{
-        title: 'A very important notice',
-        desc: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      }}
+      title="A very important notice"
+      message="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
       buttons={(
         <>
           <PopupButton basic="Learn more" onClick={action('learn')} />
@@ -86,10 +82,8 @@ export function CustomContentBelowMessage() {
     <Popup
       icon="announce"
       iconColor="green"
-      message={{
-        title: 'Website updated',
-        desc: 'We have added lots of new features!',
-      }}
+      title="Website updated"
+      message="We have added lots of new features!"
       messageBottomArea={(
         <Checkbox align="center" basic="Do not show again" />
       )}
@@ -123,10 +117,8 @@ export function CustomIcon() {
 export function NoIcon() {
   return (
     <Popup
-      message={{
-        title: 'Website updated',
-        desc: 'We have added lots of new features!',
-      }}
+      title="Website updated"
+      message="We have added lots of new features!"
       buttons={(
         <PopupButton basic="Close" onClick={action('close')} />
       )}


### PR DESCRIPTION
# Purpose

This PR gives up the `message={{ title, desc }}` prop format introduced in #292, switching to `title` + `message` props instead. So it's easier to toggle the optional `title`.

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
