### PR TITLE
移除不必要的 css 屬性

### DIFF
--- a/packages/core/src/styles/Popup.scss
+++ b/packages/core/src/styles/Popup.scss
@@ -36,7 +36,6 @@ $component: #{$prefix}-popup;
         flex-direction: column;
 
         // Active animation
-        opacity: 0;
         animation: anim-bounce-in .6s forwards;
 
         .#{$component}--large & {


### PR DESCRIPTION
# Purpose
起因是有個 [後台 popup 無法正常顯示的 issue](https://app.asana.com/0/1201530847918073/1201995968067616/f)，經查後發現多餘的 css 屬性在 Ipad OS 15.4 的瀏覽器上出問題(詳見 PR 註解)，應該是個 ios 15.4 的 bug，這邊就先拔掉修正此問題


https://user-images.githubusercontent.com/47882138/159432700-415abde0-4edf-4865-a3e1-c7769c574c02.mov


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
