### PR TITLE
Refactor: use optional chaining

### DIFF
--- a/packages/core/src/InfiniteScroll.js
+++ b/packages/core/src/InfiniteScroll.js
@@ -189,7 +189,7 @@ class InfiniteScroll extends PureComponent {
     const { usePageAsContainer } = this.props;
     this.scrollContainer = usePageAsContainer
       ? window
-      : this.scrollNode && this.scrollNode.parentNode;
+      : this.scrollNode?.parentNode;
 
     if (this.scrollContainer) {
       this.scrollContainer.addEventListener('scroll', this.handleScrollListener);

--- a/packages/imageeditor/src/ImageEditor.js
+++ b/packages/imageeditor/src/ImageEditor.js
@@ -146,7 +146,7 @@ class ImageEditor extends PureComponent {
 
   handleCanvasImageChange = () => {
     if (!this.props.readOnly) {
-      const newCropRect = this.editorRef.current && this.editorRef.current.getCroppingRect();
+      const newCropRect = this.editorRef.current?.getCroppingRect();
       this.props.onCropChange(newCropRect);
     }
 
@@ -155,7 +155,7 @@ class ImageEditor extends PureComponent {
   };
 
   handleCanvasLoadSuccess = (imgInfo) => {
-    const cropRect = this.editorRef.current && this.editorRef.current.getCroppingRect();
+    const cropRect = this.editorRef.current?.getCroppingRect();
 
     this.props.onLoadSuccess(imgInfo, cropRect);
   };


### PR DESCRIPTION
## Summary
- use optional chaining for image editor cropping rectangle access
- simplify InfiniteScroll scroll container detection with optional chaining

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6847252d492c83258dda842e4c066067