### PR TITLE
Add zIndex prop to renderToLayer HOC

### DIFF
--- a/packages/core/src/mixins/__tests__/renderToLayer.test.js
+++ b/packages/core/src/mixins/__tests__/renderToLayer.test.js
@@ -61,3 +61,10 @@ it('renders wrapped component via ReactPortal after layer is in DOM', () => {
   expect(wrapper.type()).toBe(ReactIs.Portal);
   expect(wrapper.children().is(Foo)).toBeTruthy();
 });
+
+it('set zIndex style on layer given zIndex prop', () => {
+  const zIndex = 200;
+  const wrapper = shallow(<LayerFoo zIndex={zIndex} />);
+
+  expect(wrapper.instance().baseLayer.style.zIndex).toBe(zIndex.toString());
+});

--- a/packages/core/src/mixins/renderToLayer.js
+++ b/packages/core/src/mixins/renderToLayer.js
@@ -1,4 +1,6 @@
+import omit from 'lodash.omit';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';
 
 import prefixClass from '../utils/prefixClass';
@@ -10,10 +12,13 @@ import '../styles/RenderToLayer.scss';
 const COMPONENT_NAME = prefixClass('base-layer');
 const LAYER_ID_PREFIX = 'layer';
 
-export function createLayer() {
+export function createLayer({ zIndex = null } = {}) {
   const layer = document.createElement('div');
   layer.className = COMPONENT_NAME;
   layer.id = randId({ prefix: LAYER_ID_PREFIX });
+  if (typeof zIndex === 'number') {
+    layer.style.zIndex = zIndex;
+  }
 
   return layer;
 }
@@ -35,13 +40,23 @@ function renderToLayer(WrappedComponent) {
   class RenderToLayer extends Component {
         static displayName = `renderToLayer(${componentName})`;
 
+        static propTypes = {
+          ...WrappedComponent.propTypes,
+          zIndex: PropTypes.number,
+        }
+
+        static defaultProps = {
+          ...WrappedComponent.defaultProps,
+          zIndex: undefined,
+        }
+
         state = {
           inDOM: false,
         };
 
         constructor(props) {
           super(props);
-          this.baseLayer = createLayer();
+          this.baseLayer = createLayer({ zIndex: props.zIndex });
         }
 
         componentDidMount() {
@@ -64,9 +79,10 @@ function renderToLayer(WrappedComponent) {
 
         render() {
           const { inDOM } = this.state;
+          const childrenProps = omit(this.props, ['zIndex']);
 
           return inDOM && createPortal(
-            <WrappedComponent {...this.props} />,
+            <WrappedComponent {...childrenProps} />,
             this.baseLayer,
           );
         }


### PR DESCRIPTION
# Purpose

To enable adjusting zIndex of base layer of `<Popup />` or `<Popover />`, added `zIndex` prop on `renderToLayer` HOC.

# Changes

- a list of what have been done
- maybe some code change

# Risk

Usually none, if you have any please write it here.

# TODOs

- [ ] Describe what should be done outside of this PR
- [ ] Maybe in other PRs or some manual actions.
