### PR TITLE
Add postfix for `<TextInput>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Core] Disable dropdown icon when `<SelectRow>` is ineditable. (#320)
 - [Core] Add `skip` prop on `closable` mixin. (#324)
 - [Core] Add `refreshOnWindowResize` and `distanceFromAnchor` prop on `anchored`. (#324)
+- [Core] Add `postfix` prop on `<TextInput>` / `<TextInputRow>`. (#327)
 
 ### Added
 - [Core] Add `muted` prop on following component: (#278)

--- a/packages/core/src/TextInput.js
+++ b/packages/core/src/TextInput.js
@@ -16,6 +16,7 @@ const ROOT_BEM = icBEM(COMPONENT_NAME);
 
 export const BEM = {
   input: ROOT_BEM.element('input'),
+  postfix: ROOT_BEM.element('postfix'),
 };
 
 
@@ -100,6 +101,7 @@ function TextInput({
   label,
   readOnly,
   disabled,
+  postfix,
   // <InnerInput> props
   renderInput,
   multiLine,
@@ -140,6 +142,8 @@ function TextInput({
         basic={input}
         aside={label}
       />
+
+      {postfix && <div className={BEM.postfix}>{postfix}</div>}
     </div>
   );
 }
@@ -148,6 +152,7 @@ TextInput.propTypes = {
   label: PropTypes.node,
   readOnly: PropTypes.bool,
   disabled: PropTypes.bool,
+  postfix: PropTypes.node,
   // <InnerInput> props
   renderInput: PropTypes.func,
   multiLine: PropTypes.bool,
@@ -159,6 +164,7 @@ TextInput.defaultProps = {
   label: undefined,
   readOnly: false,
   disabled: false,
+  postfix: undefined,
   // <InnerInput> props
   renderInput: undefined,
   multiLine: undefined,

--- a/packages/core/src/__tests__/TextInput.test.js
+++ b/packages/core/src/__tests__/TextInput.test.js
@@ -170,4 +170,11 @@ describe('pure <TextInput>', () => {
       },
     });
   });
+
+  it('show postfix given postfix prop', () => {
+    const wrapper = shallow(<PureTextInput postfix="Dollars" />);
+    const postfixWrapper = wrapper.find('.gyp-text-input__postfix');
+
+    expect(postfixWrapper.text()).toEqual('Dollars');
+  });
 });

--- a/packages/core/src/styles/TextInput.scss
+++ b/packages/core/src/styles/TextInput.scss
@@ -18,4 +18,11 @@
         padding: 0;
         outline: none;
     }
+
+    &__postfix {
+      margin-left: 0.5rem;
+      justify-content: flex-end;
+      align-self: flex-end;
+      font-weight: 700;
+    }
 }

--- a/packages/storybook/examples/core/TextInput.stories.js
+++ b/packages/storybook/examples/core/TextInput.stories.js
@@ -79,6 +79,19 @@ export function MultiLines() {
   );
 }
 
+export function PostFix() {
+  return (
+    <DebugBox>
+      <TextInput
+        label="Disk Size"
+        value="3.1415926"
+        postfix="TB"
+        onChange={action('change')}
+      />
+    </DebugBox>
+  );
+}
+
 export function CustomRendering() {
   return (
     <DebugBox>

--- a/packages/storybook/examples/form/TextInputRow.stories.js
+++ b/packages/storybook/examples/form/TextInputRow.stories.js
@@ -63,6 +63,16 @@ export const disabledRow = () => (
   </List>
 );
 
+export const PostfixRow = () => (
+  <List>
+    <TextInputRow
+      label="Price"
+      onChange={action('change')}
+      postfix="Dollars"
+    />
+  </List>
+);
+
 export const errorState = () => (
   <List>
     <TextInputRow


### PR DESCRIPTION
# Purpose

Add `postfix` prop for `<TextInput>` to show postfix in `<TextInput>` and `<TextInputRow>`

## Screenshots
![截圖 2022-03-21 下午4 25 01](https://user-images.githubusercontent.com/7620906/159226012-109f3201-b04a-417f-b719-a6ba5f2ae039.png)


![截圖 2022-03-21 下午4 24 52](https://user-images.githubusercontent.com/7620906/159226002-48342432-367b-4af9-b203-d291ca2ff24f.png)


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
