### PR TITLE
[Bugfix] Switch is overflow hidden in SwitchRow

### DIFF
--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -7,18 +7,7 @@ import {
   TextLabel,
 } from '@ichef/gypcrete';
 
-import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
-import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
-
 import formRow, { rowPropTypes } from './mixins/formRow';
-import './styles/SwitchRow.scss';
-
-export const COMPONENT_NAME = prefixClass('form-switch');
-const ROOT_BEM = icBEM(COMPONENT_NAME);
-export const BEM = {
-  root: ROOT_BEM,
-  switch: ROOT_BEM.element('switch'),
-};
 
 /**
  * A row consisting a text label (on the left) and a switch button (on the right).
@@ -112,7 +101,7 @@ class SwitchRow extends PureComponent {
           <Switch
             status={null}
             onChange={this.handleSwitchButtonChange}
-            className={BEM.switch.toString()}
+            minified
             {...switchProps}
           />
 

--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -7,7 +7,18 @@ import {
   TextLabel,
 } from '@ichef/gypcrete';
 
+import prefixClass from '@ichef/gypcrete/lib/utils/prefixClass';
+import icBEM from '@ichef/gypcrete/lib/utils/icBEM';
+
 import formRow, { rowPropTypes } from './mixins/formRow';
+import './styles/SwitchRow.scss';
+
+export const COMPONENT_NAME = prefixClass('form-switch');
+const ROOT_BEM = icBEM(COMPONENT_NAME);
+export const BEM = {
+  root: ROOT_BEM,
+  switch: ROOT_BEM.element('switch'),
+};
 
 /**
  * A row consisting a text label (on the left) and a switch button (on the right).
@@ -101,6 +112,7 @@ class SwitchRow extends PureComponent {
           <Switch
             status={null}
             onChange={this.handleSwitchButtonChange}
+            className={BEM.switch.toString()}
             {...switchProps}
           />
 

--- a/packages/form/src/styles/SwitchRow.scss
+++ b/packages/form/src/styles/SwitchRow.scss
@@ -1,7 +1,0 @@
-$componenet-name: gyp-form-switch;
-
-.#{$componenet-name} {
-  &__switch {
-    flex: 1 0 auto;
-  }
-}

--- a/packages/form/src/styles/SwitchRow.scss
+++ b/packages/form/src/styles/SwitchRow.scss
@@ -1,0 +1,7 @@
+$componenet-name: gyp-form-switch;
+
+.#{$componenet-name} {
+  &__switch {
+    flex: 1 0 auto;
+  }
+}


### PR DESCRIPTION
# Purpose

- Fix `Switch` is overflow hidden in `SwitchRow` with setting minified true.
![image](https://user-images.githubusercontent.com/9179190/112937340-0f9d8e00-915a-11eb-8f2c-9c6968e8ebb3.png)


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
