### PR TITLE
[RasioSelectList] rename 原有的 checkbox 相關的 svg 檔案

### DIFF
--- a/packages/core/src/icons/components/CheckboxEmpty.js
+++ b/packages/core/src/icons/components/CheckboxEmpty.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function SvgRadioEmpty(props) {
+export default function SvgCheckboxEmpty(props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/core/src/icons/components/CheckboxHalf.js
+++ b/packages/core/src/icons/components/CheckboxHalf.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function SvgRadioHalf(props) {
+export default function SvgCheckboxHalf(props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/core/src/icons/components/CheckboxSelected.js
+++ b/packages/core/src/icons/components/CheckboxSelected.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function SvgRadioSelected(props) {
+export default function SvgCheckboxSelected(props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/core/src/icons/components/index.js
+++ b/packages/core/src/icons/components/index.js
@@ -62,7 +62,7 @@ import PrevPage from './PrevPage';
 import Prev from './Prev';
 import Printer from './Printer';
 import Question from './Question';
-import RadioEmpty from './RadioEmpty';
+import CheckboxEmpty from './CheckboxEmpty';
 import RadioHalf from './RadioHalf';
 import RadioSelected from './RadioSelected';
 import Refresh from './Refresh';
@@ -143,7 +143,7 @@ export default {
   prev: Prev,
   printer: Printer,
   question: Question,
-  'radio-empty': RadioEmpty,
+  'checkbox-empty': CheckboxEmpty,
   'radio-half': RadioHalf,
   'radio-selected': RadioSelected,
   refresh: Refresh,

--- a/packages/core/src/icons/components/index.js
+++ b/packages/core/src/icons/components/index.js
@@ -63,7 +63,7 @@ import Prev from './Prev';
 import Printer from './Printer';
 import Question from './Question';
 import CheckboxEmpty from './CheckboxEmpty';
-import RadioHalf from './RadioHalf';
+import CheckboxHalf from './CheckboxHalf';
 import RadioSelected from './RadioSelected';
 import Refresh from './Refresh';
 import RemoveElement from './RemoveElement';
@@ -144,7 +144,7 @@ export default {
   printer: Printer,
   question: Question,
   'checkbox-empty': CheckboxEmpty,
-  'radio-half': RadioHalf,
+  'checkbox-half': CheckboxHalf,
   'radio-selected': RadioSelected,
   refresh: Refresh,
   'remove-element': RemoveElement,

--- a/packages/core/src/icons/components/index.js
+++ b/packages/core/src/icons/components/index.js
@@ -64,7 +64,7 @@ import Printer from './Printer';
 import Question from './Question';
 import CheckboxEmpty from './CheckboxEmpty';
 import CheckboxHalf from './CheckboxHalf';
-import RadioSelected from './RadioSelected';
+import CheckboxSelected from './CheckboxSelected';
 import Refresh from './Refresh';
 import RemoveElement from './RemoveElement';
 import Retry from './Retry';
@@ -145,7 +145,7 @@ export default {
   question: Question,
   'checkbox-empty': CheckboxEmpty,
   'checkbox-half': CheckboxHalf,
-  'radio-selected': RadioSelected,
+  'checkbox-selected': CheckboxSelected,
   refresh: Refresh,
   'remove-element': RemoveElement,
   retry: Retry,

--- a/packages/core/src/icons/svg/checkbox-empty.svg
+++ b/packages/core/src/icons/svg/checkbox-empty.svg
@@ -6,7 +6,7 @@
       }
     </style>
   </defs>
-  <g id="radio-empty" transform="translate(-2028 -5329)">
+  <g id="checkbox-empty" transform="translate(-2028 -5329)">
     <rect id="長方形_7898" data-name="長方形 7898" class="cls-1" width="32" height="32" transform="translate(48 328)"/>
     <path id="前面オブジェクトで型抜き_9" data-name="前面オブジェクトで型抜き 9" d="M-2768-3701h-12a4.005,4.005,0,0,1-4-4v-12a4,4,0,0,1,4-4h12a4,4,0,0,1,4,4v12A4,4,0,0,1-2768-3701Zm-12-18a2,2,0,0,0-2,2v12a2,2,0,0,0,2,2h12a2,2,0,0,0,2-2v-12a2,2,0,0,0-2-2Z" transform="translate(2838 4055)"/>
   </g>

--- a/packages/core/src/icons/svg/checkbox-half.svg
+++ b/packages/core/src/icons/svg/checkbox-half.svg
@@ -6,7 +6,7 @@
       }
     </style>
   </defs>
-  <g id="radio-half" transform="translate(-2308 -5433)">
+  <g id="checkbox-half" transform="translate(-2308 -5433)">
     <rect id="長方形_7901" data-name="長方形 7901" class="cls-1" width="32" height="32" transform="translate(328 376)"/>
     <path id="前面オブジェクトで型抜き_8" data-name="前面オブジェクトで型抜き 8" d="M-2768-3701h-12a4.005,4.005,0,0,1-4-4v-12a4,4,0,0,1,4-4h12a4,4,0,0,1,4,4v12A4,4,0,0,1-2768-3701Zm-12-11.5v3h12v-3Z" transform="translate(3118 4103)"/>
   </g>

--- a/packages/core/src/icons/svg/checkbox-selected.svg
+++ b/packages/core/src/icons/svg/checkbox-selected.svg
@@ -6,7 +6,7 @@
       }
     </style>
   </defs>
-  <g id="radio-selected" transform="translate(-2308 -5489)">
+  <g id="checkbox-selected" transform="translate(-2308 -5489)">
     <rect id="長方形_7901" data-name="長方形 7901" class="cls-1" width="32" height="32" transform="translate(328 376)"/>
     <path id="前面オブジェクトで型抜き_8" data-name="前面オブジェクトで型抜き 8" d="M-2768-3701h-12a4.005,4.005,0,0,1-4-4v-12a4,4,0,0,1,4-4h12a4,4,0,0,1,4,4v12A4,4,0,0,1-2768-3701Zm-10.628-12.608-2.122,2.122,5.656,5.657,8.486-8.485-2.122-2.122-6.364,6.364-3.535-3.536Z" transform="translate(3118 4103)"/>
   </g>

--- a/packages/core/src/styles/Checkbox.scss
+++ b/packages/core/src/styles/Checkbox.scss
@@ -24,7 +24,7 @@
 
     &__input:checked + &__button,
     &__input:checked + .#{$prefix}-iconlayout > &__button {
-        background: url('../icons/svg/radio-selected.svg');
+        background: url('../icons/svg/checkbox-selected.svg');
     }
 
     &__input:indeterminate + &__button,

--- a/packages/core/src/styles/Checkbox.scss
+++ b/packages/core/src/styles/Checkbox.scss
@@ -19,7 +19,7 @@
     &__button {
         position: relative;
         z-index: 1;
-        background: url('../icons/svg/radio-empty.svg');
+        background: url('../icons/svg/checkbox-empty.svg');
     }
 
     &__input:checked + &__button,

--- a/packages/core/src/styles/Checkbox.scss
+++ b/packages/core/src/styles/Checkbox.scss
@@ -29,6 +29,6 @@
 
     &__input:indeterminate + &__button,
     &__input:indeterminate + .#{$prefix}-iconlayout > &__button {
-        background: url('../icons/svg/radio-half.svg');
+        background: url('../icons/svg/checkbox-half.svg');
     }
 }


### PR DESCRIPTION
# Purpose

- Asana link: https://app.asana.com/0/1200180520342664/1201939347884007/f
- 底下框起來的三個 svg 元件都是與 checkbox 相關的元件，但他的命名都是 Radio 開頭，與接下來要實作的 RadioSelectList 相衝突，所以先把他們名稱改掉

![截圖 2022-05-03 上午9 53 16](https://user-images.githubusercontent.com/9179190/166393951-b3fc1b0b-9a53-43ef-b6b7-0e77e6f899b8.png)

附上接下來會加進來的 RadioSelectList 示意圖
![截圖 2022-04-29 上午11 21 46](https://user-images.githubusercontent.com/9179190/166394073-cd048766-1024-4f6b-9e82-3ff36a14a41f.png)

 

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
