### PR TITLE
[Anchor] Support left / right direction (pt. 1 - refactor getPositionState with placement strategies)

### DIFF
--- a/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
+++ b/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
@@ -31,34 +31,35 @@ jest.mock('document-offset', () => (
 describe('getPlacement()', () => {
   const { TOP, BOTTOM } = PLACEMENT;
   const runTest = it.each`
-        expected  | defaultVal | situation                                             | anchorTop | anchorHeight | selfHeight | remainingSpace | distanceFromAnchor
-        ${TOP}    | ${TOP}     | ${'enough'}                                           | ${120}    | ${30}        | ${100}     | ${120}         | ${0}
-        ${BOTTOM} | ${TOP}     | ${'not enough for top'}                               | ${90}     | ${30}        | ${100}     | ${648}         | ${0}
-        ${BOTTOM} | ${TOP}     | ${'not enough for top consider distance from anchor'} | ${100}    | ${30}        | ${100}     | ${638}         | ${10}
-        ${TOP}    | ${BOTTOM}  | ${'not enough for bottom'}                            | ${600}    | ${100}       | ${100}     | ${600}         | ${0}
-        ${BOTTOM} | ${BOTTOM}  | ${'enough'}                                           | ${300}    | ${100}       | ${100}     | ${368}         | ${0}
-        ${BOTTOM} | ${BOTTOM}  | ${'not enough for both, but bottom is larger'}        | ${300}    | ${100}       | ${400}     | ${368}         | ${0}
-        ${TOP}    | ${BOTTOM}  | ${'not enough for both, but top is larger'}           | ${450}    | ${100}       | ${500}     | ${450}         | ${0}
+        expected  | defaultPlacement | situation                                             | anchorTop | anchorHeight | selfHeight | remainingSpace | distanceFromAnchor
+        ${TOP}    | ${TOP}           | ${'enough'}                                           | ${120}    | ${30}        | ${100}     | ${120}         | ${0}
+        ${BOTTOM} | ${TOP}           | ${'not enough for top'}                               | ${90}     | ${30}        | ${100}     | ${648}         | ${0}
+        ${BOTTOM} | ${TOP}           | ${'not enough for top consider distance from anchor'} | ${100}    | ${30}        | ${100}     | ${638}         | ${10}
+        ${TOP}    | ${BOTTOM}        | ${'not enough for bottom'}                            | ${600}    | ${100}       | ${100}     | ${600}         | ${0}
+        ${BOTTOM} | ${BOTTOM}        | ${'enough'}                                           | ${300}    | ${100}       | ${100}     | ${368}         | ${0}
+        ${BOTTOM} | ${BOTTOM}        | ${'not enough for both, but bottom is larger'}        | ${300}    | ${100}       | ${400}     | ${368}         | ${0}
+        ${TOP}    | ${BOTTOM}        | ${'not enough for both, but top is larger'}           | ${450}    | ${100}       | ${500}     | ${450}         | ${0}
     `;
 
   runTest(
     'returns $expected when default is $defaultVal, and the space is $situation',
     ({
       expected,
-      defaultVal,
+      defaultPlacement,
       anchorTop,
       anchorHeight,
       selfHeight,
       remainingSpace,
       distanceFromAnchor,
     }) => {
-      const result = getPlacementAndRemainingSpace(
-        defaultVal,
-        anchorTop,
-        anchorHeight,
-        selfHeight,
-        distanceFromAnchor
-      );
+      const anchorRect = { top: anchorTop, height: anchorHeight };
+      const selfRect = { height: selfHeight };
+      const result = getPlacementAndRemainingSpace({
+        defaultPlacement,
+        anchorRect,
+        selfRect,
+        distanceFromAnchor,
+      });
       expect(result.placement).toBe(expected);
       expect(result.remainingSpace).toBe(remainingSpace);
     }

--- a/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
+++ b/packages/core/src/mixins/anchored/__tests__/getPositionState.test.js
@@ -121,6 +121,27 @@ describe('getLeftPositionSet()', () => {
 
   /**
      * ┌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┐
+     * ╎       □                ╎
+     * ╎    ┌╌╌^╌╌┐             ╎
+     * ╎    └╌╌╌╌╌┘             ╎
+     * └╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┘
+     */
+  it('returns coord sets for center-align sceanario -- when document left is differed from screen', () => {
+    const result = getLeftPositionSet(
+      200, // anchor screen left
+      300, // anchor document left
+      30, // anchor width
+      200, // self width
+      8, // edge padding
+    );
+    expect(result).toEqual({
+      selfLeft: 215,
+      arrowLeft: 100,
+    });
+  });
+
+  /**
+     * ┌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┐
      * ╎ □                      ╎
      * ╎┌^╌╌╌╌┐                 ╎
      * ╎└╌╌╌╌╌┘                 ╎

--- a/packages/core/src/mixins/anchored/__tests__/placementStrategies.test.js
+++ b/packages/core/src/mixins/anchored/__tests__/placementStrategies.test.js
@@ -1,0 +1,45 @@
+import placementStrategies from '../placementStrategies';
+import PLACEMENT from '../constants/placement';
+
+describe('TOP placement strategy', () => {
+  const topPlacementStrategy = placementStrategies[PLACEMENT.TOP];
+  describe('getPosition', () => {
+    it.each`
+      resultTop  | anchorTop | anchorHeight | selfHeight | distanceFromAnchor
+      ${20}      | ${120}    | ${30}        | ${100}     | ${0}
+      ${10}      | ${120}    | ${30}        | ${100}     | ${10}
+    `(
+      'top value should be $resultTop when placed on TOP of anchor (y=$anchorTop, h=$anchorHeight)',
+      ({
+        resultTop,
+        anchorTop,
+        anchorHeight,
+        selfHeight,
+        distanceFromAnchor,
+      }) => {
+        const anchorRect = {
+          top: anchorTop,
+          left: 0,
+          width: 100,
+          height: anchorHeight,
+        };
+        const anchorOffset = {
+          top: anchorTop,
+          left: 0,
+        };
+        const selfRect = {
+          width: 100,
+          height: selfHeight,
+        };
+        const { position } = topPlacementStrategy.getPosition({
+          anchorRect,
+          anchorOffset,
+          selfRect,
+          distanceFromAnchor,
+          edgePadding: 10,
+        });
+        expect(position.top).toEqual(resultTop);
+      }
+    );
+  });
+});

--- a/packages/core/src/mixins/anchored/constants/placement.js
+++ b/packages/core/src/mixins/anchored/constants/placement.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line filenames/match-exported
+const TOP = 'top';
+const BOTTOM = 'bottom';
+const LEFT = 'left';
+const RIGHT = 'right';
+const PLACEMENT = { TOP, BOTTOM, LEFT, RIGHT };
+export default PLACEMENT;

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -1,12 +1,10 @@
 // @ts-check
 import documentOffset from 'document-offset';
-import { bottomPlacementStrategy, topPlacementStrategy } from './placementStrategies';
+import placementStrategies from './placementStrategies';
+import PLACEMENT from './constants/placement';
 
-const TOP = 'top';
-const BOTTOM = 'bottom';
-const LEFT = 'left';
-const RIGHT = 'right';
-export const PLACEMENT = { TOP, BOTTOM, LEFT, RIGHT };
+export { PLACEMENT };
+const { TOP, BOTTOM } = PLACEMENT;
 
 /**
  * @typedef {typeof TOP| typeof BOTTOM} Placement
@@ -41,7 +39,7 @@ export function getPlacementAndRemainingSpace({
   const {
     canPlace: hasSpaceToPlaceSelfAbove,
     remainingSpace: topSpace,
-  } = topPlacementStrategy.canPlace({
+  } = placementStrategies[TOP].canPlace({
     anchorRect,
     selfRect,
     distanceFromAnchor,
@@ -49,7 +47,7 @@ export function getPlacementAndRemainingSpace({
   const {
     canPlace: hasSpaceToPlaceSelfBelow,
     remainingSpace: bottomSpace,
-  } = bottomPlacementStrategy.canPlace({
+  } = placementStrategies[BOTTOM].canPlace({
     anchorRect,
     selfRect,
     distanceFromAnchor,
@@ -254,21 +252,14 @@ const getPositionState = (defaultPlacement, edgePadding) => (
     anchorRect.width,
     selfRect.width,
     edgePadding,
-  );*/
+  ); */
 
-  const { arrowPosition, position } = placement === TOP
-    ? topPlacementStrategy.getPosition({
-      anchorRect,
-      selfRect,
-      distanceFromAnchor,
-      edgePadding,
-    })
-    : bottomPlacementStrategy.getPosition({
-      anchorRect,
-      selfRect,
-      distanceFromAnchor,
-      edgePadding
-    });
+  const { arrowPosition, position } = placementStrategies[placement].getPosition({
+    anchorRect,
+    selfRect,
+    distanceFromAnchor,
+    edgePadding,
+  });
 
   return {
     placement,

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -216,11 +216,17 @@ const getPositionState = (defaultPlacement, edgePadding) => (
   //   Measuring anchor and self
   // -------------------------------------
 
-  const anchorRect = anchorNode.getBoundingClientRect();
-  const selfRect = selfNode.getBoundingClientRect();
-
   /** @type {DocumentOffset} */
   const anchorOffset = documentOffset(anchorNode);
+  const anchorBoundingClientRect = anchorNode.getBoundingClientRect();
+
+  const anchorRect = {
+    top: anchorOffset.top,
+    left: anchorOffset.left,
+    width: anchorBoundingClientRect.width,
+    height: anchorBoundingClientRect.height,
+  };
+  const selfRect = selfNode.getBoundingClientRect();
 
   // -------------------------------------
   //   Determine position
@@ -233,6 +239,7 @@ const getPositionState = (defaultPlacement, edgePadding) => (
     distanceFromAnchor,
   });
 
+  /*
   const selfTop = getTopPosition(
     placement,
     anchorOffset.top,
@@ -247,17 +254,28 @@ const getPositionState = (defaultPlacement, edgePadding) => (
     anchorRect.width,
     selfRect.width,
     edgePadding,
-  );
+  );*/
+
+  const { arrowPosition, position } = placement === TOP
+    ? topPlacementStrategy.getPosition({
+      anchorRect,
+      selfRect,
+      distanceFromAnchor,
+      edgePadding,
+    })
+    : bottomPlacementStrategy.getPosition({
+      anchorRect,
+      selfRect,
+      distanceFromAnchor,
+      edgePadding
+    });
 
   return {
     placement,
     remainingSpace,
-    position: {
-      top: selfTop,
-      left: selfLeft,
-    },
+    position,
     arrowPosition: {
-      left: arrowLeft,
+      left: arrowPosition.left,
     },
   };
 };

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -216,14 +216,7 @@ const getPositionState = (defaultPlacement, edgePadding) => (
 
   /** @type {DocumentOffset} */
   const anchorOffset = documentOffset(anchorNode);
-  const anchorBoundingClientRect = anchorNode.getBoundingClientRect();
-
-  const anchorRect = {
-    top: anchorOffset.top,
-    left: anchorOffset.left,
-    width: anchorBoundingClientRect.width,
-    height: anchorBoundingClientRect.height,
-  };
+  const anchorRect = anchorNode.getBoundingClientRect();
   const selfRect = selfNode.getBoundingClientRect();
 
   // -------------------------------------
@@ -256,6 +249,7 @@ const getPositionState = (defaultPlacement, edgePadding) => (
 
   const { arrowPosition, position } = placementStrategies[placement].getPosition({
     anchorRect,
+    anchorOffset,
     selfRect,
     distanceFromAnchor,
     edgePadding,

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -30,27 +30,14 @@ export const PLACEMENT = { TOP, BOTTOM, LEFT, RIGHT };
  * Determine whether *wrapped component* should be placed above or below
  * its *anchor*.
  *
- * @param {Placement} defaultPlacement
- * @param {number} anchorRectTop
- * @param {number} anchorHeight
- * @param {number} selfHeight
- * @param {number} distanceFromAnchor
  * @returns {{ placement: Placement, remainingSpace: number }}
  */
-export function getPlacementAndRemainingSpace(
+export function getPlacementAndRemainingSpace({
   defaultPlacement,
-  anchorRectTop,
-  anchorHeight,
-  selfHeight,
+  anchorRect,
+  selfRect,
   distanceFromAnchor,
-) {
-  const anchorRect = {
-    top: anchorRectTop,
-    height: anchorHeight,
-  };
-  const selfRect = {
-    height: selfHeight,
-  };
+}) {
   const {
     canPlace: hasSpaceToPlaceSelfAbove,
     remainingSpace: topSpace,
@@ -239,13 +226,12 @@ const getPositionState = (defaultPlacement, edgePadding) => (
   //   Determine position
   // -------------------------------------
 
-  const { placement, remainingSpace } = getPlacementAndRemainingSpace(
+  const { placement, remainingSpace } = getPlacementAndRemainingSpace({
     defaultPlacement,
-    anchorRect.top,
-    anchorRect.height,
-    selfRect.height,
+    anchorRect,
+    selfRect,
     distanceFromAnchor,
-  );
+  });
 
   const selfTop = getTopPosition(
     placement,

--- a/packages/core/src/mixins/anchored/getPositionState.js
+++ b/packages/core/src/mixins/anchored/getPositionState.js
@@ -1,9 +1,12 @@
 // @ts-check
 import documentOffset from 'document-offset';
+import { bottomPlacementStrategy, topPlacementStrategy } from './placementStrategies';
 
 const TOP = 'top';
 const BOTTOM = 'bottom';
-export const PLACEMENT = { TOP, BOTTOM };
+const LEFT = 'left';
+const RIGHT = 'right';
+export const PLACEMENT = { TOP, BOTTOM, LEFT, RIGHT };
 
 /**
  * @typedef {typeof TOP| typeof BOTTOM} Placement
@@ -41,12 +44,30 @@ export function getPlacementAndRemainingSpace(
   selfHeight,
   distanceFromAnchor,
 ) {
-  const hasSpaceToPlaceSelfAbove = anchorRectTop >= selfHeight + distanceFromAnchor;
-  const hasSpaceToPlaceSelfBelow = (
-    (anchorRectTop + anchorHeight + selfHeight + distanceFromAnchor) <= window.innerHeight
-  );
-  const topSpace = anchorRectTop;
-  const bottomSpace = window.innerHeight - anchorRectTop - anchorHeight;
+  const anchorRect = {
+    top: anchorRectTop,
+    height: anchorHeight,
+  };
+  const selfRect = {
+    height: selfHeight,
+  };
+  const {
+    canPlace: hasSpaceToPlaceSelfAbove,
+    remainingSpace: topSpace,
+  } = topPlacementStrategy.canPlace({
+    anchorRect,
+    selfRect,
+    distanceFromAnchor,
+  });
+  const {
+    canPlace: hasSpaceToPlaceSelfBelow,
+    remainingSpace: bottomSpace,
+  } = bottomPlacementStrategy.canPlace({
+    anchorRect,
+    selfRect,
+    distanceFromAnchor,
+  });
+
   if (!hasSpaceToPlaceSelfBelow && !hasSpaceToPlaceSelfAbove) {
     return {
       placement: topSpace > bottomSpace ? TOP : BOTTOM,

--- a/packages/core/src/mixins/anchored/placementStrategies.js
+++ b/packages/core/src/mixins/anchored/placementStrategies.js
@@ -23,16 +23,17 @@ import PLACEMENT from './constants/placement';
  * @param {number} selfWidth
  * @param {number} edgePadding
  */
-export function getLeftPositionSetForVerticalPlacement({
-  anchorOffset,
-  anchorRect,
-  selfRect,
+ export function getLeftPositionSetForVerticalPlacement(
+  anchorRectLeft,
+  anchorOffsetLeft,
+  anchorWidth,
+  selfWidth,
   edgePadding,
-}) {
-  const anchorHalfWidth = anchorRect.width / 2;
-  const selfHalfWidth = selfRect.width / 2;
+) {
+  const anchorHalfWidth = anchorWidth / 2;
+  const selfHalfWidth = selfWidth / 2;
 
-  const anchorCenterCoordXOnViewPort = anchorRect.left + anchorHalfWidth;
+  const anchorCenterCoordXOnViewPort = anchorRectLeft + anchorHalfWidth;
 
   const hasSpaceOnLeftOfAnchorCenter = anchorCenterCoordXOnViewPort >= selfHalfWidth;
   const hasSpaceOnRightOfAnchorCenter = (
@@ -45,26 +46,26 @@ export function getLeftPositionSetForVerticalPlacement({
   switch (true) {
     // Center-aligned
     case (hasSpaceOnLeftOfAnchorCenter && hasSpaceOnRightOfAnchorCenter):
-      selfLeft = (anchorOffset.left + anchorHalfWidth) - selfHalfWidth;
+      selfLeft = (anchorOffsetLeft + anchorHalfWidth) - selfHalfWidth;
       arrowLeft = selfHalfWidth;
       break;
 
       // Right-align to the anchor
     case (hasSpaceOnLeftOfAnchorCenter && !hasSpaceOnRightOfAnchorCenter):
-      selfLeft = (anchorOffset.left + anchorOffset.width) - selfRect.width;
-      arrowLeft = selfRect.width - anchorHalfWidth;
+      selfLeft = (anchorOffsetLeft + anchorWidth) - selfWidth;
+      arrowLeft = selfWidth - anchorHalfWidth;
       break;
 
       // Left-align to the anchor
     default:
-      selfLeft = anchorOffset.left;
+      selfLeft = anchorOffsetLeft;
       arrowLeft = anchorHalfWidth;
       break;
   }
 
   // Calibrate to keep arrow stay in *wrapped component*
   const arrowLeftMin = edgePadding;
-  const arrowLeftMax = selfRect.width - edgePadding;
+  const arrowLeftMax = selfWidth - edgePadding;
 
   arrowLeft = Math.max(
     arrowLeftMin,
@@ -88,12 +89,13 @@ export const topPlacementStrategy = {
   }),
 
   getPosition: ({ anchorRect, anchorOffset, selfRect, distanceFromAnchor, edgePadding }) => {
-    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
-      anchorRect,
-      anchorOffset,
-      selfRect,
+    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement(
+      anchorRect.left,
+      anchorOffset.left,
+      anchorRect.width,
+      selfRect.width,
       edgePadding,
-    });
+    );
 
     return {
       position: {
@@ -126,12 +128,13 @@ export const bottomPlacementStrategy = {
   }),
 
   getPosition: ({ anchorRect, anchorOffset, selfRect, distanceFromAnchor, edgePadding }) => {
-    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
-      anchorRect,
-      anchorOffset,
-      selfRect,
+    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement(
+      anchorRect.left,
+      anchorOffset.left,
+      anchorRect.width,
+      selfRect.width,
       edgePadding,
-    });
+    );
 
     return {
       position: {

--- a/packages/core/src/mixins/anchored/placementStrategies.js
+++ b/packages/core/src/mixins/anchored/placementStrategies.js
@@ -1,3 +1,79 @@
+/**
+ * Determine horizontal positions of *wrapped component* and its
+ * inner *arrow element*.
+ *
+ * The *arrow element* is expected to point to the center of *anchor element*.
+ * It should also horizontally stay inside the “safe area”, which is the width
+ * of *wrapped component* deducted by `edgePadding` from both edges.
+ *
+ ```
+        arrow        edge padding
+╭╌┊╌╌╌╌╌╌╌/\╌╌╌╌╌╌╌╌┊╌╮
+╎ ┊                 ┊ ╎
+╎ ┊                 ┊ ╎
+╰╌┊╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┊╌╯
+    arrow safe area
+ ```
+ *
+ * @param {number} anchorRectLeft
+ * @param {number} anchorOffsetLeft
+ * @param {number} anchorWidth
+ * @param {number} selfWidth
+ * @param {number} edgePadding
+ */
+export function getLeftPositionSetForVerticalPlacement({
+  anchorRect,
+  selfRect,
+  edgePadding,
+}) {
+  const anchorHalfWidth = anchorRect.width / 2;
+  const selfHalfWidth = selfRect.width / 2;
+
+  const anchorCenterCoordXOnViewPort = anchorRect.left + anchorHalfWidth;
+
+  const hasSpaceOnLeftOfAnchorCenter = anchorCenterCoordXOnViewPort >= selfHalfWidth;
+  const hasSpaceOnRightOfAnchorCenter = (
+    (window.innerWidth - anchorCenterCoordXOnViewPort) >= selfHalfWidth
+  );
+
+  let selfLeft = 0;
+  let arrowLeft = 0;
+
+  switch (true) {
+    // Center-aligned
+    case (hasSpaceOnLeftOfAnchorCenter && hasSpaceOnRightOfAnchorCenter):
+      selfLeft = (anchorRect.left + anchorHalfWidth) - selfHalfWidth;
+      arrowLeft = selfHalfWidth;
+      break;
+
+      // Right-align to the anchor
+    case (hasSpaceOnLeftOfAnchorCenter && !hasSpaceOnRightOfAnchorCenter):
+      selfLeft = (anchorRect.left + anchorRect.width) - selfRect.width;
+      arrowLeft = selfRect.width - anchorHalfWidth;
+      break;
+
+      // Left-align to the anchor
+    default:
+      selfLeft = anchorRect.left;
+      arrowLeft = anchorHalfWidth;
+      break;
+  }
+
+  // Calibrate to keep arrow stay in *wrapped component*
+  const arrowLeftMin = edgePadding;
+  const arrowLeftMax = selfRect.width - edgePadding;
+
+  arrowLeft = Math.max(
+    arrowLeftMin,
+    Math.min(arrowLeft, arrowLeftMax)
+  );
+
+  return {
+    selfLeft,
+    arrowLeft,
+  };
+}
+
 export const topPlacementStrategy = {
   canPlace: ({
     anchorRect,
@@ -7,6 +83,25 @@ export const topPlacementStrategy = {
     canPlace: anchorRect.top >= selfRect.height + distanceFromAnchor,
     remainingSpace: anchorRect.top,
   }),
+
+  getPosition: ({ anchorRect, selfRect, distanceFromAnchor, edgePadding }) => {
+    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
+      anchorRect,
+      selfRect,
+      edgePadding,
+    });
+
+    return {
+      position: {
+        top: Math.max(anchorRect.top - selfRect.height - distanceFromAnchor, 0),
+        left: selfLeft,
+      },
+      arrowPosition: {
+        top: selfRect.height,
+        left: arrowLeft,
+      },
+    };
+  },
 };
 
 export const bottomPlacementStrategy = {
@@ -25,4 +120,23 @@ export const bottomPlacementStrategy = {
     ),
     remainingSpace: window.innerHeight - anchorRect.top - anchorRect.height,
   }),
+
+  getPosition: ({ anchorRect, selfRect, distanceFromAnchor, edgePadding }) => {
+    const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
+      anchorRect,
+      selfRect,
+      edgePadding,
+    });
+
+    return {
+      position: {
+        top: anchorRect.top + anchorRect.height + distanceFromAnchor,
+        left: selfLeft,
+      },
+      arrowPosition: {
+        top: 0,
+        left: arrowLeft,
+      },
+    };
+  },
 };

--- a/packages/core/src/mixins/anchored/placementStrategies.js
+++ b/packages/core/src/mixins/anchored/placementStrategies.js
@@ -1,3 +1,5 @@
+import PLACEMENT from './constants/placement';
+
 /**
  * Determine horizontal positions of *wrapped component* and its
  * inner *arrow element*.
@@ -140,3 +142,10 @@ export const bottomPlacementStrategy = {
     };
   },
 };
+
+const placementStrategies = {
+  [PLACEMENT.TOP]: topPlacementStrategy,
+  [PLACEMENT.BOTTOM]: bottomPlacementStrategy,
+};
+
+export default placementStrategies;

--- a/packages/core/src/mixins/anchored/placementStrategies.js
+++ b/packages/core/src/mixins/anchored/placementStrategies.js
@@ -1,0 +1,28 @@
+export const topPlacementStrategy = {
+  canPlace: ({
+    anchorRect,
+    selfRect,
+    distanceFromAnchor,
+  }) => ({
+    canPlace: anchorRect.top >= selfRect.height + distanceFromAnchor,
+    remainingSpace: anchorRect.top,
+  }),
+};
+
+export const bottomPlacementStrategy = {
+  canPlace: ({
+    anchorRect,
+    selfRect,
+    distanceFromAnchor,
+  }) => ({
+    canPlace: (
+      (
+        anchorRect.top
+        + anchorRect.height
+        + selfRect.height
+        + distanceFromAnchor
+      ) <= window.innerHeight
+    ),
+    remainingSpace: window.innerHeight - anchorRect.top - anchorRect.height,
+  }),
+};

--- a/packages/core/src/mixins/anchored/placementStrategies.js
+++ b/packages/core/src/mixins/anchored/placementStrategies.js
@@ -24,6 +24,7 @@ import PLACEMENT from './constants/placement';
  * @param {number} edgePadding
  */
 export function getLeftPositionSetForVerticalPlacement({
+  anchorOffset,
   anchorRect,
   selfRect,
   edgePadding,
@@ -44,19 +45,19 @@ export function getLeftPositionSetForVerticalPlacement({
   switch (true) {
     // Center-aligned
     case (hasSpaceOnLeftOfAnchorCenter && hasSpaceOnRightOfAnchorCenter):
-      selfLeft = (anchorRect.left + anchorHalfWidth) - selfHalfWidth;
+      selfLeft = (anchorOffset.left + anchorHalfWidth) - selfHalfWidth;
       arrowLeft = selfHalfWidth;
       break;
 
       // Right-align to the anchor
     case (hasSpaceOnLeftOfAnchorCenter && !hasSpaceOnRightOfAnchorCenter):
-      selfLeft = (anchorRect.left + anchorRect.width) - selfRect.width;
+      selfLeft = (anchorOffset.left + anchorOffset.width) - selfRect.width;
       arrowLeft = selfRect.width - anchorHalfWidth;
       break;
 
       // Left-align to the anchor
     default:
-      selfLeft = anchorRect.left;
+      selfLeft = anchorOffset.left;
       arrowLeft = anchorHalfWidth;
       break;
   }
@@ -86,16 +87,17 @@ export const topPlacementStrategy = {
     remainingSpace: anchorRect.top,
   }),
 
-  getPosition: ({ anchorRect, selfRect, distanceFromAnchor, edgePadding }) => {
+  getPosition: ({ anchorRect, anchorOffset, selfRect, distanceFromAnchor, edgePadding }) => {
     const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
       anchorRect,
+      anchorOffset,
       selfRect,
       edgePadding,
     });
 
     return {
       position: {
-        top: Math.max(anchorRect.top - selfRect.height - distanceFromAnchor, 0),
+        top: Math.max(anchorOffset.top - selfRect.height - distanceFromAnchor, 0),
         left: selfLeft,
       },
       arrowPosition: {
@@ -123,16 +125,17 @@ export const bottomPlacementStrategy = {
     remainingSpace: window.innerHeight - anchorRect.top - anchorRect.height,
   }),
 
-  getPosition: ({ anchorRect, selfRect, distanceFromAnchor, edgePadding }) => {
+  getPosition: ({ anchorRect, anchorOffset, selfRect, distanceFromAnchor, edgePadding }) => {
     const { arrowLeft, selfLeft } = getLeftPositionSetForVerticalPlacement({
       anchorRect,
+      anchorOffset,
       selfRect,
       edgePadding,
     });
 
     return {
       position: {
-        top: anchorRect.top + anchorRect.height + distanceFromAnchor,
+        top: anchorOffset.top + anchorRect.height + distanceFromAnchor,
         left: selfLeft,
       },
       arrowPosition: {


### PR DESCRIPTION
# Purpose

這支 PR 及其後續 #391 #392 #393 讓 Popover (`anchored`) 可以支援置於 anchor 的左 / 右方。之前只能置於上下。

## 修改步驟

修改的步驟如下：
1. 將 `getPositionState()` 對 top / bottom 方向的計算各自封裝到 `top / bottom placementStrategy` 的物件下。 (#390, #391)

  `getPositionState()` 是用來計算 popover / tooltip 相對於 anchor 的位置。若要加入左右方向，依現在的結構會有點困難：
- 由於之前只需支援上下兩方向，直接在 function 內用 condition 來判斷應回傳的結果([例子](https://github.com/iCHEF/gypcrete/blob/558abdad602b3b5f147b759a57e501e215c3ef1f/packages/core/src/mixins/anchored/getPositionState.js#L87-L92))。
- getPositionState 中使用的 getTopPosition 和 getLeftPositionSet 只吃計算 top / bottom 時需要的參數，要再包含 left / right 所需的參數又更多
- 原本 top / bottom 時 popover 的 arrow 位置計算是在 getLeftPositionSet 之下，但 left / right 時應該要是 getTopPositionSet。
  因此這支 PR 引入了 placement strategy 的概念，每個 placement strategy 會對應到一個方向，並實作下列的 function
  (1) 被 anchor 的 UI 能否置於該方向
  (2) 被 anchor 的 UI 若置於該方向，其 position 為何。
  如此 top / bottom 方向在這兩題的計算，可以被歸類到各自的 placement strategy 去。

2. 增加 left / right 的方向及對應的 placementStrategy。 (#392)
  支援 left / right 方向就只需增加 placement strategy 即可。
3. 調整 Popover 的樣式讓它可以吃 left / right placement。 (#393)



# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
