### PR TITLE
refactor: Refactor SelectList component to use React hooks

### DIFF
--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -94,15 +94,18 @@ const SelectList = React.memo(({
   );
 
   // Check if the component is switching between controlled and uncontrolled
-  useEffect(() => {
-    warning(
-      isControlled === prevIsControlled.current,
-      '<SelectList> should not switch from controlled to uncontrolled (or vice versa).'
-    );
+  useEffect(
+    () => {
+      warning(
+        isControlled === prevIsControlled.current,
+        '<SelectList> should not switch from controlled to uncontrolled (or vice versa).'
+      );
 
-    // Saving current value for the next comparison
-    prevIsControlled.current = isControlled;
-  }, [isControlled]);
+      // Saving current value for the next comparison
+      prevIsControlled.current = isControlled;
+    },
+    [isControlled]
+  );
 
   const handleChange = (nextCheckedState) => {
     if (!isControlled) {

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 
@@ -7,7 +7,6 @@ import { Map as ImmutableMap } from 'immutable';
 import {
   List,
 } from '@ichef/gypcrete';
-import getRemainingProps from '@ichef/gypcrete/lib/utils/getRemainingProps';
 
 import Option, {
   valueType,
@@ -34,217 +33,202 @@ function getInitialCheckedState(selectedValue, multiple = true) {
  * It can be in either **single** or **multiple** response mode.
  */
 
-class SelectList extends PureComponent {
-    static propTypes = {
-      multiple: PropTypes.bool,
-      showCheckAll: PropTypes.bool,
-      minCheck: PropTypes.number,
-      checkAllLabel: PropTypes.node,
-      value: PropTypes.oneOfType([
-        valueType,
-        PropTypes.arrayOf(valueType),
-      ]),
-      defaultValue: PropTypes.oneOfType([
-        valueType,
-        PropTypes.arrayOf(valueType),
-      ]),
-      onChange: PropTypes.func,
-      title: PropTypes.string,
-      desc: PropTypes.node,
-    };
+const SelectList = React.memo(({
+  multiple,
+  showCheckAll,
+  minCheck,
+  checkAllLabel,
+  value,
+  defaultValue,
+  onChange,
+  title,
+  desc,
+  children,
+  ...wrapperProps
+}) => {
+  const getInitialValue = () => {
+    if (value !== undefined) {
+      return value;
+    }
 
-    static defaultProps = {
-      multiple: false,
-      showCheckAll: true,
-      minCheck: 0,
-      checkAllLabel: 'All',
-      value: undefined,
-      defaultValue: undefined,
-      onChange: () => {},
-      title: undefined,
-      desc: undefined,
-    };
+    if (multiple && defaultValue === undefined) {
+      return [];
+    }
 
-    state = {
-      checkedState: getInitialCheckedState(
-        this.getInitialValue(),
-        this.props.multiple
-      ),
-    };
+    return defaultValue;
+  };
 
-    getInitialValue() {
-      const { value, defaultValue, multiple } = this.props;
+  const [checkedState, setCheckedState] = useState(getInitialCheckedState(
+    getInitialValue(),
+    multiple
+  ));
+  const prevMultiple = useRef(multiple);
+  const isControlled = value !== undefined;
+  const prevIsControlled = useRef(isControlled);
 
-      if (value !== undefined) {
-        return value;
+  const options = parseSelectOptions(children);
+
+  const isAllChecked = options.every(option => checkedState.get(option.value));
+
+  // Update state when value prop changes
+  useEffect(
+    () => {
+      if (isControlled) {
+        setCheckedState(getInitialCheckedState(value, multiple));
       }
+    },
+    [value, multiple, isControlled]
+  );
 
-      if (multiple && defaultValue === undefined) {
-        return [];
-      }
-
-      return defaultValue;
-    }
-
-    getIsControlled(fromProps = this.props) {
-      return fromProps.value !== undefined;
-    }
-
-    getIsAllChecked() {
-      const { checkedState } = this.state;
-      const allOptions = this.getOptions();
-
-      return allOptions.every(option => checkedState.get(option.value));
-    }
-
-    getOptions(fromProps = this.props) {
-      return parseSelectOptions(fromProps.children);
-    }
-
-    // eslint-disable-next-line react/destructuring-assignment
-    getValues(fromCheckedState = this.state.checkedState) {
-      const allOptions = this.getOptions();
-
-      return allOptions
-        .filter(option => fromCheckedState.get(option.value))
-        .map(option => option.value);
-    }
-
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      warning(
-        this.getIsControlled(this.props) === this.getIsControlled(nextProps),
-        '<SelectList> should not switch from controlled to uncontrolled (or vice versa).'
-      );
-
-      if (this.getIsControlled(nextProps)) {
-        this.setState({
-          checkedState: getInitialCheckedState(nextProps.value, nextProps.multiple),
-        });
-      } else if (this.props.multiple !== nextProps.multiple) {
+  // Reset state when multiple prop changes
+  useEffect(
+    () => {
+      if (!isControlled && prevMultiple.current !== multiple) {
         warning(false, '<SelectList>: you should not change `multiple` prop while it is uncontrolled. Its value will be reset now.');
-        this.setState({
-          checkedState: getInitialCheckedState([]),
+        setCheckedState(getInitialCheckedState([]));
+      }
+      // Saving current value to ref for comparing it on next render
+      prevMultiple.current = multiple;
+    },
+    [multiple, isControlled]
+  );
+
+  // Check if the component is switching between controlled and uncontrolled
+  useEffect(() => {
+    warning(
+      isControlled === prevIsControlled.current,
+      '<SelectList> should not switch from controlled to uncontrolled (or vice versa).'
+    );
+
+    // Saving current value for the next comparison
+    prevIsControlled.current = isControlled;
+  }, [isControlled]);
+
+  const handleChange = (nextCheckedState) => {
+    if (!isControlled) {
+      setCheckedState(nextCheckedState);
+    }
+
+    const newValues = options
+      .filter(option => nextCheckedState.get(option.value))
+      .map(option => option.value);
+
+    onChange(multiple ? newValues : newValues[0]);
+  };
+
+  const handleOptionChange = (optionValue, isChecked) => {
+    let nextState = checkedState;
+
+    if (multiple) {
+      nextState = nextState.set(optionValue, isChecked);
+
+      const nextCheckedSize = nextState.filter(_value => _value).size;
+
+      if (nextCheckedSize < minCheck) {
+        // Cancel this operation
+        return;
+      }
+    } else {
+      const currentCheckedOptionValue = checkedState.findKey(_value => _value);
+
+      if (optionValue === currentCheckedOptionValue) {
+        // Does not consider a change
+        return;
+      }
+      nextState = nextState
+        .set(currentCheckedOptionValue, false)
+        .set(optionValue, isChecked);
+    }
+
+    handleChange(nextState);
+  };
+
+  const handleCheckAllOptionChange = (ignoreThis, isChecked) => {
+    const variableOptions = options.filter(option => !option.readOnly);
+
+    const nextState = checkedState.withMutations((map) => {
+      variableOptions.forEach(option => map.set(option.value, isChecked));
+
+      const nextCheckedSize = map.filter(_value => _value).size;
+      const checksNeeded = minCheck - nextCheckedSize;
+
+      // Check options until matching minCheck
+      if (checksNeeded > 0) {
+        variableOptions.slice(0, checksNeeded)
+          .forEach(option => map.set(option.value, true));
+      }
+    });
+
+    handleChange(nextState);
+  };
+
+  const renderOptions = childrenToRender => React.Children.map(
+    childrenToRender,
+    (child) => {
+      const elementTypeSymbol = getElementTypeSymbol(child);
+      if (
+        elementTypeSymbol === CHECKBOX_OPTION_TYPE_SYMBOL
+        || elementTypeSymbol === RADIO_OPTION_TYPE_SYMBOL
+      ) {
+        return React.cloneElement(child, {
+          checked: checkedState.get(child.props.value),
+          onChange: handleOptionChange,
         });
       }
-    }
 
-    handleChange(nextCheckedState) {
-      const { onChange, multiple } = this.props;
-      const nextValues = this.getValues(nextCheckedState);
-
-      if (!this.getIsControlled()) {
-        this.setState({ checkedState: nextCheckedState });
-      }
-      onChange(multiple ? nextValues : nextValues[0]);
-    }
-
-    handleOptionChange = (optionValue, isChecked) => {
-      const { multiple, minCheck } = this.props;
-      const { checkedState } = this.state;
-
-      let nextState = checkedState;
-
-      if (multiple) {
-        nextState = nextState.set(optionValue, isChecked);
-
-        const nextCheckedSize = nextState.filter(value => value).size;
-
-        if (nextCheckedSize < minCheck) {
-          // Cancel this operation
-          return;
-        }
-      } else {
-        const currentCheckedOptionValue = checkedState.findKey(value => value);
-
-        if (optionValue === currentCheckedOptionValue) {
-          // Does not consider a change
-          return;
-        }
-        nextState = nextState
-          .set(currentCheckedOptionValue, false)
-          .set(optionValue, isChecked);
+      if (child && child.type === React.Fragment) {
+        return renderOptions(child.props.children);
       }
 
-      this.handleChange(nextState);
+      return child;
     }
+  );
 
-    handleCheckAllOptionChange = (ignoreThis, isChecked) => {
-      const { minCheck } = this.props;
-      const { checkedState } = this.state;
+  const renderCheckAllOption = () => (
+    <Option
+      label={checkAllLabel}
+      value={null}
+      checked={isAllChecked}
+      onChange={handleCheckAllOptionChange}
+    />
+  );
 
-      const variableOptions = this.getOptions()
-        .filter(option => !option.readOnly);
-
-      const nextState = checkedState.withMutations((map) => {
-        variableOptions.forEach(option => map.set(option.value, isChecked));
-
-        const nextCheckedSize = map.filter(value => value).size;
-        const checksNeeded = minCheck - nextCheckedSize;
-
-        // Check options until matching minCheck
-        if (checksNeeded > 0) {
-          variableOptions.slice(0, checksNeeded)
-            .forEach(option => map.set(option.value, true));
-        }
-      });
-
-      this.handleChange(nextState);
-    }
-
-    renderOptions(children = this.props.children) {
-      const { checkedState } = this.state;
-
-      return React.Children.map(children, (child) => {
-        const elementTypeSymbol = getElementTypeSymbol(child);
-        if (
-          elementTypeSymbol === CHECKBOX_OPTION_TYPE_SYMBOL
-          || elementTypeSymbol === RADIO_OPTION_TYPE_SYMBOL
-        ) {
-          return React.cloneElement(child, {
-            checked: checkedState.get(child.props.value),
-            onChange: this.handleOptionChange,
-          });
-        }
-
-        if (child && child.type === React.Fragment) {
-          return this.renderOptions(child.props.children);
-        }
-
-        return child;
-      });
-    }
-
-    renderCheckAllOption() {
-      const { checkAllLabel } = this.props;
-      const isAllChecked = this.getIsAllChecked();
-
-      return (
-        <Option
-          label={checkAllLabel}
-          value={null}
-          checked={isAllChecked}
-          onChange={this.handleCheckAllOptionChange}
-        />
-      );
-    }
-
-    render() {
-      const {
-        multiple,
-        showCheckAll,
-        title,
-        desc,
-      } = this.props;
-      const wrapperProps = getRemainingProps(this.props, SelectList.propTypes);
-
-      return (
-        <List title={title} desc={desc} {...wrapperProps}>
-          {multiple && showCheckAll && this.renderCheckAllOption()}
-          {this.renderOptions()}
-        </List>
-      );
-    }
-}
+  return (
+    <List title={title} desc={desc} {...wrapperProps}>
+      {multiple && showCheckAll && renderCheckAllOption()}
+      {renderOptions(children)}
+    </List>
+  );
+});
 
 export default SelectList;
+
+SelectList.propTypes = {
+  multiple: PropTypes.bool,
+  showCheckAll: PropTypes.bool,
+  minCheck: PropTypes.number,
+  checkAllLabel: PropTypes.node,
+  value: PropTypes.oneOfType([
+    valueType,
+    PropTypes.arrayOf(valueType),
+  ]),
+  defaultValue: PropTypes.oneOfType([
+    valueType,
+    PropTypes.arrayOf(valueType),
+  ]),
+  onChange: PropTypes.func,
+  title: PropTypes.string,
+  desc: PropTypes.node,
+};
+
+SelectList.defaultProps = {
+  multiple: false,
+  showCheckAll: true,
+  minCheck: 0,
+  checkAllLabel: 'All',
+  value: undefined,
+  defaultValue: undefined,
+  onChange: () => {},
+  title: undefined,
+  desc: undefined,
+};

--- a/packages/form/src/SelectList.js
+++ b/packages/form/src/SelectList.js
@@ -201,8 +201,6 @@ const SelectList = React.memo(({
   );
 });
 
-export default SelectList;
-
 SelectList.propTypes = {
   multiple: PropTypes.bool,
   showCheckAll: PropTypes.bool,
@@ -232,3 +230,5 @@ SelectList.defaultProps = {
   title: undefined,
   desc: undefined,
 };
+
+export default SelectList;

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -1,265 +1,306 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
-
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SelectList from '../SelectList';
-import Option from '../SelectOption';
+import SelectOption from '../SelectOption';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  const element = (
-    <SelectList>
-      <Option label="Foo" value="foo" />
-      <Option label="Bar" value="bar" />
-    </SelectList>
-  );
+describe('SelectList', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-  ReactDOM.render(element, div);
-});
+  it('renders SelectList with default props', () => {
+    render(<SelectList title="List Title" />);
+    expect(screen.getByText('List Title')).toBeInTheDocument();
+  });
 
-it('reads options only from <SelectOptions>', () => {
-  const wrapper = shallow(
-    <SelectList value="foo">
-      <Option label="Foo" value="foo" />
-      <Option label="Bar" value="bar" />
-      <div />
-    </SelectList>
-  );
+  it('renders SelectList in single select mode', () => {
+    render(
+      <SelectList value="one">
+        <SelectOption value="one" label="one" />
+      </SelectList>
+    );
+    expect(screen.getByText('one')).toBeInTheDocument();
 
-  const readOptions = wrapper.instance().getOptions();
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionOneCheckbox = optionCheckboxes[0];
 
-  expect(readOptions).toHaveLength(2);
-  expect(readOptions[0].value).toBe('foo');
-  expect(readOptions[1].value).toBe('bar');
-});
+    expect(optionOneCheckbox).toBeChecked();
+  });
 
-describe('Single response mode', () => {
-  it('triggers onChange() with only one value', () => {
+  it('renders SelectList in multiple select mode', () => {
+    render(
+      <SelectList multiple value={['one']}>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+      </SelectList>
+    );
+    expect(screen.getByText('one')).toBeInTheDocument();
+    expect(screen.getByText('two')).toBeInTheDocument();
+
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
+
+    expect(optionCheckAllCheckbox).not.toBeChecked();
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
+  });
+
+  it('renders SelectList in multiple select mode with checkAll option', () => {
+    render(
+      <SelectList multiple showCheckAll>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+      </SelectList>
+    );
+    expect(screen.getByText('All')).toBeInTheDocument();
+  });
+
+  it('renders SelectList in multiple select mode with checkAll option and custom label', () => {
+    render(
+      <SelectList multiple showCheckAll checkAllLabel="Select All">
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+      </SelectList>
+    );
+    expect(screen.getByText('Select All')).toBeInTheDocument();
+  });
+
+  it('changes the value prop in a controlled SelectList', () => {
+    const { rerender } = render(
+      <SelectList value="one">
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+      </SelectList>
+    );
+    rerender(
+      <SelectList value="two">
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+      </SelectList>
+    );
+
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionOneCheckbox = optionCheckboxes[0];
+    const optionTwoCheckbox = optionCheckboxes[1];
+
+    expect(optionOneCheckbox).not.toBeChecked();
+    expect(optionTwoCheckbox).toBeChecked();
+  });
+
+  it('changes the value prop in a controlled SelectList with multiple options', () => {
+    const { rerender } = render(
+      <SelectList multiple value={['one', 'two']}>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+        <SelectOption value="three" label="three" />
+      </SelectList>
+    );
+    rerender(
+      <SelectList multiple value={['one', 'three']}>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
+        <SelectOption value="three" label="three" />
+      </SelectList>
+    );
+
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
+    const optionThreeCheckbox = optionCheckboxes[3];
+
+    expect(optionCheckAllCheckbox).not.toBeChecked();
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
+    expect(optionThreeCheckbox).toBeChecked();
+  });
+
+  it('clicks on an option in SelectList', () => {
     const handleChange = jest.fn();
-    const wrapper = shallow(
+    render(
       <SelectList onChange={handleChange}>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
+        <SelectOption value="one" label="one" />
       </SelectList>
     );
-    expect(handleChange).not.toHaveBeenCalled();
-
-    wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
-    expect(handleChange).toHaveBeenLastCalledWith('foo');
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-    expect(handleChange).toHaveBeenLastCalledWith('bar');
+    userEvent.click(screen.getByRole('checkbox'));
+    expect(handleChange).toHaveBeenCalled();
   });
 
-  it('keeps one option checked when uncontrolled', () => {
-    const wrapper = shallow(
-      <SelectList>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-    expect(wrapper.instance().getValues()).toEqual([]);
-
-    wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
-    expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeTruthy();
-    expect(wrapper.instance().getValues()).toEqual(['bar']);
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', false);
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeTruthy();
-    expect(wrapper.instance().getValues()).toEqual(['bar']);
-  });
-
-  it('does not update options checked state when controlled', () => {
-    const wrapper = shallow(
-      <SelectList value="foo">
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
-  });
-
-  it('updates <Option checked> if is controlled and values changes', () => {
-    const wrapper = shallow(
-      <SelectList value="foo">
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-    expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
-
-    wrapper.setProps({ value: 'bar' });
-    expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeFalsy();
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeTruthy();
-  });
-
-  it('does not update <Option checked> if is uncontrolled and other prop changes', () => {
-    const wrapper = shallow(
-      <SelectList defaultValue="foo">
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-    expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
-
-    wrapper.setProps({ defaultValue: ['bar'] });
-    expect(wrapper.find('SelectOption[value="foo"]').prop('checked')).toBeTruthy();
-    expect(wrapper.find('SelectOption[value="bar"]').prop('checked')).toBeFalsy();
-  });
-});
-
-describe('Multiple response mode', () => {
-  it('renders an "All" option above any option', () => {
-    const wrapper = shallow(
-      <SelectList multiple>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-
-    expect(wrapper.find(Option).at(0).props()).toMatchObject({
-      label: 'All',
-      value: null,
-      onChange: wrapper.instance().handleCheckAllOptionChange,
-    });
-
-    wrapper.setProps({ checkAllLabel: 'Check All' });
-    expect(wrapper.find(Option).at(0).prop('label')).toBe('Check All');
-  });
-
-  it('should not renders the "All" option if showCheckAll is false', () => {
-    const wrapper = shallow(
-      <SelectList multiple showCheckAll={false}>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-      </SelectList>
-    );
-
-    expect(wrapper.find(Option).at(0).props()).toMatchObject({
-      label: 'Foo',
-      value: 'foo',
-    });
-  });
-
-  it('triggers onChange with sorted values', () => {
+  it('unchecked an option in SelectList with single option should not work', () => {
     const handleChange = jest.fn();
-    const wrapper = shallow(
-      <SelectList multiple onChange={handleChange}>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-        <Option label="Meh" value="meh" />
+    render(
+      <SelectList defaultValue="one" onChange={handleChange}>
+        <SelectOption value="one" label="one" />
       </SelectList>
     );
+
+    const optionCheckbox = screen.getByRole('checkbox');
+
+    // can't uncheck the only checked option
+    userEvent.click(optionCheckbox);
+
     expect(handleChange).not.toHaveBeenCalled();
 
-    wrapper.find('SelectOption[value="meh"]').simulate('change', 'meh', true);
-    expect(handleChange).toHaveBeenLastCalledWith(['meh']);
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-    expect(handleChange).toHaveBeenLastCalledWith(['bar', 'meh']);
-
-    wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', true);
-    expect(handleChange).toHaveBeenLastCalledWith(['foo', 'bar', 'meh']);
-
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', false);
-    expect(handleChange).toHaveBeenLastCalledWith(['foo', 'meh']);
+    expect(optionCheckbox).toBeChecked();
   });
 
-  it('can toggle all options at once', () => {
-    const wrapper = shallow(
-      <SelectList multiple>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
+  it('clicks on an option in SelectList with multiple options', () => {
+    const handleChange = jest.fn();
+    render(
+      <SelectList multiple onChange={handleChange}>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
       </SelectList>
     );
-    expect(wrapper.instance().getValues()).toEqual([]);
 
-    wrapper.find(Option).at(0).simulate('change', null, true);
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
 
-    wrapper.find(Option).at(0).simulate('change', null, false);
-    expect(wrapper.instance().getValues()).toEqual([]);
+    userEvent.click(optionTwoCheckbox);
+
+    expect(handleChange).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith(['two']);
+
+    expect(optionCheckAllCheckbox).not.toBeChecked();
+    expect(optionOneCheckbox).not.toBeChecked();
+    expect(optionTwoCheckbox).toBeChecked();
   });
-});
 
-describe('Read-only options', () => {
-  it('toggles all options without affecting read-only options', () => {
-    const wrapper = shallow(
-      <SelectList multiple defaultValue={['foo']}>
-        <Option label="Foo" value="foo" readOnly />
-        <Option label="Bar" value="bar" />
+  it('unchecked an option in SelectList with multiple options and minCheck', () => {
+    const handleChange = jest.fn();
+    render(
+      <SelectList
+        multiple
+        minCheck={1}
+        defaultValue={['one']}
+        onChange={handleChange}
+      >
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
       </SelectList>
     );
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
 
-    wrapper.find(Option).at(0).simulate('change', null, true);
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
 
-    wrapper.find(Option).at(0).simulate('change', null, false);
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
+    // can't uncheck the only checked option when minCheck is 1
+    userEvent.click(optionOneCheckbox);
+
+    expect(handleChange).not.toHaveBeenCalled();
+
+    expect(optionCheckAllCheckbox).not.toBeChecked();
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
   });
-});
 
-describe('Minimum checks limit', () => {
-  it('does not allow to uncheck if will unable to match minCheck', () => {
-    const wrapper = shallow(
-      <SelectList multiple minCheck={1} defaultValue={['foo']}>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
+  it('click on checkAll option in SelectList with multiple options', () => {
+    const handleChange = jest.fn();
+    render(
+      <SelectList multiple showCheckAll onChange={handleChange}>
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
       </SelectList>
     );
-    expect(wrapper.instance().getValues()).toEqual(['foo']);
 
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', true);
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
 
-    wrapper.find('SelectOption[value="foo"]').simulate('change', 'foo', false);
-    expect(wrapper.instance().getValues()).toEqual(['bar']);
+    userEvent.click(optionCheckAllCheckbox);
 
-    wrapper.find('SelectOption[value="bar"]').simulate('change', 'bar', false);
-    expect(wrapper.instance().getValues()).toEqual(['bar']);
+    expect(handleChange).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith(['one', 'two']);
+
+    expect(optionCheckAllCheckbox).toBeChecked();
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).toBeChecked();
   });
 
-  it('keeps first n-options checked when unchecking all options', () => {
-    const wrapper = shallow(
-      <SelectList multiple minCheck={2} defaultValue={['foo', 'option3']}>
-        <Option label="Foo" value="foo" />
-        <Option label="Bar" value="bar" />
-        <Option label="Option3" value="option3" />
+  it('click on checkAll option in SelectList with multiple options and minCheck', () => {
+    const handleChange = jest.fn();
+    render(
+      <SelectList
+        multiple
+        showCheckAll
+        defaultValue={['one', 'two']}
+        minCheck={1}
+        onChange={handleChange}
+      >
+        <SelectOption value="one" label="one" />
+        <SelectOption value="two" label="two" />
       </SelectList>
     );
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'option3']);
 
-    wrapper.find(Option).at(0).simulate('change', null, true);
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'bar', 'option3']);
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionCheckAllCheckbox = optionCheckboxes[0];
+    const optionOneCheckbox = optionCheckboxes[1];
+    const optionTwoCheckbox = optionCheckboxes[2];
 
-    wrapper.find(Option).at(0).simulate('change', null, false);
-    expect(wrapper.instance().getValues()).toEqual(['foo', 'bar']);
+    userEvent.click(optionCheckAllCheckbox);
+
+    expect(handleChange).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith(['one']);
+
+    expect(optionCheckAllCheckbox).not.toBeChecked();
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
   });
-});
 
-it('if change `multiple` prop when uncontrolled, it will auto reset cachedValue', () => {
-  const wrapper = shallow(
-    <SelectList defaultValue="foo">
-      <Option label="Option A" value="foo" />
-      <Option label="Option B" value="bar" />
-    </SelectList>
-  );
-  expect(wrapper.instance().getValues()).toEqual(['foo']);
 
-  wrapper.setProps({ multiple: true, defaultValue: ['foo', 'bar'] });
-  expect(wrapper.instance().getValues()).toEqual([]);
+  it('reset value of SelectList when multiple prop changes', () => {
+    const { rerender } = render(
+      <SelectList multiple defaultValue={['option1']} showCheckAll={false}>
+        <SelectOption value="option1" label="Option 1" />
+        <SelectOption value="option2" label="Option 2" />
+      </SelectList>
+    );
 
-  wrapper.setProps({ multiple: false, defaultValue: ['bar'] });
-  expect(wrapper.instance().getValues()).toEqual([]);
+    rerender(
+      <SelectList defaultValue={['option1']}>
+        <SelectOption value="option1" label="Option 1" />
+        <SelectOption value="option2" label="Option 2" />
+      </SelectList>
+    );
+
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionOneCheckbox = optionCheckboxes[0];
+    const optionTwoCheckbox = optionCheckboxes[1];
+
+    expect(optionOneCheckbox).not.toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
+  });
+
+  it('correctly renders nested Option components in React.Fragment', () => {
+    render(
+      <SelectList value="option1" onChange={() => {}}>
+        <>
+          <SelectOption value="option1" label="Option 1" />
+          <SelectOption value="option2" label="Option 2" />
+          <div> other content </div>
+        </>
+      </SelectList>,
+    );
+
+    // Check if options are correctly rendered with valid checked status
+    const option1 = screen.getByText('Option 1');
+    const option2 = screen.getByText('Option 2');
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).toBeInTheDocument();
+
+    const optionCheckboxes = screen.getAllByRole('checkbox');
+    const optionOneCheckbox = optionCheckboxes[0];
+    const optionTwoCheckbox = optionCheckboxes[1];
+
+    expect(optionOneCheckbox).toBeChecked();
+    expect(optionTwoCheckbox).not.toBeChecked();
+  });
 });

--- a/packages/form/src/__tests__/SelectList.test.js
+++ b/packages/form/src/__tests__/SelectList.test.js
@@ -5,10 +5,6 @@ import SelectList from '../SelectList';
 import SelectOption from '../SelectOption';
 
 describe('SelectList', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('renders SelectList with default props', () => {
     render(<SelectList title="List Title" />);
     expect(screen.getByText('List Title')).toBeInTheDocument();


### PR DESCRIPTION
# Purpose

- 重構有使用到 UNSAFE lifecycle 的 components，用 react hooks 改寫
- 由於從 class component 改寫成 functional component，原本的 enzyme 測試針對 class component 的測試方法會失敗，因此也將對應的測試用 testing-library 重寫了
- 這個 PR 只改寫了 SelectList，因為內容比較複雜、重寫的測試情境也滿多的，單獨發一個 PR
