### PR TITLE
[Bugfix] Should not apply asideControlClickableOnDisabled if not disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- [Core] Should not apply asideControlClickableOnDisabled if not disabled. (#332)
+
 ## [4.4.0]
 
 ### Breaking

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -205,13 +205,14 @@ const rowComp = ({
             tag,
             bold,
             asideControlClickableOnDisabled,
+            disabled,
           } = this.props;
 
           const textLayoutProps = getTextLayoutProps(align, !!icon);
           const asideControlClickableProps = (
-            asideControlClickableOnDisabled
+            (asideControlClickableOnDisabled && disabled)
               ? {
-                onClick: (event) => { event.stopPropagation(); }
+                onClick: (event) => { event.stopPropagation(); },
               }
               : undefined
           );

--- a/packages/core/src/styles/RowComp.scss
+++ b/packages/core/src/styles/RowComp.scss
@@ -43,22 +43,22 @@
     &--aside-control-clickable {
         &.#{$prefix-state}-disabled {
           opacity: 1 !important;
-        }
 
-        .#{$prefix}-text__basic {
-          opacity: .3 !important;
-        }
-
-        .#{$prefix}-icon {
-          opacity: .3 !important;
-        }
-
-        .#{$prefix}-text__aside {
-          display: block;
-
-          a, button {
-            opacity: 1;
-            pointer-events: auto;
+          .#{$prefix}-text__basic {
+            opacity: .3 !important;
+          }
+  
+          .#{$prefix}-icon {
+            opacity: .3 !important;
+          }
+  
+          .#{$prefix}-text__aside {
+            display: block;
+  
+            a, button {
+              opacity: 1;
+              pointer-events: auto;
+            }
           }
         }
     }


### PR DESCRIPTION
# Purpose

`asideControlClickableOnDisabled` prop should not applied if `disabled` prop is `false`, or the click event handler on `rowComp()` wont trigger.


# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
