### PR TITLE
Bugfix: Change EditableTextLabel to listen touchEnd event

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -13,6 +13,9 @@ reviewers:
   - benny0642
   - leannechen
   - a26620236
+  - sharonshenzizi
+  - brianwu291
+  - YuCJ
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Use node 12 in travis CI. (#290)
 - [Core] Add `titleRightArea` on `<Section>` / `<List>`. (#297)
 - [Core] Fix popover placement when there is no enough space on top or bottom of content. (#303)
+- [Core] Change `<EditableTextLabel>` onTouchStart event handler to onTouchEnd event handler (#310)
 
 ### Added
 - [Core] Add `muted` prop on following component: (#278)

--- a/packages/core/src/EditableTextLabel.js
+++ b/packages/core/src/EditableTextLabel.js
@@ -105,7 +105,7 @@ class EditableTextLabel extends PureComponent {
       onDblClick(event);
     }
 
-    handleTouchStart = (event) => {
+    handleTouchEnd = (event) => {
       const { touchCount, dblTouchTimeout } = this.state;
       const currentCount = touchCount + 1;
 
@@ -180,7 +180,7 @@ class EditableTextLabel extends PureComponent {
           <TextLabel
             status={status}
             onDoubleClick={this.handleDoubleClick}
-            onTouchStart={this.handleTouchStart}
+            onTouchEnd={this.handleTouchEnd}
             {...labelProps}
           />
         );

--- a/packages/core/src/__tests__/EditableTextLabel.test.js
+++ b/packages/core/src/__tests__/EditableTextLabel.test.js
@@ -181,11 +181,11 @@ describe('Double-touch simulation', () => {
     expect(handleDblClick).not.toHaveBeenCalled();
 
     return new Promise((resolve) => {
-      wrapper.simulate('touchstart');
+      wrapper.simulate('touchend');
       expect(wrapper.state('touchCount')).toBe(1);
 
       setTimeout(() => {
-        wrapper.simulate('touchstart');
+        wrapper.simulate('touchend');
         resolve();
       }, 200);
     }).then(() => {


### PR DESCRIPTION
# Purpose
- Change `onTouchStart` to `onTouchEnd` in `EditableTextLabel`.
- Because react dnd multi-backend would dispatch  a cloned version of the touchstart event, it would make `handleTouchStart` event handler in `EditableTextLabel` executed twice.

