### PR TITLE
Remove isRequired of anchor props  'remainingSpace'

### DIFF
--- a/packages/core/src/mixins/anchored/index.js
+++ b/packages/core/src/mixins/anchored/index.js
@@ -15,7 +15,7 @@ export const anchoredPropTypes = {
   placement: PropTypes.oneOf(Object.values(PLACEMENT)),
   arrowStyle: PropTypes.objectOf(PropTypes.number),
   nodeRef: PropTypes.func,
-  remainingSpace: PropTypes.number.isRequired,
+  remainingSpace: PropTypes.number,
 };
 
 function filterDOMNode(node) {


### PR DESCRIPTION
# Purpose

在製作 https://github.com/iCHEF/cloud-frontend/pull/961 的時候，發現原本的設定會導致 Popover 在不傳 `remainingSpace` 的時候報錯：

![error-message](https://user-images.githubusercontent.com/35912430/103335606-625e9f80-4ab0-11eb-8c48-272263df9cdc.png)

但根據[這行](https://github.com/iCHEF/gypcrete/blob/develop/packages/core/src/Popover.js#L51)，推測該 props 應非必填 props


# Changes
移除`remainingSpace` props 的必填設定

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
