### PR TITLE
修改 SwitchRow disabled style

### DIFF
--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -92,7 +92,7 @@ class SwitchRow extends PureComponent {
       return (
         <ListRow className={className} {...rowProps}>
           <TextLabel
-            bold={!ineditable}
+            disabled={ineditable}
             verticalOrder="reverse"
             basic={this.getSwitchAside()}
             aside={label}


### PR DESCRIPTION
# Purpose
- `SwitchRow` disabled 時，其中的 `TextLabel` 是以非 `bold` 的樣式顯示，現在修改為 `disabled` 樣式。
- 這個修改同時影響到 disabled 以及 readOnly 兩個 style，也就是說當 `SwitchRow` readOnly 時，其中的 `TextLabel` 也是以 `disabled` 的樣式顯示。

Before:
![image](https://user-images.githubusercontent.com/9179190/102031020-a9317180-3def-11eb-8fc1-fb8547b72da3.png)

After:
![image](https://user-images.githubusercontent.com/9179190/102030786-fcef8b00-3dee-11eb-87b5-9522ca97d5f9.png)


# Changes
- 掃過一次 cloud/frontend，沒有 component 用到 SwitchRow 的 `disabled` or `readonly`，所以基本上沒有影響

