### PR TITLE
Add `skip` in closable, `refreshOnWindowResize` and `distanceFromAnchor` in `anchored`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Fix popover placement when there is no enough space on top or bottom of content. (#303)
 - [Core] Change `<EditableTextLabel>` onTouchStart event handler to onTouchEnd event handler (#310)
 - [Core] Disable dropdown icon when `<SelectRow>` is ineditable. (#320)
+- [Core] Add `skip` prop on `closable` mixin. (#324)
+- [Core] Add `refreshOnWindowResize` and `distanceFromAnchor` prop on `anchored`. (#324)
 
 ### Added
 - [Core] Add `muted` prop on following component: (#278)

--- a/packages/core/src/mixins/__tests__/closable.test.js
+++ b/packages/core/src/mixins/__tests__/closable.test.js
@@ -192,3 +192,26 @@ describe.each`
     expect(handleClose).toHaveBeenCalledTimes(shouldBeCalled ? 1 : 0);
   });
 });
+
+it('prevent render closable overlay on runtime by passing skip=true', () => {
+  const ClosableFoo = closable({
+    onEscape: true,
+    onClickOutside: true,
+  })(Foo);
+  const handleClose = jest.fn();
+
+  const wrapper = mount((
+    <ClosableFoo
+      onClose={handleClose}
+      closable={{
+        skip: true,
+      }}
+    />
+  ));
+
+  expect(wrapper.find('div.gyp-closable')).toHaveLength(0);
+
+  const event = new KeyboardEvent('keyup', { keyCode: keycode('Escape') });
+  document.dispatchEvent(event);
+  expect(handleClose).not.toHaveBeenCalled();
+});

--- a/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
+++ b/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
@@ -31,25 +31,33 @@ jest.mock('document-offset', () => (
 describe('getPlacement()', () => {
   const { TOP, BOTTOM } = PLACEMENT;
   const runTest = it.each`
-        expected  | defaultVal | situation                                      | anchorTop | anchorHeight | selfHeight | remainingSpace
-        ${TOP}    | ${TOP}     | ${'enough'}                                    | ${120}    | ${30}        | ${100}     | ${120}
-        ${BOTTOM} | ${TOP}     | ${'not enough for top'}                        | ${90}     | ${30}        | ${100}     | ${648}
-        ${TOP}    | ${BOTTOM}  | ${'not enough for bottom'}                     | ${600}    | ${100}       | ${100}     | ${600}
-        ${BOTTOM} | ${BOTTOM}  | ${'enough'}                                    | ${300}    | ${100}       | ${100}     | ${368}
-        ${BOTTOM} | ${BOTTOM}  | ${'not enough for both, but bottom is larger'} | ${300}    | ${100}       | ${400}     | ${368}
-        ${TOP}    | ${BOTTOM}  | ${'not enough for both, but top is larger'}    | ${450}    | ${100}       | ${500}     | ${450}
+        expected  | defaultVal | situation                                             | anchorTop | anchorHeight | selfHeight | remainingSpace | distanceFromAnchor
+        ${TOP}    | ${TOP}     | ${'enough'}                                           | ${120}    | ${30}        | ${100}     | ${120}         | ${0}
+        ${BOTTOM} | ${TOP}     | ${'not enough for top'}                               | ${90}     | ${30}        | ${100}     | ${648}         | ${0}
+        ${BOTTOM} | ${TOP}     | ${'not enough for top consider distance from anchor'} | ${100}    | ${30}        | ${100}     | ${638}         | ${10}
+        ${TOP}    | ${BOTTOM}  | ${'not enough for bottom'}                            | ${600}    | ${100}       | ${100}     | ${600}         | ${0}
+        ${BOTTOM} | ${BOTTOM}  | ${'enough'}                                           | ${300}    | ${100}       | ${100}     | ${368}         | ${0}
+        ${BOTTOM} | ${BOTTOM}  | ${'not enough for both, but bottom is larger'}        | ${300}    | ${100}       | ${400}     | ${368}         | ${0}
+        ${TOP}    | ${BOTTOM}  | ${'not enough for both, but top is larger'}           | ${450}    | ${100}       | ${500}     | ${450}         | ${0}
     `;
 
   runTest(
     'returns $expected when default is $defaultVal, and the space is $situation',
     ({
-      expected, defaultVal, anchorTop, anchorHeight, selfHeight, remainingSpace,
+      expected,
+      defaultVal,
+      anchorTop,
+      anchorHeight,
+      selfHeight,
+      remainingSpace,
+      distanceFromAnchor,
     }) => {
       const result = getPlacementAndRemainingSpace(
         defaultVal,
         anchorTop,
         anchorHeight,
         selfHeight,
+        distanceFromAnchor
       );
       expect(result.placement).toBe(expected);
       expect(result.remainingSpace).toBe(remainingSpace);
@@ -60,19 +68,28 @@ describe('getPlacement()', () => {
 describe('getTopPosition()', () => {
   const { TOP, BOTTOM } = PLACEMENT;
   const runTest = it.each`
-        expected  | placement  | anchorTop | anchorHeight | selfHeight
-        ${20}     | ${TOP}     | ${120}    | ${30}        | ${100}
-        ${400}    | ${BOTTOM}  | ${300}    | ${100}       | ${100}
+        expected  | placement  | anchorTop | anchorHeight | selfHeight | distanceFromAnchor
+        ${20}     | ${TOP}     | ${120}    | ${30}        | ${100}     | ${0}
+        ${10}     | ${TOP}     | ${120}    | ${30}        | ${100}     | ${10}
+        ${400}    | ${BOTTOM}  | ${300}    | ${100}       | ${100}     | ${0}
     `;
 
   runTest(
     'returns $expected when placed on $placement of anchor (y=$anchorTop, h=$anchorHeight)',
-    ({ expected, placement, anchorTop, anchorHeight, selfHeight }) => {
+    ({
+      expected,
+      placement,
+      anchorTop,
+      anchorHeight,
+      selfHeight,
+      distanceFromAnchor,
+    }) => {
       const result = getTopPosition(
         placement,
         anchorTop,
         anchorHeight,
         selfHeight,
+        distanceFromAnchor
       );
       expect(result).toBe(expected);
     }
@@ -234,7 +251,7 @@ describe('getPositionState()', () => {
       left: 10,
     });
 
-    const result = getterFunc(anchorNode, selfNode);
+    const result = getterFunc(anchorNode, selfNode, 0);
 
     expect(anchorNode.getBoundingClientRect).toHaveBeenCalled();
     expect(selfNode.getBoundingClientRect).toHaveBeenCalled();

--- a/packages/core/src/mixins/anchored/__tests__/index.js
+++ b/packages/core/src/mixins/anchored/__tests__/index.js
@@ -88,5 +88,6 @@ it('passed anchor and self nodes to getter function for position config', () => 
   expect(mockedGetterFunc).toHaveBeenCalledWith(
     anchorRef.current,
     wrapper.state().selfNode,
+    0
   );
 });

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -31,17 +31,19 @@ export const PLACEMENT = { TOP, BOTTOM };
  * @param {number} anchorRectTop
  * @param {number} anchorHeight
  * @param {number} selfHeight
+ * @param {number} distanceFromAnchor
  * @returns {{ placement: Placement, remainingSpace: number }}
  */
 export function getPlacementAndRemainingSpace(
   defaultPlacement,
   anchorRectTop,
   anchorHeight,
-  selfHeight
+  selfHeight,
+  distanceFromAnchor,
 ) {
-  const hasSpaceToPlaceSelfAbove = anchorRectTop >= selfHeight;
+  const hasSpaceToPlaceSelfAbove = anchorRectTop >= selfHeight + distanceFromAnchor;
   const hasSpaceToPlaceSelfBelow = (
-    (anchorRectTop + anchorHeight + selfHeight) <= window.innerHeight
+    (anchorRectTop + anchorHeight + selfHeight + distanceFromAnchor) <= window.innerHeight
   );
   const topSpace = anchorRectTop;
   const bottomSpace = window.innerHeight - anchorRectTop - anchorHeight;
@@ -71,15 +73,22 @@ export function getPlacementAndRemainingSpace(
  * @param {number} anchorOffsetTop
  * @param {number} anchorHeight
  * @param {number} selfHeight
+ * @param {number} distanceFromAnchor
  */
-export function getTopPosition(placement, anchorOffsetTop, anchorHeight, selfHeight) {
+export function getTopPosition(
+  placement,
+  anchorOffsetTop,
+  anchorHeight,
+  selfHeight,
+  distanceFromAnchor,
+) {
   let positionTop = 0;
 
   if (placement === TOP) {
     // Make sure user can see whole wrapped component when placement is TOP.
-    positionTop = Math.max(anchorOffsetTop - selfHeight, 0);
+    positionTop = Math.max(anchorOffsetTop - selfHeight - distanceFromAnchor, 0);
   } else {
-    positionTop = anchorOffsetTop + anchorHeight;
+    positionTop = anchorOffsetTop + anchorHeight + distanceFromAnchor;
   }
 
   return positionTop;
@@ -175,10 +184,18 @@ export function getLeftPositionSet(
  *
  * @param {Placement} defaultPlacement
  * @param {number} edgePadding
- * @returns {(anchorNode:HTMLElement, selfNode:HTMLElement) => ResultState}
+ * @returns {(
+ *  anchorNode:HTMLElement,
+ *  selfNode:HTMLElement,
+ *  distanceFromAnchor: number
+ * ) => ResultState}
  */
 
-const getPositionState = (defaultPlacement, edgePadding) => (anchorNode, selfNode) => {
+const getPositionState = (defaultPlacement, edgePadding) => (
+  anchorNode,
+  selfNode,
+  distanceFromAnchor = 0,
+) => {
   if (!anchorNode || !selfNode) {
     return {
       placement: defaultPlacement,
@@ -206,6 +223,7 @@ const getPositionState = (defaultPlacement, edgePadding) => (anchorNode, selfNod
     anchorRect.top,
     anchorRect.height,
     selfRect.height,
+    distanceFromAnchor,
   );
 
   const selfTop = getTopPosition(
@@ -213,6 +231,7 @@ const getPositionState = (defaultPlacement, edgePadding) => (anchorNode, selfNod
     anchorOffset.top,
     anchorRect.height,
     selfRect.height,
+    distanceFromAnchor,
   );
 
   const { selfLeft, arrowLeft } = getLeftPositionSet(

--- a/packages/core/src/mixins/anchored/index.js
+++ b/packages/core/src/mixins/anchored/index.js
@@ -97,11 +97,13 @@ const anchored = ({
         static propTypes = {
           anchor: PropTypes.instanceOf(window.HTMLElement),
           refreshOnWindowResize: PropTypes.bool,
+          distanceFromAnchor: PropTypes.number,
         };
 
         static defaultProps = {
           anchor: null,
           refreshOnWindowResize: false,
+          distanceFromAnchor: 0,
         };
 
         state = {
@@ -131,11 +133,15 @@ const anchored = ({
         }
 
         getPositions = (anchor, selfNode) => {
-          const { refreshOnWindowResize } = this.props;
+          const { refreshOnWindowResize, distanceFromAnchor } = this.props;
           if (!refreshOnWindowResize) {
-            return defaultGetPositionState(anchor, selfNode);
+            return defaultGetPositionState(anchor, selfNode, distanceFromAnchor);
           }
-          return getPositionState(defaultPlacement, edgePadding)(anchor, selfNode)
+          return getPositionState(defaultPlacement, edgePadding)(
+            anchor,
+            selfNode,
+            distanceFromAnchor
+          );
         }
 
         setSelfNode = (nodeRef) => {
@@ -146,6 +152,7 @@ const anchored = ({
           const {
             anchor,
             style,
+            distanceFromAnchor,
             refreshOnWindowResize,
             ...otherProps
           } = this.props;

--- a/packages/core/src/mixins/closable.js
+++ b/packages/core/src/mixins/closable.js
@@ -46,6 +46,7 @@ const closable = ({
             onClickOutside: PropTypes.bool,
             onClickInside: PropTypes.bool,
             stopEventPropagation: PropTypes.bool,
+            skip: PropTypes.bool,
           }),
         };
 
@@ -55,11 +56,15 @@ const closable = ({
         };
 
         componentDidMount() {
-          document.addEventListener('keyup', this.handleDocumentKeyup);
+          if (!this.props.closable.skip) {
+            document.addEventListener('keyup', this.handleDocumentKeyup);
+          }
         }
 
         componentWillUnmount() {
-          document.removeEventListener('keyup', this.handleDocumentKeyup);
+          if (!this.props.closable.skip) {
+            document.removeEventListener('keyup', this.handleDocumentKeyup);
+          }
         }
 
         getOptions() {
@@ -120,11 +125,13 @@ const closable = ({
 
           return (
             <>
-              <div
-                role="presentation"
-                className={ROOT_BEM.toString()}
-                onClick={this.handleOuterLayerClick}
-              />
+              {!runtimeOptions.skip && (
+                <div
+                  role="presentation"
+                  className={ROOT_BEM.toString()}
+                  onClick={this.handleOuterLayerClick}
+                />
+              )}
               <WrappedComponent
                 onInsideClick={this.handleInsideClick}
                 {...otherProps}


### PR DESCRIPTION
# Purpose

- Add `skip` in `closable` to remove closable layer in runtime. e.g. remove closable layer temporarily for `<Popover />`
- Add `refreshOnWindowResize` on `anchored` to keep anchored node position on resize.
- Add `distanceFromAnchor` on `anchored`, which determine the distance between anchor and anchored node (default is 0, which is current behavior).

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
