### PR TITLE
refactor: Refactor SelectRow component to use React hooks

### DIFF
--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -134,7 +134,7 @@ const SelectRow = React.memo(({
   useEffect(
     () => {
       warning(
-        isControlled === prevIsControlled && prevIsControlled !== undefined,
+        isControlled === prevIsControlled || prevIsControlled === undefined,
         '<SelectRow> should not switch from controlled to uncontrolled (or vice versa).'
       );
 

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -38,9 +38,12 @@ const CLOSABLE_CONFIG = {
 function usePrevious(value) {
   const ref = useRef();
 
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
+  useEffect(
+    () => {
+      ref.current = value;
+    },
+    [value]
+  );
 
   return ref.current;
 }

--- a/packages/form/src/SelectRow.js
+++ b/packages/form/src/SelectRow.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import warning from 'warning';
@@ -35,6 +35,16 @@ const CLOSABLE_CONFIG = {
   onClickInside: false,
 };
 
+function usePrevious(value) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
 /**
  * Generate a value-label map from all `<SelectOption>`s.
  *
@@ -57,231 +67,231 @@ function getValueToLabelAvatarMap(fromChildren = []) {
   return resultMap;
 }
 
-class SelectRow extends PureComponent {
-    static propTypes = {
-      label: PropTypes.node.isRequired,
-      asideAllLabel: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.bool, // can pass false to disable 'All' label
-      ]),
-      asideNoneLabel: PropTypes.string,
-      asideSeparator: PropTypes.string,
-      disabled: PropTypes.bool,
-      renderRowValueLabel: PropTypes.func,
-      // <SelectList> props
-      multiple: SelectList.propTypes.multiple,
-      value: SelectList.propTypes.value,
-      defaultValue: SelectList.propTypes.defaultValue,
-      onChange: PropTypes.func,
-      // from formRow()
-      ineditable: PropTypes.bool,
-      rowProps: rowPropTypes,
-    };
+const SelectRow = React.memo(({
+  label,
+  asideAllLabel,
+  asideNoneLabel,
+  asideSeparator,
+  disabled,
+  renderRowValueLabel: renderRowValueLabelProp,
+  multiple,
+  value,
+  defaultValue,
+  onChange,
+  ineditable,
+  rowProps,
+  className,
+  children,
+  ...restProps
+}) => {
+  const getInitialValue = () => {
+    if (value !== undefined) {
+      return value;
+    }
 
-    static defaultProps = {
-      asideAllLabel: 'All',
-      asideNoneLabel: '(Unset)',
-      asideSeparator: ', ',
-      disabled: false,
-      renderRowValueLabel: undefined,
-      // <SelectList> props
-      multiple: SelectList.defaultProps.multiple,
-      value: SelectList.defaultProps.value,
-      defaultValue: SelectList.defaultProps.defaultValue,
-      onChange: () => {},
-      // from formRow()
-      ineditable: false,
-      rowProps: {},
-    };
+    if (multiple && defaultValue === undefined) {
+      return [];
+    }
 
-    state = {
-      isPopoverOpen: false,
-      valueLabelMap: getValueToLabelAvatarMap(this.props.children),
-      cachedValue: this.getInitialValue(),
-    };
+    return defaultValue;
+  };
 
-    getInitialValue() {
-      const { value, defaultValue, multiple } = this.props;
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [valueLabelMap, setValueLabelMap] = useState(getValueToLabelAvatarMap(children));
+  const [cachedValue, setCachedValue] = useState(getInitialValue());
 
-      if (value !== undefined) {
-        return value;
+  const anchorNode = useRef(null);
+
+  const prevMultiple = usePrevious(multiple);
+  const isControlled = value !== undefined;
+  const prevIsControlled = usePrevious(isControlled);
+
+  const cacheValueArray = (multiple) ? cachedValue : [cachedValue].filter(val => val !== undefined);
+
+  // Handle change of "multiple" prop
+  useEffect(
+    () => {
+      if (!isControlled && (multiple !== prevMultiple) && prevMultiple !== undefined) {
+        warning(
+          false,
+          '<SelectRow>: you should not change `multiple` prop while it is uncontrolled. Its value will be reset now.'
+        );
+        setCachedValue((multiple) ? [] : null);
       }
+    },
+    [isControlled, multiple, prevMultiple]
+  );
 
-      if (multiple && defaultValue === undefined) {
-        return [];
-      }
+  // Handle children changes
+  useEffect(
+    () => {
+      setValueLabelMap(getValueToLabelAvatarMap(children));
+    },
+    [children]
+  );
 
-      return defaultValue;
-    }
-
-    getIsControlled(fromProps = this.props) {
-      return fromProps.value !== undefined;
-    }
-
-    getCacheValueArray = () => {
-      const { multiple } = this.props;
-      const { cachedValue } = this.state;
-      return (multiple) ? cachedValue : [cachedValue].filter(val => val !== undefined);
-    }
-
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      this.setState({
-        valueLabelMap: getValueToLabelAvatarMap(nextProps.children),
-      });
-
+  // Handle controlled/uncontrolled switch
+  useEffect(
+    () => {
       warning(
-        this.getIsControlled(this.props) === this.getIsControlled(nextProps),
+        isControlled === prevIsControlled && prevIsControlled !== undefined,
         '<SelectRow> should not switch from controlled to uncontrolled (or vice versa).'
       );
 
-      if (this.getIsControlled(nextProps)) {
-        this.setState({ cachedValue: nextProps.value });
-      } else if (this.props.multiple !== nextProps.multiple) {
-        warning(false, '<SelectRow>: you should not change `multiple` prop while it is uncontrolled. Its value will be reset now.');
-        this.setState({ cachedValue: (nextProps.multiple) ? [] : null });
+      if (isControlled) {
+        setCachedValue(value);
+      }
+    },
+    [value, isControlled, prevIsControlled]
+  );
+
+  const handleButtonClick = () => {
+    setIsPopoverOpen(true);
+  };
+
+  const handlePopoverClose = () => {
+    setIsPopoverOpen(false);
+  };
+
+  const handleSelectChange = (nextValue) => {
+    if (!isControlled) {
+      setCachedValue(nextValue);
+    }
+    onChange(nextValue);
+
+    if (!multiple) {
+      handlePopoverClose();
+    }
+  };
+
+  const renderPopover = selectListProps => (
+    <Popover
+      anchor={anchorNode.current}
+      className={BEM.popover.toString()}
+      closable={CLOSABLE_CONFIG}
+      onClose={handlePopoverClose}
+    >
+      <SelectList
+        value={cachedValue}
+        onChange={handleSelectChange}
+        {...selectListProps}
+      />
+    </Popover>
+  );
+
+  const renderRowValueLabel = () => {
+    if (typeof renderRowValueLabelProp === 'function') {
+      return renderRowValueLabelProp({ values: cachedValue, valueLabelMap });
+    }
+
+    const isSingleEmptyValue = cachedValue === undefined || cachedValue === '';
+    const isMultipleEmptyValue = multiple && cachedValue.length === 0;
+
+    if (isSingleEmptyValue || isMultipleEmptyValue) {
+      return <span className={BEM.placeholder.toString()}>{asideNoneLabel}</span>;
+    }
+
+    if (multiple) {
+      // Can turn off 'All' display by passing `false`.
+      if (asideAllLabel && cachedValue.length === valueLabelMap.size) {
+        return asideAllLabel;
       }
     }
 
-    handleButtonClick = () => {
-      this.setState({ isPopoverOpen: true });
-    }
+    return cacheValueArray
+      .map((_value) => {
+        const valueMap = valueLabelMap.get(_value) || {};
+        return valueMap.label;
+      })
+      .filter(_label => Boolean(_label))
+      .join(asideSeparator);
+  };
 
-    handlePopoverClose = () => {
-      this.setState({ isPopoverOpen: false });
-    }
+  const renderAvatar = () => (
+    cacheValueArray
+      .map((_value) => {
+        const valueMap = valueLabelMap.get(_value) || {};
+        return (
+          <React.Fragment key={_value}>
+            {valueMap.avatar}
+          </React.Fragment>
+        );
+      })
+  );
 
-    handleSelectChange = (nextValue) => {
-      if (!this.getIsControlled()) {
-        this.setState({ cachedValue: nextValue });
-      }
-      this.props.onChange(nextValue);
+  const wrapperClassName = classNames(
+    COMPONENT_NAME,
+    className,
+  );
 
-      if (!this.props.multiple) {
-        this.handlePopoverClose();
-      }
-    }
+  const Content = ineditable ? TextLabel : Button;
+  const contentProps = ineditable ? {} : {
+    onClick: handleButtonClick,
+  };
 
-    renderPopover(selectListProps) {
-      return (
-        <Popover
-          anchor={this.anchorNode}
-          className={BEM.popover.toString()}
-          closable={CLOSABLE_CONFIG}
-          onClose={this.handlePopoverClose}
-        >
-          <SelectList
-            value={this.state.cachedValue}
-            onChange={this.handleSelectChange}
-            {...selectListProps}
-          />
-        </Popover>
-      );
-    }
+  const selectListProps = {
+    multiple,
+    children,
+    ...restProps,
+  };
 
-    renderRowValueLabel() {
-      const {
-        multiple,
-        asideAllLabel,
-        asideNoneLabel,
-        asideSeparator,
-        renderRowValueLabel,
-      } = this.props;
-      const { cachedValue, valueLabelMap } = this.state;
+  return (
+    <ListRow className={wrapperClassName} {...rowProps}>
+      {renderAvatar()}
+      <Content minified={false} disabled={disabled} {...contentProps}>
+        <Text
+          verticalOrder="reverse"
+          bold={!ineditable}
+          basic={renderRowValueLabel()}
+          aside={label}
+        />
 
-      if (typeof renderRowValueLabel === 'function') {
-        return renderRowValueLabel({ values: cachedValue, valueLabelMap });
-      }
+        <span ref={anchorNode}>
+          <Icon type="dropdown" disabled={ineditable} />
+        </span>
 
-      const isSingleEmptyValue = cachedValue === undefined || cachedValue === '';
-      const isMultipleEmptyValue = multiple && cachedValue.length === 0;
+        {isPopoverOpen && renderPopover(selectListProps)}
+      </Content>
+    </ListRow>
+  );
+});
 
-      if (isSingleEmptyValue || isMultipleEmptyValue) {
-        return <span className={BEM.placeholder.toString()}>{asideNoneLabel}</span>;
-      }
+SelectRow.propTypes = {
+  label: PropTypes.node.isRequired,
+  asideAllLabel: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool, // can pass false to disable 'All' label
+  ]),
+  asideNoneLabel: PropTypes.string,
+  asideSeparator: PropTypes.string,
+  disabled: PropTypes.bool,
+  renderRowValueLabel: PropTypes.func,
+  // <SelectList> props
+  multiple: SelectList.propTypes.multiple,
+  value: SelectList.propTypes.value,
+  defaultValue: SelectList.propTypes.defaultValue,
+  onChange: PropTypes.func,
+  // from formRow()
+  ineditable: PropTypes.bool,
+  rowProps: rowPropTypes,
+};
 
-      if (multiple) {
-        // Can turn off 'All' display by passing `false`.
-        if (asideAllLabel && cachedValue.length === valueLabelMap.size) {
-          return asideAllLabel;
-        }
-      }
+SelectRow.defaultProps = {
+  asideAllLabel: 'All',
+  asideNoneLabel: '(Unset)',
+  asideSeparator: ', ',
+  disabled: false,
+  renderRowValueLabel: undefined,
+  // <SelectList> props
+  multiple: SelectList.defaultProps.multiple,
+  value: SelectList.defaultProps.value,
+  defaultValue: SelectList.defaultProps.defaultValue,
+  onChange: () => {},
+  // from formRow()
+  ineditable: false,
+  rowProps: {},
+};
 
-      return this.getCacheValueArray()
-        .map((value) => {
-          const valueMap = valueLabelMap.get(value) || {};
-          return valueMap.label;
-        })
-        .filter(label => Boolean(label))
-        .join(asideSeparator);
-    }
-
-    renderAvatar() {
-      const { valueLabelMap } = this.state;
-      return this.getCacheValueArray()
-        .map((value) => {
-          const valueMap = valueLabelMap.get(value) || {};
-          return (
-            <React.Fragment key={value}>
-              {valueMap.avatar}
-            </React.Fragment>
-          );
-        });
-    }
-
-    render() {
-      const {
-        label,
-        asideAllLabel,
-        asideNoneLabel,
-        asideSeparator,
-        disabled,
-        renderRowValueLabel,
-        // <ListRow> props (intercepted from it)
-        // multiple,
-        value,
-        defaultValue,
-        onChange,
-        // from formRow()
-        ineditable,
-        rowProps,
-        // React props
-        className,
-        ...selectListProps
-      } = this.props;
-      const { isPopoverOpen } = this.state;
-
-      const wrapperClassName = classNames(
-        COMPONENT_NAME,
-        className,
-      );
-
-      const Content = ineditable ? TextLabel : Button;
-      const contentProps = ineditable ? {} : {
-        onClick: this.handleButtonClick,
-      };
-
-      return (
-        <ListRow className={wrapperClassName} {...rowProps}>
-          {this.renderAvatar()}
-          <Content minified={false} disabled={disabled} {...contentProps}>
-            <Text
-              verticalOrder="reverse"
-              bold={!ineditable}
-              basic={this.renderRowValueLabel()}
-              aside={label}
-            />
-
-            <span ref={(ref) => { this.anchorNode = ref; }}>
-              <Icon type="dropdown" disabled={ineditable} />
-            </span>
-
-            {isPopoverOpen && this.renderPopover(selectListProps)}
-          </Content>
-        </ListRow>
-      );
-    }
-}
 
 export { SelectRow as PureSelectRow };
 export default formRow()(SelectRow);

--- a/packages/form/src/SwitchRow.js
+++ b/packages/form/src/SwitchRow.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -15,101 +15,92 @@ import formRow, { rowPropTypes } from './mixins/formRow';
  *
  * All unknown props should go to the `<Switch>` from `@ichef/gypcrete` core package.
  */
-class SwitchRow extends PureComponent {
-    static propTypes = {
-      /** row label */
-      label: PropTypes.node.isRequired,
-      /** descriptive value label when switch is turned __on__ */
-      asideOn: PropTypes.node,
-      /** descriptive value label when switch is turned __off__ */
-      asideOff: PropTypes.node,
-      // input props
-      checked: PropTypes.bool,
-      defaultChecked: PropTypes.bool,
-      onChange: PropTypes.func,
-      // from formRow()
-      ineditable: PropTypes.bool,
-      rowProps: rowPropTypes,
-    };
+const SwitchRow = React.memo(({
+  label,
+  asideOn,
+  asideOff,
+  // input props
+  checked,
+  defaultChecked,
+  onChange,
+  // from formRow()
+  ineditable,
+  rowProps,
+  // react props
+  className,
+  children,
+  ...restProps
+}) => {
+  const [checkedState, setCheckedState] = useState(defaultChecked || checked);
+  const isControlled = checked !== undefined && checked !== null;
+  const switchAside = (checkedState) ? asideOn : asideOff;
 
-    static defaultProps = {
-      asideOn: 'ON',
-      asideOff: 'OFF',
-      checked: undefined,
-      defaultChecked: undefined,
-      onChange: () => {},
-      ineditable: false,
-      rowProps: {},
-    };
+  useEffect(
+    () => {
+      setCheckedState(checked);
+    },
+    [checked]
+  );
 
-    state = {
-      checked: this.props.defaultChecked || this.props.checked,
-    };
-
-    getIsControlled() {
-      const isControlled = this.props.checked !== undefined
-            && this.props.checked !== null;
-
-      return isControlled;
+  const handleSwitchButtonChange = (event) => {
+    if (!isControlled) {
+      setCheckedState(event.target.checked);
     }
+    onChange(event);
+  };
 
-    getSwitchAside() {
-      const { asideOn, asideOff } = this.props;
+  const switchProps = {
+    ...restProps,
+    checked,
+    defaultChecked,
+  };
 
-      return this.state.checked ? asideOn : asideOff;
-    }
+  return (
+    <ListRow className={className} {...rowProps}>
+      <TextLabel
+        disabled={ineditable}
+        verticalOrder="reverse"
+        basic={switchAside}
+        aside={label}
+      />
 
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      this.setState({ checked: nextProps.checked });
-    }
+      <Switch
+        status={null}
+        onChange={handleSwitchButtonChange}
+        minified
+        {...switchProps}
+      />
 
-    handleSwitchButtonChange = (event) => {
-      if (!this.getIsControlled()) {
-        this.setState({ checked: event.target.checked });
-      }
-      this.props.onChange(event);
-    }
+      {children}
+    </ListRow>
+  );
+});
 
-    render() {
-      const {
-        label,
-        asideOn,
-        asideOff,
-        // input props
-        // checked,
-        // defaultChecked,
-        onChange,
-        // from formRow()
-        ineditable,
-        rowProps,
-        // React props
-        className,
-        children,
-        ...switchProps
-      } = this.props;
+SwitchRow.propTypes = {
+  /** row label */
+  label: PropTypes.node.isRequired,
+  /** descriptive value label when switch is turned __on__ */
+  asideOn: PropTypes.node,
+  /** descriptive value label when switch is turned __off__ */
+  asideOff: PropTypes.node,
+  // input props
+  checked: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
+  onChange: PropTypes.func,
+  // from formRow()
+  ineditable: PropTypes.bool,
+  rowProps: rowPropTypes,
+};
 
-      return (
-        <ListRow className={className} {...rowProps}>
-          <TextLabel
-            disabled={ineditable}
-            verticalOrder="reverse"
-            basic={this.getSwitchAside()}
-            aside={label}
-          />
-
-          <Switch
-            status={null}
-            onChange={this.handleSwitchButtonChange}
-            minified
-            {...switchProps}
-          />
-
-          {children}
-        </ListRow>
-      );
-    }
-}
+SwitchRow.defaultProps = {
+  asideOn: 'ON',
+  asideOff: 'OFF',
+  checked: undefined,
+  defaultChecked: undefined,
+  onChange: () => {},
+  ineditable: false,
+  rowProps: {},
+};
 
 export { SwitchRow as PureSwitchRow };
 export default formRow()(SwitchRow);

--- a/packages/form/src/__tests__/SwitchRow.test.js
+++ b/packages/form/src/__tests__/SwitchRow.test.js
@@ -1,88 +1,51 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { mount, shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SwitchRow from '../SwitchRow';
 
-import { Switch, TextLabel } from '@ichef/gypcrete';
-import SwitchRow, { PureSwitchRow } from '../SwitchRow';
+describe('SwitchRow', () => {
+  const mockOnChange = jest.fn();
+  const defaultProps = {
+    label: 'Test Label',
+    asideOn: 'ON',
+    asideOff: 'OFF',
+    defaultChecked: false,
+    onChange: mockOnChange,
+  };
 
-describe('formRow(SwitchRow)', () => {
-  it('renders without crashing', () => {
-    const div = document.createElement('div');
-    const element = (
-      <SwitchRow label="foo" />
-    );
-
-    ReactDOM.render(element, div);
-  });
-});
-
-describe('Pure <SwitchRow>', () => {
-  it('renders a <Switch> from @ichef/gypcrete with all unknown props', () => {
-    const wrapper = mount(
-      <PureSwitchRow
-        label="foo"
-        tabIndex="-1"
-        data-foo="bar"
-      />
-    );
-
-    expect(wrapper.find(Switch).exists()).toBeTruthy();
-    expect(wrapper.find(Switch).props()).not.toHaveProperty('label');
-    expect(wrapper.find(Switch).props()).toMatchObject({
-      tabIndex: '-1',
-      'data-foo': 'bar',
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('observes checked state of inner <Switch> and cache in state', () => {
-    // Default Switch
-    let wrapper = mount(<PureSwitchRow label="foo" />);
-    expect(wrapper.state('checked')).toBeFalsy();
-
-    // Uncontrolled Switch
-    wrapper = mount(<PureSwitchRow label="foo" defaultChecked />);
-    expect(wrapper.state('checked')).toBeTruthy();
-
-    wrapper.find('input').simulate('change', { target: { checked: false } });
-    expect(wrapper.state('checked')).toBeFalsy();
-
-    wrapper.find('input').simulate('change', { target: { checked: true } });
-    expect(wrapper.state('checked')).toBeTruthy();
-
-    // Controller Switch
-    wrapper = mount(<PureSwitchRow label="foo" checked />);
-    expect(wrapper.state('checked')).toBeTruthy();
-
-    wrapper.setProps({ checked: false });
-    expect(wrapper.state('checked')).toBeFalsy();
-
-    wrapper.find('input').simulate('change', { target: { checked: true } });
-    expect(wrapper.state('checked')).toBeFalsy();
+  it('renders correctly with default props', () => {
+    render(<SwitchRow {...defaultProps} />);
+    expect(screen.getByText(defaultProps.label)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.asideOff)).toBeInTheDocument();
   });
 
-  it('shows different basic with checked state', () => {
-    const wrapper = shallow(
-      <PureSwitchRow
-        checked
-        label="foo"
-        asideOn="TEST_ON"
-        asideOff="TEST_OFF"
-      />
-    );
-
-    expect(wrapper.find(TextLabel).prop('basic')).toBe('TEST_ON');
-
-    wrapper.setProps({ checked: false });
-    expect(wrapper.find(TextLabel).prop('basic')).toBe('TEST_OFF');
+  it('updates switch state correctly when it is uncontrolled', () => {
+    render(<SwitchRow {...defaultProps} />);
+    const switchElement = screen.getByRole('checkbox');
+    userEvent.click(switchElement);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(defaultProps.asideOn)).toBeInTheDocument();
   });
 
-  it('accepts additional children', () => {
-    const wrapper = mount(
-      <PureSwitchRow label="foo">
-        <span data-foo />
-      </PureSwitchRow>
-    );
+  it('does not update switch state when it is controlled', () => {
+    render(<SwitchRow {...defaultProps} checked={false} />);
+    const switchElement = screen.getByRole('checkbox');
+    userEvent.click(switchElement);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(defaultProps.asideOff)).toBeInTheDocument();
+  });
 
-    expect(wrapper.containsMatchingElement(<span data-foo />)).toBeTruthy();
+  it('renders children correctly', () => {
+    render(
+      <SwitchRow {...defaultProps}>
+        <div>Test Children</div>
+      </SwitchRow>
+    );
+    expect(screen.getByText('Test Children')).toBeInTheDocument();
   });
 });

--- a/packages/storybook/examples/form/SelectRow.stories.js
+++ b/packages/storybook/examples/form/SelectRow.stories.js
@@ -67,6 +67,7 @@ export const multipleValues = () => (
       label="Minimal selection: 2"
       minCheck={2}
       defaultValue={['opt-c', 'opt-d']}
+      onChange={action('change')}
     >
       <SelectOption label="Option A" value="opt-a" />
       <SelectOption label="Option B" value="opt-b" />


### PR DESCRIPTION
# Purpose

- 重構有使用到 UNSAFE lifecycle 的 components，用 react hooks 改寫
- 由於從 class component 改寫成 functional component，原本的 enzyme 測試針對 class component 的測試方法會失敗，因此也將對應的測試用 testing-library 重寫了
- 這個 PR 改寫了 SelectRow 和 SwitchRow ，並更新對應的測試
- 建議依照 commit review
