### PR TITLE
[UI優化] Add popup max height

### DIFF
--- a/packages/core/src/styles/Popup.scss
+++ b/packages/core/src/styles/Popup.scss
@@ -54,6 +54,7 @@ $component: #{$prefix}-popup;
         padding: rem(16px);
         flex: 0 1 auto;
         overflow: auto;
+        max-height: 564px;
 
         .#{$component}--large & {
             padding: rem(16px) rem(56px);


### PR DESCRIPTION
# Purpose

Asana task: https://app.asana.com/0/347798529122928/1123332906306723/f
popup body 在內容過多的時候會跑版，和設計討論後對 popup body 加了一個 max height 修正此問題。
後面會再盤點後台所有用到的地方，確保不會跑版。

後續有[討論](https://github.com/iCHEF/cloud-frontend/pull/2802#discussion_r811687163)到 container 已經有加 max-height 了，不用再針對 body 加 max-height，所以關掉此 PR

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
