### PR TITLE
[Bugfix] Change errorMsg prop type to array

### DIFF
--- a/packages/core/src/ListRow.js
+++ b/packages/core/src/ListRow.js
@@ -52,8 +52,8 @@ class ListRow extends PureComponent {
 
       return (
         <div className={BEM.footer.toString()}>
-          {errorMsg && wrapIfNotElement(errorMsg, { with: 'p' })}
-          {desc && wrapIfNotElement(desc, { with: 'p' })}
+          {errorMsg && wrapIfNotElement(errorMsg, { with: 'div' })}
+          {desc && wrapIfNotElement(desc, { with: 'div' })}
         </div>
       );
     }

--- a/packages/core/src/mixins/withStatus.js
+++ b/packages/core/src/mixins/withStatus.js
@@ -11,7 +11,10 @@ export { STATUS_CODE };
 export const statusPropTypes = {
   status: PropTypes.oneOf(Object.values(STATUS_CODE)),
   statusOptions: PropTypes.object,
-  errorMsg: PropTypes.arrayOf(PropTypes.node),
+  errorMsg: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
 };
 
 // prop types for what's going to set on wrapped component

--- a/packages/core/src/mixins/withStatus.js
+++ b/packages/core/src/mixins/withStatus.js
@@ -11,7 +11,7 @@ export { STATUS_CODE };
 export const statusPropTypes = {
   status: PropTypes.oneOf(Object.values(STATUS_CODE)),
   statusOptions: PropTypes.object,
-  errorMsg: PropTypes.string,
+  errorMsg: PropTypes.arrayOf(PropTypes.node),
 };
 
 // prop types for what's going to set on wrapped component

--- a/packages/core/src/styles/ListRow.scss
+++ b/packages/core/src/styles/ListRow.scss
@@ -35,7 +35,7 @@ $component: #{$prefix}-list-row;
         padding-bottom: rem($list-row-footer-padding-bottom);
         white-space: pre-wrap;
 
-        p {
+        & > div {
             margin: 0 0 rem($list-row-footer-padding-bottom);
         }
     }


### PR DESCRIPTION
# Purpose
- Let ListRow errorMsg support array of React node.
- Fix p tag wrap other tag.

![image](https://user-images.githubusercontent.com/9179190/102858153-bfc96f80-4464-11eb-862d-fa095308b333.png)

![image](https://user-images.githubusercontent.com/9179190/102858164-c6f07d80-4464-11eb-94b8-519cd3fe37d2.png)


# Changes
- ListRow.js

