### PR TITLE
refactor: Refactor componentDidUpdate in ImageEditor.js

### DIFF
--- a/packages/imageeditor/src/ImageEditor.js
+++ b/packages/imageeditor/src/ImageEditor.js
@@ -102,6 +102,17 @@ class ImageEditor extends PureComponent {
 
     editorRef = React.createRef();
 
+    componentDidUpdate(prevProps) {
+      const { image } = this.props;
+      if (image !== prevProps.image) {
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({
+          scale: DEFAULT_SCALE,
+          position: DEFAULT_POSITION,
+        });
+      }
+    }
+
     getImageCanvas = ({ originalSize = false } = {}) => {
       if (originalSize) {
         return this.editorRef.current.getImage();
@@ -115,17 +126,6 @@ class ImageEditor extends PureComponent {
       }
 
       return this.editorRef.current.getCroppingRect();
-    }
-
-    // eslint-disable-next-line react/no-deprecated, camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
-      // Consider current `scale`, `position` and `initCropRect` outdated when image changes
-      if (nextProps.image !== this.props.image) {
-        this.setState({
-          scale: DEFAULT_SCALE,
-          position: DEFAULT_POSITION,
-        });
-      }
     }
 
     handleSliderChange = (event) => {


### PR DESCRIPTION
# Purpose

- 為了更新 React 18，將原本的 UNSAFE_componentWillReceiveProps 的部分改成 componentDidUpdate，因為沒有改寫成 functional component，原本的 enzyme 測試就不需要改
- 另外補充為什麼不改寫成 functional component 的原因：原本的 ImageEditor 程式碼似乎有刻意利用 class component 的特性去提供 `getCroppingRect`、`getImageCanvas` 等方法讓外部調用，由於此次目的不在重構成 functional component，想盡可能減少 API 變動的風險，所以決定維持 class component，只替換掉 unsafe lifecycle 就好