### PR TITLE
[Popup] Make Popup message able to display line break with newline characters

### DIFF
--- a/packages/core/src/Popup.js
+++ b/packages/core/src/Popup.js
@@ -27,6 +27,7 @@ export const BEM = {
   body: ROOT_BEM.element('body'),
   messageTitle: ROOT_BEM.element('message-title'),
   messageDesc: ROOT_BEM.element('message-desc'),
+  messageDescWithTitle: ROOT_BEM.element('message-desc').modifier('with-title'),
   button: ROOT_BEM.element('button'),
   buttonsGroup: ROOT_BEM.element('buttons-group'),
 };
@@ -63,13 +64,15 @@ export function PopupMessage({ title, message }) {
     return (
       <>
         <div className={BEM.messageTitle}>{title}</div>
-        <div className={BEM.messageDesc}>{message}</div>
+        <div className={BEM.messageDescWithTitle}>{message}</div>
       </>
     );
   }
 
   // variant: simple message
-  return message;
+  return (
+    <div className={BEM.messageDesc}>{message}</div>
+  );
 }
 PopupMessage.propTypes = {
   title: PropTypes.node,

--- a/packages/core/src/__tests__/Popup.test.js
+++ b/packages/core/src/__tests__/Popup.test.js
@@ -76,7 +76,7 @@ describe('<Popup> icon', () => {
 });
 
 describe('<Popup> message', () => {
-  it('supports message with optional title', () => {
+  it('supports message with title', () => {
     const wrapper = shallow(
       <PurePopup title="foo" message="bar" />
     );
@@ -85,8 +85,19 @@ describe('<Popup> message', () => {
     expect(
       messageWrapper.containsAllMatchingElements([
         <div className={POPUP_BEM.messageTitle}>foo</div>,
-        <div className={POPUP_BEM.messageDesc}>bar</div>,
+        <div className={POPUP_BEM.messageDescWithTitle}>bar</div>,
       ])
+    ).toBeTruthy();
+  });
+
+  it('supports message without title', () => {
+    const wrapper = shallow(
+      <PurePopup message="foo" />
+    );
+    const messageWrapper = wrapper.find(PopupMessage).shallow();
+
+    expect(
+      messageWrapper.containsMatchingElement(<div className={POPUP_BEM.messageDesc}>foo</div>)
     ).toBeTruthy();
   });
 

--- a/packages/core/src/styles/Popup.scss
+++ b/packages/core/src/styles/Popup.scss
@@ -69,6 +69,10 @@ $component: #{$prefix}-popup;
 
     // Message desc
     &__message-desc {
+        white-space: pre-line;
+    }
+
+    &__message-desc--with-title {
         font-size: rem(14px);
         line-height: rem(20px);
         color: rgba(0, 0, 0, .7);

--- a/packages/storybook/examples/core/Popup.stories.js
+++ b/packages/storybook/examples/core/Popup.stories.js
@@ -145,7 +145,11 @@ export function CustomMessageNode() {
 }
 
 export function VeryLongMessage() {
-  const MESSAGE = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae finibus elit. In ante odio, pretium vel convallis ut, mattis eget turpis. Praesent eget mattis neque. Fusce sit amet libero magna. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Etiam vehicula vel justo vitae varius. Nulla vitae dui libero. Mauris aliquam orci nunc, sit amet aliquet libero bibendum nec. Nulla metus ante, mattis sagittis tortor vitae, consequat ultricies neque. Integer vel urna fermentum, finibus justo ornare, malesuada erat.';
+  const MESSAGE = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+   Mauris vitae finibus elit. In ante odio, pretium vel convallis ut, mattis eget turpis.
+   Praesent eget mattis neque. Fusce sit amet libero magna. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Etiam vehicula vel justo vitae varius.
+   Nulla vitae dui libero. Mauris aliquam orci nunc, sit amet aliquet libero bibendum nec. Nulla metus ante, mattis sagittis tortor vitae, consequat ultricies neque. Integer vel urna fermentum, finibus justo ornare, malesuada erat.
+  `;
 
   return (
     <Popup


### PR DESCRIPTION

# Purpose
讓 Popup 的 `message` 遇到換行字元 e.g. `\n` 的時候可以顯示換行

![popup-line-break](https://user-images.githubusercontent.com/35912430/102058586-ac961e80-3e2a-11eb-8625-00702ca76245.png)

# Changes
- 新增 `white-space: pre-line`，讓文字可在有換行字元時換行
- 新增 `with-title` 的 modifier class 並將原本 `message-desc` 的樣式移入
- 由於 `message` 在有 `title` 跟沒有 `title` 的狀況下會有不同樣式（字體大小、顏色等），所以分開處理


# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
