### PR TITLE
Refactor/remove-unsafe-lifecycles-part1

### DIFF
--- a/packages/core/src/EditableTextLabel.js
+++ b/packages/core/src/EditableTextLabel.js
@@ -164,9 +164,6 @@ const EditableTextLabel = React.memo(({
   );
 });
 
-export default EditableTextLabel;
-
-
 EditableTextLabel.propTypes = {
   inEdit: PropTypes.bool,
   onEditEnd: PropTypes.func,
@@ -188,3 +185,5 @@ EditableTextLabel.defaultProps = {
   align: TextLabel.defaultProps.align,
   status: TextLabel.defaultProps.status,
 };
+
+export default EditableTextLabel;

--- a/packages/core/src/EditableTextLabel.js
+++ b/packages/core/src/EditableTextLabel.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import keycode from 'keycode';
 
@@ -25,184 +25,166 @@ const TOUCH_TIMEOUT_MS = 250;
  * it's in edit mode.
  *
  * The “editibility” can be either controlled or uncontrolled, depending on
- * the existance of the `inEdit` prop. An uncontrolled `<EditableTextLabel>` can
+ * the existence of the `inEdit` prop. An uncontrolled `<EditableTextLabel>` can
  * go into edit mode automatically when you double-click on it.
  *
  * Unlike `<TextInput>`, you should treat `<EditableTextLabel>` like a `<TextLabel>`.
  * It does not offer direct control to the `<input>` inside.
  */
 
-class EditableTextLabel extends PureComponent {
-    static propTypes = {
-      inEdit: PropTypes.bool,
-      onEditEnd: PropTypes.func,
-      onDblClick: PropTypes.func,
-      // <TextLabel> props
-      icon: TextLabel.propTypes.icon,
-      basic: TextLabel.propTypes.basic,
-      align: TextLabel.propTypes.align,
-      status: TextLabel.propTypes.status,
-    };
+const EditableTextLabel = React.memo(({
+  inEdit: inEditProp, // not used here
+  onDblClick, // also not used here
+  onEditEnd,
+  status,
+  ...labelProps
+}) => {
+  const [inEdit, setInEdit] = useState(inEditProp || false);
+  const [touchCount, setTouchCount] = useState(0);
+  // For simulating double-touch
+  const [dblTouchTimeout, setDblTouchTimeout] = useState(null);
 
-    static defaultProps = {
-      inEdit: undefined,
-      onEditEnd: () => {},
-      onDblClick: () => {},
-      // <TextLabel> props
-      icon: TextLabel.defaultProps.icon,
-      basic: TextLabel.defaultProps.basic,
-      align: TextLabel.defaultProps.align,
-      status: TextLabel.defaultProps.status,
-    };
+  const getEditabilityControlled = useCallback(
+    () => inEditProp !== undefined,
+    [inEditProp]
+  );
 
-    state = {
-      // eslint-disable-next-line react/destructuring-assignment
-      inEdit: this.props.inEdit || false,
-      // For simulating double-touch
-      touchCount: 0,
-      dblTouchTimeout: null,
-    };
+  const resetDblTouchSimulation = () => {
+    setTouchCount(0);
+    setDblTouchTimeout(null);
+  };
 
-    getEditabilityControlled(fromProps = this.props) {
-      return fromProps.inEdit !== undefined;
+  useEffect(
+    () => {
+      if (getEditabilityControlled()) {
+        setInEdit(inEditProp);
+      }
+    },
+    [getEditabilityControlled, inEditProp]
+  );
+
+  const leaveEditModeIfNotControlled = () => {
+    if (!getEditabilityControlled()) {
+      setInEdit(false);
+    }
+  };
+
+  const handleDoubleClick = (event) => {
+    /**
+     * If `inEdit` isn't controlled, this component by default
+     * goes into edit mode on double click/touch.
+     */
+    if (!getEditabilityControlled()) {
+      setInEdit(true);
     }
 
-    resetDblTouchSimulation = () => {
-      this.setState({
-        touchCount: 0,
-        dblTouchTimeout: null,
-      });
+    onDblClick(event);
+  };
+
+  const handleTouchEnd = (event) => {
+    const currentCount = touchCount + 1;
+
+    if (currentCount === 2) {
+      // Simulates “double touch”
+      handleDoubleClick(event);
+      resetDblTouchSimulation();
+      return;
     }
 
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      /**
-       * If the edit-state of <EditableTextLabel> is *controlled* by `inEdit` prop.
-       * If the prop is `undefined`, this component became *uncontrolled*
-       * and should run itself.
+    /**
+       * Clears prev timeout to keep touch counts, and then
+       * create new timeout to reset touch counts.
        */
-      if (this.getEditabilityControlled(nextProps)) {
-        this.setState({ inEdit: nextProps.inEdit });
+    global.clearTimeout(dblTouchTimeout);
+    const resetTimeout = global.setTimeout(
+      resetDblTouchSimulation,
+      TOUCH_TIMEOUT_MS
+    );
+
+    setTouchCount(currentCount);
+    setDblTouchTimeout(resetTimeout);
+  };
+
+  const handleInputBlur = (event) => {
+    leaveEditModeIfNotControlled();
+    onEditEnd({
+      value: event.currentTarget.value,
+      event,
+    });
+  };
+
+  const handleInputKeyDown = (event) => {
+    switch (event.keyCode) {
+      case keycode('Enter'):
+        // Blur the input, and trigger `onEditEnd` in blur handler
+        event.currentTarget.blur();
+        break;
+      case keycode('Escape'): {
+        leaveEditModeIfNotControlled();
+        onEditEnd({
+          value: null,
+          event,
+        });
+        break;
       }
+      default:
+        break;
     }
+  };
 
-    leaveEditModeIfNotControlled() {
-      if (!this.getEditabilityControlled(this.props)) {
-        this.setState({ inEdit: false });
-      }
-    }
 
-    handleDoubleClick = (event) => {
-      /**
-       * If `inEdit` isn't controlled, this component by default
-       * goes into edit mode on double click/touch.
-       */
-      if (!this.getEditabilityControlled()) {
-        this.setState({ inEdit: true });
-      }
+  const { icon, basic, align } = labelProps;
 
-      const { onDblClick } = this.props;
-      onDblClick(event);
-    }
+  if (!inEdit && status !== STATUS.LOADING) {
+    return (
+      <TextLabel
+        status={status}
+        onDoubleClick={handleDoubleClick}
+        onTouchEnd={handleTouchEnd}
+        {...labelProps}
+      />
+    );
+  }
 
-    handleTouchEnd = (event) => {
-      const { touchCount, dblTouchTimeout } = this.state;
-      const currentCount = touchCount + 1;
+  const layoutProps = getTextLayoutProps(align, !!icon); // { align, noGrow }
+  const labelIcon = icon && wrapIfNotElement(icon, { with: Icon, via: 'type' });
 
-      if (currentCount === 2) {
-        // Simulates “double touch”
-        this.handleDoubleClick(event);
-        this.resetDblTouchSimulation();
-        return;
-      }
+  return (
+    <TextLabel {...labelProps}>
+      {labelIcon}
 
-      /**
-         * Clears prev timeout to keep touch counts, and then
-         * create new timeout to reset touch counts.
-         */
-      global.clearTimeout(dblTouchTimeout);
-      const resetTimeout = global.setTimeout(
-        this.resetDblTouchSimulation,
-        TOUCH_TIMEOUT_MS
-      );
-
-      this.setState({
-        touchCount: currentCount,
-        dblTouchTimeout: resetTimeout,
-      });
-    }
-
-    handleInputBlur = (event) => {
-      const { onEditEnd } = this.props;
-
-      this.leaveEditModeIfNotControlled();
-      onEditEnd({
-        value: event.currentTarget.value,
-        event,
-      });
-    }
-
-    handleInputKeyDown = (event) => {
-      switch (event.keyCode) {
-        case keycode('Enter'):
-          // Blur the input, and trigger `onEditEnd` in blur handler
-          event.currentTarget.blur();
-          break;
-        case keycode('Escape'): {
-          const { onEditEnd } = this.props;
-
-          this.leaveEditModeIfNotControlled();
-          onEditEnd({
-            value: null,
-            event,
-          });
-          break;
-        }
-        default:
-          break;
-      }
-    }
-
-    render() {
-      const {
-        inEdit, // not used here
-        onDblClick, // also not used here
-        onEditEnd,
-        status,
-        ...labelProps
-      } = this.props;
-      const { inEdit: stateInEdit } = this.state;
-
-      const { icon, basic, align } = labelProps;
-
-      if (!stateInEdit && status !== STATUS.LOADING) {
-        return (
-          <TextLabel
-            status={status}
-            onDoubleClick={this.handleDoubleClick}
-            onTouchEnd={this.handleTouchEnd}
-            {...labelProps}
-          />
-        );
-      }
-
-      const layoutProps = getTextLayoutProps(align, !!icon); // { align, noGrow }
-      const labelIcon = icon && wrapIfNotElement(icon, { with: Icon, via: 'type' });
-
-      return (
-        <TextLabel {...labelProps}>
-          {labelIcon}
-
-          <EditableText
-            defaultValue={basic}
-            autoFocus={stateInEdit}
-            onBlur={this.handleInputBlur}
-            onKeyDown={this.handleInputKeyDown}
-            {...layoutProps}
-          />
-        </TextLabel>
-      );
-    }
-}
+      <EditableText
+        defaultValue={basic}
+        autoFocus={inEdit}
+        onBlur={handleInputBlur}
+        onKeyDown={handleInputKeyDown}
+        {...layoutProps}
+      />
+    </TextLabel>
+  );
+});
 
 export default EditableTextLabel;
+
+
+EditableTextLabel.propTypes = {
+  inEdit: PropTypes.bool,
+  onEditEnd: PropTypes.func,
+  onDblClick: PropTypes.func,
+  // <TextLabel> props
+  icon: TextLabel.propTypes.icon,
+  basic: TextLabel.propTypes.basic,
+  align: TextLabel.propTypes.align,
+  status: TextLabel.propTypes.status,
+};
+
+EditableTextLabel.defaultProps = {
+  inEdit: undefined,
+  onEditEnd: () => {},
+  onDblClick: () => {},
+  // <TextLabel> props
+  icon: TextLabel.defaultProps.icon,
+  basic: TextLabel.defaultProps.basic,
+  align: TextLabel.defaultProps.align,
+  status: TextLabel.defaultProps.status,
+};

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -115,8 +115,6 @@ const StatusIcon = React.memo(({
 });
 
 
-export default StatusIcon;
-
 StatusIcon.propTypes = {
   status: PropTypes.oneOf([LOADING, SUCCESS, ERROR]),
   position: PropTypes.oneOf([INLINE, CORNER]),
@@ -132,3 +130,6 @@ StatusIcon.defaultProps = {
   position: INLINE,
   autohide: true,
 };
+
+
+export default StatusIcon;

--- a/packages/core/src/StatusIcon.js
+++ b/packages/core/src/StatusIcon.js
@@ -1,9 +1,13 @@
-import React, { PureComponent } from 'react';
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import icBEM from './utils/icBEM';
 import prefixClass from './utils/prefixClass';
-import getRemainingProps from './utils/getRemainingProps';
 import './styles/StatusIcon.scss';
 
 import Icon from './Icon';
@@ -22,115 +26,109 @@ const ROOT_BEM = icBEM(COMPONENT_NAME);
 
 const ICON_HIDE_TIMEOUT = 2 * 1000;
 
-class StatusIcon extends PureComponent {
-    static propTypes = {
-      status: PropTypes.oneOf([LOADING, SUCCESS, ERROR]),
-      position: PropTypes.oneOf([INLINE, CORNER]),
-      /**
-         * if `true`, Auto hides status icon after being success for 2 secs,
-         * or shows icon when component leaves success state.
-         * */
-      autohide: PropTypes.bool,
-    };
+const StatusIcon = React.memo(({
+  status,
+  position,
+  autohide,
+  ...wrapperProps
+}) => {
+  const [hideIcon, setHideIcon] = useState(false);
+  const hideIconTimeout = useRef(null);
 
-    static defaultProps = {
-      status: undefined,
-      position: INLINE,
-      autohide: true,
-    };
-
-    constructor(props) {
-      super(props);
-      this.hideIconTimeout = null;
-    }
-
-    state = {
-      hideIcon: false,
-    };
-
-    componentWillUnmount() {
-      clearTimeout(this.hideIconTimeout);
-    }
-
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillMount() {
-      this.autoToggleStatusIcon();
-    }
-
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      if (nextProps.status !== this.props.status) {
-        this.autoToggleStatusIcon(nextProps.status);
-      }
-
-      // If 'autohide' is turned off, make icon visible immediately
-      if (!nextProps.autohide && this.state.hideIcon) {
-        this.setState({ hideIcon: false });
-      }
-    }
-
-    /**
-     * Auto hides status icon after being SUCCESS for 2 secs,
-     * or shows icon when component leaves SUCCESS state.
-     *
-     * Scenario:
-     *   - LOADING -> SUCCESS -> (2s) ==> hide
-     *   - LOADING -> SUCCESS -> (1s) -> LOADING|ERROR|null ==> clear timeout
-     *   - LOADING -> SUCCESS -> (1s) -> (render) -> SUCCESS ==> keep timeout
-     *   - SUCCESS -> LOADING|ERROR|null ==> clear timeout & show icon
-     *
-     * @param {String} status - current or next 'status'
-     */
-    autoToggleStatusIcon(status = this.props.status) {
-      // Ignore if autohide === false
-      if (!this.props.autohide) {
+  /**
+   * Auto hides status icon after being SUCCESS for 2 secs,
+   * or shows icon when component leaves SUCCESS state.
+   *
+   * Scenario:
+   *   - LOADING -> SUCCESS -> (2s) ==> hide
+   *   - LOADING -> SUCCESS -> (1s) -> LOADING|ERROR|null ==> clear timeout
+   *   - LOADING -> SUCCESS -> (1s) -> (render) -> SUCCESS ==> keep timeout
+   *   - SUCCESS -> LOADING|ERROR|null ==> clear timeout & show icon
+   *
+   * @param {String} status - current or next 'status'
+   */
+  const autoToggleStatusIcon = useCallback(
+    () => {
+    // Ignore if autohide === false
+      if (!autohide) {
         return;
       }
 
       // LOADING|ERROR|null -> SUCCESS
       if (status === SUCCESS) {
-        this.hideIconTimeout = setTimeout(() => {
-          this.setState({ hideIcon: true });
-          this.hideIconTimeout = null;
+        hideIconTimeout.current = setTimeout(() => {
+          setHideIcon(true);
+          hideIconTimeout.current = null;
         }, ICON_HIDE_TIMEOUT);
 
         return;
       }
 
       // SUCCESS -> LOADING|ERROR|null
-      clearTimeout(this.hideIconTimeout);
-      this.setState({ hideIcon: false });
-    }
+      clearTimeout(hideIconTimeout.current);
+      setHideIcon(false);
+    },
+    [autohide, status]
+  );
 
-    render() {
-      const { status, position } = this.props;
-      const rootClassName = ROOT_BEM.modifier(position);
-      let icon = null;
+  useEffect(
+    () => () => clearTimeout(hideIconTimeout.current),
+    []
+  );
 
-      switch (status) {
-        case LOADING:
-          icon = <Icon type="inline-loading" color="gray" spinning />;
-          break;
-        case SUCCESS:
-          if (!this.state.hideIcon) {
-            icon = <Icon type="inline-success" color="blue" />;
-          }
-          break;
-        case ERROR:
-          icon = <Icon type="inline-error" color="red" />;
-          break;
-        default:
-          break;
+  useEffect(
+    () => {
+      autoToggleStatusIcon();
+
+      // If 'autohide' is turned off, make icon visible immediately
+      if (!autohide && hideIcon) {
+        setHideIcon(false);
       }
+    },
+    [status, autohide, hideIcon, autoToggleStatusIcon]
+  );
 
-      const wrapperProps = getRemainingProps(this.props, StatusIcon.propTypes);
+  const rootClassName = ROOT_BEM.modifier(position);
+  let icon = null;
 
-      return (icon && (
-        <span className={rootClassName} {...wrapperProps}>
-          {icon}
-        </span>
-      ));
-    }
-}
+  switch (status) {
+    case LOADING:
+      icon = <Icon type="inline-loading" color="gray" spinning />;
+      break;
+    case SUCCESS:
+      if (!hideIcon) {
+        icon = <Icon type="inline-success" color="blue" />;
+      }
+      break;
+    case ERROR:
+      icon = <Icon type="inline-error" color="red" />;
+      break;
+    default:
+      break;
+  }
+
+  return (icon && (
+    <span className={rootClassName} {...wrapperProps}>
+      {icon}
+    </span>
+  ));
+});
+
 
 export default StatusIcon;
+
+StatusIcon.propTypes = {
+  status: PropTypes.oneOf([LOADING, SUCCESS, ERROR]),
+  position: PropTypes.oneOf([INLINE, CORNER]),
+  /**
+   * if `true`, Auto hides status icon after being success for 2 secs,
+   * or shows icon when component leaves success state.
+   * */
+  autohide: PropTypes.bool,
+};
+
+StatusIcon.defaultProps = {
+  status: undefined,
+  position: INLINE,
+  autohide: true,
+};

--- a/packages/core/src/__tests__/EditableBasicRow.test.js
+++ b/packages/core/src/__tests__/EditableBasicRow.test.js
@@ -1,132 +1,140 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { shallow, mount } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditableBasicRow, { ROW_INPUT_TAGS } from '../EditableBasicRow';
 
-import EditableBasicRow, { BEM } from '../EditableBasicRow';
+describe('<EditableBasicRow />', () => {
+  let value;
+  let onChange;
+  let onFocus;
+  let onBlur;
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  const element = <EditableBasicRow />;
+  beforeEach(() => {
+    value = 'Test value';
+    onChange = jest.fn();
+    onFocus = jest.fn();
+    onBlur = jest.fn();
+  });
 
-  ReactDOM.render(element, div);
-});
+  it('renders correctly', () => {
+    render(
+      <EditableBasicRow
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-it('renders an <input> or <textarea> inside a <BasicRow>', () => {
-  const wrapper = shallow(<EditableBasicRow />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue(value);
+  });
 
-  expect(wrapper.find('BasicRow')).toHaveLength(1);
-  expect(wrapper.find('BasicRow').find('input')).toHaveLength(1);
-  expect(wrapper.find('BasicRow').find('textarea')).toHaveLength(0);
+  it('handles input change', () => {
+    render(
+      <EditableBasicRow
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  wrapper.setProps({ inputTag: 'textarea' });
-  expect(wrapper.find('BasicRow').find('input')).toHaveLength(0);
-  expect(wrapper.find('BasicRow').find('textarea')).toHaveLength(1);
-});
+    const input = screen.getByRole('textbox');
+    userEvent.type(input, 'New test value');
 
-it('updates state on input focus/blur', () => {
-  const wrapper = shallow(<EditableBasicRow />);
-  const inputWrapper = wrapper.find('input');
+    expect(onChange).toHaveBeenCalled();
+  });
 
-  expect(wrapper.state('focused')).toBeFalsy();
+  it('handles input change and input is not controlled', () => {
+    render(
+      <EditableBasicRow
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  inputWrapper.simulate('focus');
-  expect(wrapper.state('focused')).toBeTruthy();
+    const input = screen.getByRole('textbox');
+    userEvent.type(input, 'New test value');
 
-  inputWrapper.simulate('blur');
-  expect(wrapper.state('focused')).toBeFalsy();
-});
+    expect(screen.getByText('New test value')).toBeInTheDocument();
+  });
 
-it('forwards onFocus/onBlur events', () => {
-  const handleFocus = jest.fn();
-  const handleBlur = jest.fn();
+  it('handles input focus and blur', () => {
+    render(
+      <EditableBasicRow
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  const wrapper = shallow(<EditableBasicRow onFocus={handleFocus} onBlur={handleBlur} />);
-  const inputWrapper = wrapper.find('input');
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    expect(onFocus).toHaveBeenCalled();
 
-  expect(handleFocus).not.toHaveBeenCalled();
-  expect(handleBlur).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onBlur).toHaveBeenCalled();
+  });
 
-  inputWrapper.simulate('focus');
-  expect(handleFocus).toHaveBeenCalledTimes(1);
-  expect(handleBlur).not.toHaveBeenCalled();
+  it('renders textarea when inputTag is set to TEXTAREA', () => {
+    render(
+      <EditableBasicRow
+        inputTag={ROW_INPUT_TAGS.TEXTAREA}
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  inputWrapper.simulate('blur');
-  expect(handleFocus).toHaveBeenCalledTimes(1);
-  expect(handleBlur).toHaveBeenCalledTimes(1);
-});
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveValue(value);
+  });
 
-it('forwards onChange event', () => {
-  const handleChange = jest.fn();
-  const wrapper = shallow(<EditableBasicRow onChange={handleChange} />);
-  const inputWrapper = wrapper.find('input');
+  it('renders with default placeholder when value is not provided', () => {
+    render(
+      <EditableBasicRow
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  expect(handleChange).not.toHaveBeenCalled();
+    const input = screen.getByPlaceholderText('Unset');
+    expect(input).toHaveValue('');
+  });
 
-  inputWrapper.simulate('change', { currentTarget: document.createElement('input') });
-  expect(handleChange).toHaveBeenCalledTimes(1);
-});
+  it('renders as disabled when disabled prop is true', () => {
+    render(
+      <EditableBasicRow
+        value={value}
+        disabled
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-it('updates user input inside state when not controlled', () => {
-  const wrapper = shallow(<EditableBasicRow defaultValue="Foo" />);
-  const inputWrapper = wrapper.find('input');
-  const mockedInput = document.createElement('input');
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
 
-  expect(wrapper.state('currentValue')).toBe('Foo');
+  it('renders as read-only when readOnly prop is true', () => {
+    render(
+      <EditableBasicRow
+        value={value}
+        readOnly
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
 
-  mockedInput.value = 'Bar';
-  inputWrapper.simulate('change', { currentTarget: mockedInput });
-  expect(wrapper.state('currentValue')).toBe('Bar');
-});
-
-it('freezes input value when controlled via prop', () => {
-  const wrapper = shallow(<EditableBasicRow value="Foo" />);
-  const inputWrapper = wrapper.find('input');
-  const mockedInput = document.createElement('input');
-
-  expect(wrapper.state('currentValue')).toBe('Foo');
-
-  mockedInput.value = 'Bar';
-  inputWrapper.simulate('change', { currentTarget: mockedInput });
-  expect(wrapper.state('currentValue')).toBe('Foo');
-});
-
-it('renders basic label with the same visual text from input', () => {
-  const wrapper = mount(<EditableBasicRow value="Foo" placeholder="Unset" />);
-  const labelClass = `.${BEM.basicLabel}`;
-  expect(wrapper.find(labelClass).text()).toBe('Foo');
-
-  wrapper.setProps({ value: 'Bar' });
-  expect(wrapper.find(labelClass).text()).toBe('Bar');
-
-  wrapper.setProps({ value: '' });
-  expect(wrapper.find(labelClass).text()).toBe('Unset');
-});
-
-it('renders basic label with additional line-break when tag is textarea', () => {
-  const wrapper = mount(
-    <EditableBasicRow inputTag="textarea" value="Foo" placeholder="Unset" />
-  );
-  const labelClass = `.${BEM.basicLabel}`;
-  expect(wrapper.find(labelClass).text()).toBe('Foo\n');
-
-  wrapper.setProps({ value: 'Foo\n' });
-  expect(wrapper.find(labelClass).text()).toBe('Foo\n\n');
-});
-
-it('keeps input from keyboard navigation when input looks untouchable', () => {
-  const wrapper = shallow(<EditableBasicRow readOnly={false} disabled={false} />);
-  expect(wrapper.find('input').prop('tabIndex')).toBeUndefined();
-
-  wrapper.setProps({ readOnly: true, disabled: false });
-  expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
-
-  wrapper.setProps({ readOnly: false, disabled: true });
-  expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
-});
-
-it('passes unknown props to its underlying input', () => {
-  const wrapper = shallow(<EditableBasicRow autoFocus id="foo-input" />);
-
-  expect(wrapper.find('input').prop('autoFocus')).toBeTruthy();
-  expect(wrapper.find('input').prop('id')).toBe('foo-input');
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('readonly');
+  });
 });

--- a/packages/core/src/__tests__/EditableTextLabel.test.js
+++ b/packages/core/src/__tests__/EditableTextLabel.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EditableTextLabel from '../EditableTextLabel';
 
@@ -112,5 +112,30 @@ describe('EditableTextLabel', () => {
       value: 'new text',
       event: expect.any(Object),
     }));
+  });
+
+
+  it('do not call onDblClick when only touched once', () => {
+    render(<EditableTextLabel {...defaultProps} />);
+    fireEvent.touchEnd(screen.getByText(defaultProps.basic));
+    expect(defaultProps.onDblClick).toHaveBeenCalledTimes(0);
+  });
+
+  it('do not call onDblClick when touched twice but over 250ms', () => {
+    jest.useFakeTimers();
+
+    render(<EditableTextLabel {...defaultProps} />);
+
+    fireEvent.touchEnd(screen.getByText(defaultProps.basic));
+    jest.advanceTimersByTime(300);
+    fireEvent.touchEnd(screen.getByText(defaultProps.basic));
+    expect(defaultProps.onDblClick).toHaveBeenCalledTimes(0);
+  });
+
+  it('call onDblClick when touched twice', () => {
+    render(<EditableTextLabel {...defaultProps} />);
+    fireEvent.touchEnd(screen.getByText(defaultProps.basic));
+    fireEvent.touchEnd(screen.getByText(defaultProps.basic));
+    expect(defaultProps.onDblClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/__tests__/EditableTextLabel.test.js
+++ b/packages/core/src/__tests__/EditableTextLabel.test.js
@@ -1,212 +1,116 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
-import keycode from 'keycode';
-
-import { getTextLayoutProps, ROW_COMP_ALIGN } from '../mixins/rowComp';
-
-import EditableText from '../EditableText';
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import EditableTextLabel from '../EditableTextLabel';
-import Icon from '../Icon';
-import TextLabel from '../TextLabel';
 
-describe('rendering', () => {
-  it('renders without crashing', () => {
-    const div = document.createElement('div');
-    const element = <EditableTextLabel />;
+describe('EditableTextLabel', () => {
+  const defaultProps = {
+    inEdit: undefined,
+    onEditEnd: jest.fn(),
+    onDblClick: jest.fn(),
+    icon: 'icon',
+    basic: 'basic text',
+    align: 'center',
+    status: 'status',
+  };
 
-    ReactDOM.render(element, div);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('renders like a typical <TextLabel> when not inEdit or loading', () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" />);
+  it('renders in display mode by default', () => {
+    render(<EditableTextLabel {...defaultProps} />);
 
-    expect(wrapper.is(TextLabel)).toBeTruthy();
-    expect(wrapper.prop('basic')).toBe('Foo');
-    expect(wrapper.prop('children')).toBeUndefined();
+    expect(screen.getByText(defaultProps.basic)).toBeInTheDocument();
   });
 
-  it('renders <EditableText> inside <TextLabel> when in edit mode', () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" inEdit />);
+  it('enters edit mode on double click when inEdit is not controlled', () => {
+    render(<EditableTextLabel {...defaultProps} />);
 
-    expect(wrapper.is(TextLabel)).toBeTruthy();
-    expect(wrapper.find(EditableText).exists()).toBeTruthy();
-    expect(wrapper.find(EditableText).prop('defaultValue')).toBe('Foo');
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
 
-    wrapper.setProps({ inEdit: false });
-    expect(wrapper.find(EditableText).exists()).toBeFalsy();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
-  it('renders icon no matter in edit mode or not', () => {
-    const wrapper = shallow(<EditableTextLabel icon="printer" basic="Foo" />);
+  it('does not enter edit mode on double click when inEdit is controlled as false', () => {
+    const props = { ...defaultProps, inEdit: false };
 
-    // Icon is rendered by <TextLabel> when not inEdit
-    expect(wrapper.dive().contains(<Icon type="printer" />)).toBeTruthy();
+    render(<EditableTextLabel {...props} />);
 
-    // Icon is passed into <TextLabel> by <EditableTextLabel> when inEdit
-    wrapper.setProps({ inEdit: true });
-    expect(wrapper.contains(<Icon type="printer" />)).toBeTruthy();
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
-  it('renders <EditableText> with layout props the same as rowComp() in edit mode', () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" align="left" inEdit />);
+  it('does not enter edit mode on double click when inEdit is controlled as true', () => {
+    const props = { ...defaultProps, inEdit: true };
 
-    Object.values(ROW_COMP_ALIGN).forEach((alignment) => {
-      let layoutProps = getTextLayoutProps(alignment, false);
-      wrapper.setProps({ align: alignment, icon: undefined });
+    render(<EditableTextLabel {...props} />);
 
-      expect(wrapper.find(EditableText).prop('align')).toBe(layoutProps.align);
-      expect(wrapper.find(EditableText).prop('noGrow')).toBe(layoutProps.noGrow);
-
-      layoutProps = getTextLayoutProps(alignment, true);
-      wrapper.setProps({ align: alignment, icon: 'printer' });
-
-      expect(wrapper.find(EditableText).prop('align')).toBe(layoutProps.align);
-      expect(wrapper.find(EditableText).prop('noGrow')).toBe(layoutProps.noGrow);
-    });
-  });
-});
-
-describe('input event handlers', () => {
-  it('fires onEditEnd with input value on input blurs', () => {
-    const handleEditEnd = jest.fn(() => EditableTextLabel.defaultProps.onEditEnd());
-    const wrapper = shallow(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
-
-    expect(handleEditEnd).not.toHaveBeenCalled();
-
-    // Blur without changing input value
-    wrapper.find(EditableText).simulate('blur', { currentTarget: { value: 'foo' } });
-    expect(handleEditEnd).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 'foo' })
-    );
-
-    // Blur with a different value
-    wrapper.find(EditableText).simulate('blur', { currentTarget: { value: 'bar' } });
-    expect(handleEditEnd).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: 'bar' })
-    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
-  it('blurs input on Enter key', () => {
-    const wrapper = shallow(<EditableTextLabel basic="foo" inEdit />);
-    const mockedBlur = jest.fn();
-
-    expect(mockedBlur).not.toHaveBeenCalled();
-
-    wrapper.find(EditableText).simulate('keydown', {
-      currentTarget: { blur: mockedBlur },
-      keyCode: keycode('Enter'),
-    });
-    expect(mockedBlur).toHaveBeenCalledTimes(1);
+  it('calls onDblClick when double clicked', () => {
+    render(<EditableTextLabel {...defaultProps} />);
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
+    expect(defaultProps.onDblClick).toHaveBeenCalledTimes(1);
   });
 
-  it('fires onEditEnd with value as null on Escape key', () => {
-    const handleEditEnd = jest.fn();
-    const wrapper = shallow(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
+  it('inEdit is not controlled: call onEditEnd with input value and do not change the value when it blurs', async () => {
+    render(<EditableTextLabel {...defaultProps} />);
 
-    expect(handleEditEnd).not.toHaveBeenCalled();
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
+    const input = screen.getByRole('textbox');
+    userEvent.clear(input);
+    userEvent.type(input, 'new text');
+    userEvent.tab();
 
-    wrapper.find(EditableText).simulate('keydown', { keyCode: keycode('Escape') });
-    expect(handleEditEnd).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: null })
-    );
+    await waitFor(() => expect(defaultProps.onEditEnd).toHaveBeenCalledWith({
+      value: 'new text',
+      event: expect.any(Object),
+    }));
+
+    expect(screen.getByText(defaultProps.basic)).toBeInTheDocument();
   });
 
-  it('does not fire onEditEnd on other keys', () => {
-    const handleEditEnd = jest.fn();
-    const wrapper = shallow(<EditableTextLabel basic="foo" onEditEnd={handleEditEnd} inEdit />);
+  it('inEdit is controlled: call onEditEnd with input value and change the value when it blurs', async () => {
+    render(<EditableTextLabel {...defaultProps} inEdit />);
 
-    expect(handleEditEnd).not.toHaveBeenCalled();
+    const input = screen.getByRole('textbox');
+    userEvent.clear(input);
+    userEvent.type(input, 'new text');
+    userEvent.tab();
 
-    wrapper.find(EditableText).simulate('keydown', { keyCode: keycode('A') });
-    expect(handleEditEnd).not.toHaveBeenCalled();
+    await waitFor(() => expect(defaultProps.onEditEnd).toHaveBeenCalledWith({
+      value: 'new text',
+      event: expect.any(Object),
+    }));
 
-    wrapper.find(EditableText).simulate('keydown', { keyCode: keycode('Ctrl') });
-    expect(handleEditEnd).not.toHaveBeenCalled();
-
-    wrapper.find(EditableText).simulate('keydown', { keyCode: keycode('Delete') });
-    expect(handleEditEnd).not.toHaveBeenCalled();
-  });
-});
-
-describe('behaviors as controlled/uncontrolled component', () => {
-  it("goes edit mode on double click if 'inEdit' is uncontrolled", () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" />);
-    expect(wrapper.state('inEdit')).toBeFalsy();
-
-    wrapper.simulate('dblclick');
-    expect(wrapper.state('inEdit')).toBeTruthy();
+    expect(screen.getByText('new text')).toBeInTheDocument();
   });
 
-  it("stays in edit mode as long as 'inEdit' is uncontrolled", () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" />);
-    wrapper.setState({ inEdit: true });
-    wrapper.setProps({ icon: 'printer' });
 
-    expect(wrapper.state('inEdit')).toBeTruthy();
+  it('calls onEditEnd with null when escape key is pressed', async () => {
+    render(<EditableTextLabel {...defaultProps} />);
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
+    const input = screen.getByRole('textbox');
+    userEvent.type(input, '{esc}');
+    await waitFor(() => expect(defaultProps.onEditEnd).toHaveBeenCalledWith({
+      value: null,
+      event: expect.any(Object),
+    }));
   });
 
-  it("leaves edit mode on blur if 'inEdit' is uncontrolled", () => {
-    const wrapper = shallow(<EditableTextLabel basic="foo" />);
+  it('calls onEditEnd with input value when enter key is pressed', async () => {
+    render(<EditableTextLabel {...defaultProps} />);
+    userEvent.dblClick(screen.getByText(defaultProps.basic));
+    const input = screen.getByRole('textbox');
 
-    wrapper.setState({ inEdit: true });
-    wrapper.find(EditableText).simulate('blur', { currentTarget: {} });
+    userEvent.clear(input);
+    userEvent.type(input, 'new text{enter}');
 
-    expect(wrapper.state('inEdit')).toBeFalsy();
-  });
-
-  it("leaves edit mode on Esc if 'inEdit' is uncontrolled", () => {
-    const wrapper = shallow(<EditableTextLabel basic="foo" />);
-
-    wrapper.setState({ inEdit: true });
-    wrapper.find(EditableText).simulate('keydown', { keyCode: keycode('Escape') });
-
-    expect(wrapper.state('inEdit')).toBeFalsy();
-  });
-
-  it("does not go edit mode on double click if 'inEdit' is controlled", () => {
-    const wrapper = shallow(<EditableTextLabel basic="Foo" inEdit={false} />);
-    expect(wrapper.state('inEdit')).toBeFalsy();
-
-    wrapper.simulate('dblclick');
-    expect(wrapper.state('inEdit')).toBeFalsy();
-  });
-});
-
-describe('Double-touch simulation', () => {
-  it('triggers dblClick callback when touch twice with in 250ms', () => {
-    const handleDblClick = jest.fn();
-    const wrapper = shallow(<EditableTextLabel basic="foo" onDblClick={handleDblClick} />);
-
-    expect(handleDblClick).not.toHaveBeenCalled();
-
-    return new Promise((resolve) => {
-      wrapper.simulate('touchend');
-      expect(wrapper.state('touchCount')).toBe(1);
-
-      setTimeout(() => {
-        wrapper.simulate('touchend');
-        resolve();
-      }, 200);
-    }).then(() => {
-      expect(handleDblClick).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('does not trigger dblClick callback when touch twice in over 250ms', () => {
-    const handleDblClick = jest.fn();
-    const wrapper = shallow(<EditableTextLabel basic="foo" onDblClick={handleDblClick} />);
-
-    expect(handleDblClick).not.toHaveBeenCalled();
-
-    return new Promise((resolve) => {
-      wrapper.simulate('touchstart');
-      setTimeout(() => {
-        wrapper.simulate('touchstart');
-        resolve();
-      }, 500);
-    }).then(() => {
-      expect(handleDblClick).not.toHaveBeenCalled();
-    });
+    await waitFor(() => expect(defaultProps.onEditEnd).toHaveBeenCalledWith({
+      value: 'new text',
+      event: expect.any(Object),
+    }));
   });
 });

--- a/packages/core/src/mixins/__tests__/withStatus.test.js
+++ b/packages/core/src/mixins/__tests__/withStatus.test.js
@@ -72,7 +72,9 @@ it('passes down "errorMsg" to wrapped component', () => {
     { context: { status: 'error', errorMsg: 'Just error' } }
   );
 
-  expect(wrapper.find(Foo).shallow().text()).toBe('<StatusIcon />Just error');
+  const iconWrapper = wrapper.find(Foo).shallow().find(StatusIcon);
+  expect(iconWrapper.prop('status')).toBe('error');
+  expect(wrapper.find(Foo).prop('errorMsg')).toBe('Just error');
 });
 
 it('passes down other props to wrapped component', () => {


### PR DESCRIPTION
# Purpose

- 重構有使用到 UNSAFE lifecycle 的 components，用 react hooks 改寫
- 由於從 class component 改寫成 functional component，原本的 enzyme 測試針對 class component 的測試方法會失敗，因此也將對應的測試用 testing-library 重寫了
- 這個 PR 改寫了三個檔案，可以依照 commit review 改寫的內容和對應的測試
