### PR TITLE
[Chore] 指定 Node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "iCHEF/gypcrete",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 8.2.1",
+    "node": ">= 8.2.1 <= 12",
     "npm": ">= 5.10.0",
     "yarn": ">= 1.10.0"
   },


### PR DESCRIPTION
# Purpose
先前沒有特別指定 node version，但實際上如果用 > 12 的版本 node sass 會炸裂，無法正常跑 yarn start 等指令
所以這邊處理
1. 在 package.json 指定版本：雖然是建議性質沒有強制，但可讓開發者參考
2. 新增 .nvmrc：讓有用 nvm 的開發者可自動切換到指定版本
![截圖 2022-04-08 下午3 55 15](https://user-images.githubusercontent.com/35912430/162420564-f53ff22c-4f5b-4d55-b055-46915aebb674.png)

Ref: 
1. https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines
1. https://github.com/nvm-sh/nvm#nvmrc

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
