### PR TITLE
Fix popover placement when there is no enough space on top or bottom of content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Upgrade `eslint-config-ichef` packages to `v8.0.0`. (#290)
 - [Core] Use node 12 in travis CI. (#290)
 - [Core] Add `titleRightArea` on `<Section>` / `<List>`. (#297)
+- [Core] Fix popover placement when there is no enough space on top or bottom of content. (#303)
 
 ### Added
 - [Core] Add `muted` prop on following component: (#278)

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -30,6 +30,7 @@ function Popover({
   placement,
   arrowStyle,
   nodeRef,
+  remainingSpace,
   // from closable()
   onInsideClick,
   // React props
@@ -45,6 +46,8 @@ function Popover({
     onClick(event);
   };
 
+  const popoverPadding = 24;
+
   return (
     <ListSpacingContext.Provider value={false}>
       <div
@@ -55,7 +58,10 @@ function Popover({
         {...otherProps}
       >
         <span className={BEM.arrow} style={arrowStyle} />
-        <div className={BEM.container}>
+        <div
+          className={BEM.container}
+          style={{ maxHeight: remainingSpace ? remainingSpace - popoverPadding : undefined }}
+        >
           {children}
         </div>
       </div>
@@ -68,6 +74,7 @@ Popover.propTypes = {
   placement: anchoredPropTypes.placement,
   arrowStyle: anchoredPropTypes.arrowStyle,
   nodeRef: anchoredPropTypes.nodeRef,
+  remainingSpace: anchoredPropTypes.remainingSpace,
   onInsideClick: PropTypes.func.isRequired,
 };
 
@@ -76,6 +83,7 @@ Popover.defaultProps = {
   placement: ANCHORED_PLACEMENT.BOTTOM,
   arrowStyle: {},
   nodeRef: undefined,
+  remainingSpace: undefined,
 };
 
 export { Popover as PurePopover };

--- a/packages/core/src/Popover.js
+++ b/packages/core/src/Popover.js
@@ -24,6 +24,8 @@ export const BEM = {
   container: ROOT_BEM.element('container'),
 };
 
+const POPOVER_PADDING = 24;
+
 function Popover({
   onClick,
   // from anchored()
@@ -40,13 +42,18 @@ function Popover({
 }) {
   const bemClass = BEM.root.modifier(placement);
   const rootClassName = classNames(bemClass.toString(), className);
+  /**
+   * The `remainingSpace` is the space for whole popover.
+   * What we want here is to always show keep `remainingSpace === popoverHeight`
+   * The `maxHeight` is for `BEM.container`, which doesn't include root class padding.
+   * So we need to minus POPOVER_PADDING here.
+   */
+  const maxHeight = remainingSpace ? remainingSpace - POPOVER_PADDING : undefined;
 
   const handleWrapperClick = (event) => {
     onInsideClick(event);
     onClick(event);
   };
-
-  const popoverPadding = 24;
 
   return (
     <ListSpacingContext.Provider value={false}>
@@ -60,7 +67,7 @@ function Popover({
         <span className={BEM.arrow} style={arrowStyle} />
         <div
           className={BEM.container}
-          style={{ maxHeight: remainingSpace ? remainingSpace - popoverPadding : undefined }}
+          style={{ maxHeight }}
         >
           {children}
         </div>

--- a/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
+++ b/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
@@ -1,7 +1,7 @@
 import documentOffset from 'document-offset';
 
 import getPositionState, {
-  getPlacement,
+  getPlacementAndRemainingSpace,
   getTopPosition,
   getLeftPositionSet,
   PLACEMENT,
@@ -31,23 +31,28 @@ jest.mock('document-offset', () => (
 describe('getPlacement()', () => {
   const { TOP, BOTTOM } = PLACEMENT;
   const runTest = it.each`
-        expected  | defaultVal | situation       | anchorTop | anchorHeight | selfHeight
-        ${TOP}    | ${TOP}     | ${'enough'}     | ${120}    | ${30}        | ${100}
-        ${BOTTOM} | ${TOP}     | ${'not enough'} | ${90}     | ${30}        | ${100}
-        ${TOP}    | ${BOTTOM}  | ${'not enough'} | ${600}    | ${100}       | ${100}
-        ${BOTTOM} | ${BOTTOM}  | ${'enough'}     | ${300}    | ${100}       | ${100}
+        expected  | defaultVal | situation                                      | anchorTop | anchorHeight | selfHeight | remainingSpace
+        ${TOP}    | ${TOP}     | ${'enough'}                                    | ${120}    | ${30}        | ${100}     | ${120}
+        ${BOTTOM} | ${TOP}     | ${'not enough for top'}                        | ${90}     | ${30}        | ${100}     | ${648}
+        ${TOP}    | ${BOTTOM}  | ${'not enough for bottom'}                     | ${600}    | ${100}       | ${100}     | ${600}
+        ${BOTTOM} | ${BOTTOM}  | ${'enough'}                                    | ${300}    | ${100}       | ${100}     | ${368}
+        ${BOTTOM} | ${BOTTOM}  | ${'not enough for both, but bottom is larger'} | ${300}    | ${100}       | ${400}     | ${368}
+        ${TOP}    | ${BOTTOM}  | ${'not enough for both, but top is larger'}    | ${450}    | ${100}       | ${500}     | ${450}
     `;
 
   runTest(
-    'returns $expected when default is $defaultVal, and there is $situation space',
-    ({ expected, defaultVal, anchorTop, anchorHeight, selfHeight }) => {
-      const result = getPlacement(
+    'returns $expected when default is $defaultVal, and the space is $situation',
+    ({
+      expected, defaultVal, anchorTop, anchorHeight, selfHeight, remainingSpace,
+    }) => {
+      const result = getPlacementAndRemainingSpace(
         defaultVal,
         anchorTop,
         anchorHeight,
         selfHeight,
       );
-      expect(result).toBe(expected);
+      expect(result.placement).toBe(expected);
+      expect(result.remainingSpace).toBe(remainingSpace);
     }
   );
 });

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -41,7 +41,7 @@ export function getPlacement(defaultPlacement, anchorRectTop, anchorHeight, self
   if (defaultPlacement === TOP && !hasSpaceToPlaceSelfAbove) {
     return BOTTOM;
   }
-  if (defaultPlacement === BOTTOM && !hasSpaceToPlaceSelfBelow) {
+  if (defaultPlacement === BOTTOM && !hasSpaceToPlaceSelfBelow && hasSpaceToPlaceSelfAbove) {
     return TOP;
   }
 

--- a/packages/core/src/mixins/anchored/index.js
+++ b/packages/core/src/mixins/anchored/index.js
@@ -15,6 +15,7 @@ export const anchoredPropTypes = {
   placement: PropTypes.oneOf(Object.values(PLACEMENT)),
   arrowStyle: PropTypes.objectOf(PropTypes.number),
   nodeRef: PropTypes.func,
+  remainingSpace: PropTypes.number.isRequired,
 };
 
 function filterDOMNode(node) {
@@ -127,6 +128,7 @@ const anchored = ({
             placement,
             position,
             arrowPosition,
+            remainingSpace,
           } = this.getPositions(
             filterDOMNode(anchor),
             filterDOMNode(selfNode),
@@ -142,6 +144,7 @@ const anchored = ({
             <WrappedComponent
               {...otherProps}
               placement={placement}
+              remainingSpace={remainingSpace}
               arrowStyle={arrowPosition}
               style={mergedStyle}
               nodeRef={this.setSelfNode}


### PR DESCRIPTION
# Purpose

修正當 placement 設定為向下 (`bottom`) 的 popover 下方空間不足時往上長，結果導致看不到 popover 上半部的問題。

這是因為現在 `anchored` 的邏輯，在原本的 placement 向下且空間不足時，就會往上。因此當 popover 的內容沒有出現捲軸(不超過 `max-height`)，但又比上方空間長時，popover 上面的東西就點不到。

~解法：當 popover 的 placement 設定為向下，且下方和上方的空間都不足時，還是向下長。缺點是有機會破圖，但相對不能按應該還是好些。~

根據後續的討論，改成在上下都不夠顯示 popover 時，用空間較足夠的那邊作為 placement。並且計算剩餘空間給下面的 `<Popover>` 作為 `max-height` 來確保不會高到破版。

# Changes

- a list of what have been done
- maybe some code change

# Risk

會影響到 `<Tooltip>` 和 `<Popover>` 在 placement 設為 bottom 且上下空間都不夠時的行為，其餘不影響。

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
