### PR TITLE
fix: pass down disabled prop in the rowComp Hoc

### DIFF
--- a/packages/core/src/mixins/__tests__/rowComp.test.js
+++ b/packages/core/src/mixins/__tests__/rowComp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { shallow } from 'enzyme';
 
 import Icon from 'src/Icon';
@@ -145,4 +145,15 @@ it('takes defaults to its <RowComp> wrapper-component', () => {
 
   expect(Comp.defaultProps.align).toBe('center');
   expect(Comp.defaultProps.minified).toBeTruthy();
+});
+
+it('pass down disabled prop to wrapped component', () => {
+  const Input = ({ children, ...props }) => <input {...props} />;
+  const RowInput = rowComp()(Input);
+
+  render(<RowInput disabled />);
+
+  const wrapper = screen.getByRole('textbox');
+
+  expect(wrapper).toHaveAttribute('disabled');
 });

--- a/packages/core/src/mixins/rowComp.js
+++ b/packages/core/src/mixins/rowComp.js
@@ -112,195 +112,195 @@ const rowComp = ({
   const componentName = getComponentName(WrappedComponent);
 
   class RowComp extends PureComponent {
-        static displayName = `rowComp(${componentName})`;
+      static displayName = `rowComp(${componentName})`;
 
-        static propTypes = {
-          minified: PropTypes.bool,
+      static propTypes = {
+        minified: PropTypes.bool,
 
-          // Text label props
-          align: PropTypes.oneOf([
-            ROW_COMP_ALIGN.LEFT,
-            ROW_COMP_ALIGN.CENTER,
-            ROW_COMP_ALIGN.RIGHT,
-            ROW_COMP_ALIGN.REVERSE,
-          ]),
-          verticalOrder: PropTypes.oneOf([
-            VERTICAL_ORDER.NORMAL,
-            VERTICAL_ORDER.REVERSE,
-          ]),
-          icon: PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.element,
-          ]),
-          basic: PropTypes.node,
-          avatar: PropTypes.node,
-          aside: PropTypes.node,
-          tag: PropTypes.node,
-          bold: PropTypes.bool,
-          asideControlClickableOnDisabled: PropTypes.bool,
+        // Text label props
+        align: PropTypes.oneOf([
+          ROW_COMP_ALIGN.LEFT,
+          ROW_COMP_ALIGN.CENTER,
+          ROW_COMP_ALIGN.RIGHT,
+          ROW_COMP_ALIGN.REVERSE,
+        ]),
+        verticalOrder: PropTypes.oneOf([
+          VERTICAL_ORDER.NORMAL,
+          VERTICAL_ORDER.REVERSE,
+        ]),
+        icon: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element,
+        ]),
+        basic: PropTypes.node,
+        avatar: PropTypes.node,
+        aside: PropTypes.node,
+        tag: PropTypes.node,
+        bold: PropTypes.bool,
+        asideControlClickableOnDisabled: PropTypes.bool,
 
-          // State props
-          active: PropTypes.bool,
-          highlight: PropTypes.bool,
-          disabled: PropTypes.bool,
-          muted: PropTypes.bool,
+        // State props
+        active: PropTypes.bool,
+        highlight: PropTypes.bool,
+        disabled: PropTypes.bool,
+        muted: PropTypes.bool,
 
-          // status props
-          status: statusPropTypes.status,
-          statusOptions: statusPropTypes.statusOptions,
-          errorMsg: statusPropTypes.errorMsg,
+        // status props
+        status: statusPropTypes.status,
+        statusOptions: statusPropTypes.statusOptions,
+        errorMsg: statusPropTypes.errorMsg,
+      };
+
+      static defaultProps = {
+        minified: defaultMinified,
+
+        align: defaultAlign,
+        verticalOrder: defaultVerticalOrder,
+        icon: null,
+        basic: null,
+        avatar: null,
+        aside: null,
+        tag: null,
+        bold: false,
+        asideControlClickableOnDisabled: false,
+
+        active: false,
+        highlight: false,
+        disabled: false,
+        muted: false,
+
+        status: undefined,
+        statusOptions: undefined,
+        errorMsg: undefined,
+      };
+
+      static childContextTypes = {
+        textProps: PropTypes.shape(textPropTypes),
+        ...statusPropTypes,
+        // status,
+        // statusOptions,
+        // errorMsg,
+      };
+
+      getChildContext() {
+        const { status, statusOptions, errorMsg } = this.props;
+        const textProps = this.getTextProps();
+
+        return {
+          status,
+          statusOptions,
+          errorMsg,
+          // for <TextInput>
+          textProps,
         };
+      }
 
-        static defaultProps = {
-          minified: defaultMinified,
+      getTextProps() {
+        const {
+          align,
+          verticalOrder,
+          icon,
+          basic,
+          aside,
+          tag,
+          bold,
+          asideControlClickableOnDisabled,
+          disabled,
+        } = this.props;
 
-          align: defaultAlign,
-          verticalOrder: defaultVerticalOrder,
-          icon: null,
-          basic: null,
-          avatar: null,
-          aside: null,
-          tag: null,
-          bold: false,
-          asideControlClickableOnDisabled: false,
+        const textLayoutProps = getTextLayoutProps(align, !!icon);
+        const asideControlClickableProps = (
+          (asideControlClickableOnDisabled && disabled)
+            ? {
+              onClick: (event) => { event.stopPropagation(); },
+            }
+            : undefined
+        );
 
-          active: false,
-          highlight: false,
-          disabled: false,
-          muted: false,
-
-          status: undefined,
-          statusOptions: undefined,
-          errorMsg: undefined,
+        return {
+          verticalOrder,
+          basic,
+          aside,
+          tag,
+          bold,
+          ...asideControlClickableProps,
+          ...textLayoutProps,
         };
+      }
 
-        static childContextTypes = {
-          textProps: PropTypes.shape(textPropTypes),
-          ...statusPropTypes,
-          // status,
-          // statusOptions,
-          // errorMsg,
-        };
+      renderIconElement() {
+        const { icon } = this.props;
 
-        getChildContext() {
-          const { status, statusOptions, errorMsg } = this.props;
-          const textProps = this.getTextProps();
-
-          return {
-            status,
-            statusOptions,
-            errorMsg,
-            // for <TextInput>
-            textProps,
-          };
+        if (!icon) {
+          return null;
         }
 
-        getTextProps() {
-          const {
-            align,
-            verticalOrder,
-            icon,
-            basic,
-            aside,
-            tag,
-            bold,
-            asideControlClickableOnDisabled,
-            disabled,
-          } = this.props;
+        return isValidElement(icon)
+          ? cloneElement(icon, { key: 'comp-icon' })
+          : <Icon key="comp-icon" type={icon} />;
+      }
 
-          const textLayoutProps = getTextLayoutProps(align, !!icon);
-          const asideControlClickableProps = (
-            (asideControlClickableOnDisabled && disabled)
-              ? {
-                onClick: (event) => { event.stopPropagation(); },
-              }
-              : undefined
-          );
+      renderContent() {
+        const iconElement = this.renderIconElement();
+        const textProps = this.getTextProps();
 
-          return {
-            verticalOrder,
-            basic,
-            aside,
-            tag,
-            bold,
-            ...asideControlClickableProps,
-            ...textLayoutProps,
-          };
-        }
+        return [
+          iconElement,
+          <Text key="comp-text" {...textProps} />,
+        ];
+      }
 
-        renderIconElement() {
-          const { icon } = this.props;
+      render() {
+        const {
+          minified,
+          avatar,
+          align,
+          verticalOrder,
+          icon,
+          basic,
+          aside,
+          tag,
+          bold,
+          asideControlClickableOnDisabled,
 
-          if (!icon) {
-            return null;
-          }
+          active,
+          highlight,
+          disabled,
+          muted,
 
-          return isValidElement(icon)
-            ? cloneElement(icon, { key: 'comp-icon' })
-            : <Icon key="comp-icon" type={icon} />;
-        }
+          status,
+          statusOptions,
+          errorMsg,
 
-        renderContent() {
-          const iconElement = this.renderIconElement();
-          const textProps = this.getTextProps();
+          // React props
+          className,
+          children,
 
-          return [
-            iconElement,
-            <Text key="comp-text" {...textProps} />,
-          ];
-        }
+          ...otherProps
+        } = this.props;
 
-        render() {
-          const {
-            minified,
-            avatar,
-            align,
-            verticalOrder,
-            icon,
-            basic,
-            aside,
-            tag,
-            bold,
-            asideControlClickableOnDisabled,
+        const bemClass = ROOT_BEM
+          .modifier('minified', minified)
+          .modifier(align)
+          .modifier('aside-control-clickable', asideControlClickableOnDisabled);
 
-            active,
-            highlight,
-            disabled,
-            muted,
+        const stateClassNames = getStateClassnames({
+          active,
+          highlight,
+          disabled,
+          muted,
+          error: status === STATUS_CODE.ERROR,
+          untouchable: status === STATUS_CODE.LOADING,
+        });
+        const wrapperClassName = classNames(className, stateClassNames, `${bemClass}`);
 
-            status,
-            statusOptions,
-            errorMsg,
-
-            // React props
-            className,
-            children,
-
-            ...otherProps
-          } = this.props;
-
-          const bemClass = ROOT_BEM
-            .modifier('minified', minified)
-            .modifier(align)
-            .modifier('aside-control-clickable', asideControlClickableOnDisabled);
-
-          const stateClassNames = getStateClassnames({
-            active,
-            highlight,
-            disabled,
-            muted,
-            error: status === STATUS_CODE.ERROR,
-            untouchable: status === STATUS_CODE.LOADING,
-          });
-          const wrapperClassName = classNames(className, stateClassNames, `${bemClass}`);
-
-          return (
-            <WrappedComponent className={wrapperClassName} {...otherProps}>
-              {avatar}
-              {children || this.renderContent()}
-            </WrappedComponent>
-          );
-        }
+        return (
+          <WrappedComponent className={wrapperClassName} {...otherProps} disabled={disabled}>
+            {avatar}
+            {children || this.renderContent()}
+          </WrappedComponent>
+        );
+      }
   }
 
   return RowComp;

--- a/packages/core/src/styles/_states.scss
+++ b/packages/core/src/styles/_states.scss
@@ -14,7 +14,11 @@
   pointer-events: none !important;
 }
 
-[disabled],
+// only disable pointer events, but not apply opacity to prevent nested opacity
+[disabled] {
+  pointer-events: none !important;
+}
+
 .#{$prefix-state}-disabled {
   opacity: .3 !important;
   pointer-events: none !important;


### PR DESCRIPTION
# Purpose
- [Asana task](https://app.asana.com/0/347798529122928/1207042998264153/f)

最近在寫測試的時後發現 gypcrete 的 TextInput disabled 狀態不會有 disabled attribute，導致有點難驗證欄位是否停用。
查了一下原因是在 rowComp 這個 HOC 把 disabled prop 劫持後沒有往下傳，看起來應該是不小心漏掉，後續發現可能是為了避免樣式上對停用元素加上 opacity 導致和 `.gyp-state__disabled` 的 opacity 樣式疊加，導致 input 顏色被刷淡兩次才攔截的。

另外讓 input element 會標上 disabled html attribute 的正規作法也是有其必要的，這讓 input element 可以真正有 disabled 效果，原本會由 `rowComp` HOC 在 input 外層的 wrapper 加上 `gyp-state__disabled` class，透過 `pointer-events: none` 阻擋游標互動來模擬停用的效果，但是這樣會有一些漏洞，例如透過鍵盤 tab 仍然可以選取到停用的 input、e2e 測試如果直接選取到 input element 進行互動也可以繞過樣式的阻擋。

# Changes

- 讓 `rowComp` 會將 `disabled` prop 往下傳
- TextInput 在停用狀態的 font-weight 會從 700 → 400
原本停用狀態的 TextInput font-weight 就應該要是 400，只是原先 disabled prop 被 rowComp HOC 攔截，導致 disabled 一直以來都沒有正確傳到 TextInput 上，所以看到的一直是粗體
- 移除套用在 disabled attribute 的透明度樣式，避免外層和內層的透明度疊加，造成 Input 的顏色變得更淡
- 加上確保會代傳 `disabled` prop 的測試


# Risk

會讓以下各個 Form Input 元件 都開始會收到 disabled prop
- Button
- Checkbox
- Radio
- SearchInput
- Switch
- TextInput
- TextLabel

在這次調整中為了避免透明度疊加導致非預期樣式的情況，取消了對停用的元件加上透明度的樣式，有可能在某些地方停用元件顏色變淡的樣式會消失，不過發生的機率不高