### PR TITLE
add aside clickable on disabled in RowComp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Add new icons: `takeout` (#283), `more` (#287), `table` & `order-sheet` (#323).
 - [Core] Add `topArea` prop to `<List>`. (#311)
 - [Core] Add `people` in `<Icon>`. (#313)
+- [Core] Add `asideClickableOnDisabled` prop to `<RowComp>`. (#325)
 
 ## [4.3.0]
 

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -137,6 +137,7 @@ const rowComp = ({
           aside: PropTypes.node,
           tag: PropTypes.node,
           bold: PropTypes.bool,
+          asideControlClickableOnDisabled: PropTypes.bool,
 
           // State props
           active: PropTypes.bool,
@@ -161,6 +162,7 @@ const rowComp = ({
           aside: null,
           tag: null,
           bold: false,
+          asideControlClickableOnDisabled: false,
 
           active: false,
           highlight: false,
@@ -202,9 +204,17 @@ const rowComp = ({
             aside,
             tag,
             bold,
+            asideControlClickableOnDisabled,
           } = this.props;
 
           const textLayoutProps = getTextLayoutProps(align, !!icon);
+          const asideControlClickableProps = (
+            asideControlClickableOnDisabled
+              ? {
+                onClick: (event) => { event.stopPropagation(); }
+              }
+              : undefined
+          );
 
           return {
             verticalOrder,
@@ -212,6 +222,7 @@ const rowComp = ({
             aside,
             tag,
             bold,
+            ...asideControlClickableProps,
             ...textLayoutProps,
           };
         }
@@ -249,6 +260,7 @@ const rowComp = ({
             aside,
             tag,
             bold,
+            asideControlClickableOnDisabled,
 
             active,
             highlight,
@@ -268,7 +280,8 @@ const rowComp = ({
 
           const bemClass = ROOT_BEM
             .modifier('minified', minified)
-            .modifier(align);
+            .modifier(align)
+            .modifier('aside-control-clickable', asideControlClickableOnDisabled);
 
           const stateClassNames = getStateClassnames({
             active,

--- a/packages/core/src/styles/RowComp.scss
+++ b/packages/core/src/styles/RowComp.scss
@@ -39,4 +39,30 @@
     &--minified {
         flex: 0 0 auto;
     }
+
+    &--aside-control-clickable {
+        &.#{$prefix-state}-disabled {
+          opacity: 1 !important;
+        }
+
+        .#{$prefix}-text__basic {
+          opacity: .3 !important;
+        }
+
+        .#{$prefix}-icon {
+          opacity: .3 !important;
+        }
+
+        .#{$prefix}-text__aside {
+          display: block;
+          * {
+            /* 原本 .gyp-state-disabled opacity 乘上 .gyp-text__aside opacity: 0.3 * 0.7 */
+            opacity: .21;
+          }
+          a, button {
+            opacity: 1;
+            pointer-events: auto;
+          }
+        }
+    }
 }

--- a/packages/core/src/styles/RowComp.scss
+++ b/packages/core/src/styles/RowComp.scss
@@ -55,10 +55,7 @@
 
         .#{$prefix}-text__aside {
           display: block;
-          * {
-            /* 原本 .gyp-state-disabled opacity 乘上 .gyp-text__aside opacity: 0.3 * 0.7 */
-            opacity: .21;
-          }
+
           a, button {
             opacity: 1;
             pointer-events: auto;

--- a/packages/storybook/examples/core/Button.stories.js
+++ b/packages/storybook/examples/core/Button.stories.js
@@ -179,6 +179,26 @@ export function DisabledButton() {
   );
 }
 
+export function AsideControlClickableOnDisabledButton() {
+  return (
+    <Button
+      bold
+      color="Black"
+      basic="Black"
+      aside={(
+        <>
+          Some text
+          <a target="_blank" rel="noreferrer" href="https://www.google.com">Click me</a>
+        </>
+      )}
+      asideControlClickableOnDisabled
+      disabled
+      // eslint-disable-next-line no-alert
+      onClick={() => alert('not trigger.')}
+    />
+  );
+}
+
 export function MutedButton() {
   return (
     <FlexRow>


### PR DESCRIPTION
# Purpose

讓 RowComp 內的 Text aside，在 disabled 時仍可以觸發 onClick。
用在 button 本身 disabled，但敘述文字帶有連結或其它 control 而需要 clickable 的時候。
範例見 [storybook](https://deploy-preview-325--gypcrete.netlify.app/?path=/docs/ichef-gypcrete-button--basic-usage#aside-control-clickable-on-disabled-button)

## screenshot
![截圖 2022-01-20 上午11 22 50](https://user-images.githubusercontent.com/7620906/150266512-31d5c636-9d41-4378-bf59-af7fd815a3e5.png)



# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
